### PR TITLE
TypeError for |=: 'int' and 'Edge' on Linux PyQt6

### DIFF
--- a/ballontranslator/ui/framelesswindow/fw_qt6/linux/__init__.py
+++ b/ballontranslator/ui/framelesswindow/fw_qt6/linux/__init__.py
@@ -48,15 +48,15 @@ class LinuxFramelessWindow(QWidget):
             return False
 
         edges = 0
-        # pos = event.globalPosition().toPoint() - self.pos()
-        # if pos.x() < self.BORDER_WIDTH:
-        #     edges |= Qt.Edge.LeftEdge
-        # if pos.x() >= self.width()-self.BORDER_WIDTH:
-        #     edges |= Qt.Edge.RightEdge
-        # if pos.y() < self.BORDER_WIDTH:
-        #     edges |= Qt.Edge.TopEdge
-        # if pos.y() >= self.height()-self.BORDER_WIDTH:
-        #     edges |= Qt.Edge.BottomEdge
+        pos = event.globalPosition().toPoint() - self.pos()
+        if pos.x() < self.BORDER_WIDTH:
+            edges = edges | Qt.Edge.LeftEdge if edges != 0 else Qt.Edge.LeftEdge
+        if pos.x() >= self.width()-self.BORDER_WIDTH:
+            edges = edges | Qt.Edge.RightEdge if edges != 0 else Qt.Edge.RightEdge 
+        if pos.y() < self.BORDER_WIDTH:
+            edges = edges | Qt.Edge.TopEdge if edges != 0 else Qt.Edge.TopEdge
+        if pos.y() >= self.height()-self.BORDER_WIDTH:
+            edges = edges | Qt.Edge.BottomEdge if edges != 0 else Qt.Edge.BottomEdge 
 
         # change cursor
         if et == QEvent.Type.MouseMove and self.windowState() == Qt.WindowState.WindowNoState:

--- a/ballontranslator/ui/framelesswindow/fw_qt6/linux/__init__.py
+++ b/ballontranslator/ui/framelesswindow/fw_qt6/linux/__init__.py
@@ -48,15 +48,15 @@ class LinuxFramelessWindow(QWidget):
             return False
 
         edges = 0
-        pos = event.globalPosition().toPoint() - self.pos()
-        if pos.x() < self.BORDER_WIDTH:
-            edges |= Qt.Edge.LeftEdge
-        if pos.x() >= self.width()-self.BORDER_WIDTH:
-            edges |= Qt.Edge.RightEdge
-        if pos.y() < self.BORDER_WIDTH:
-            edges |= Qt.Edge.TopEdge
-        if pos.y() >= self.height()-self.BORDER_WIDTH:
-            edges |= Qt.Edge.BottomEdge
+        # pos = event.globalPosition().toPoint() - self.pos()
+        # if pos.x() < self.BORDER_WIDTH:
+        #     edges |= Qt.Edge.LeftEdge
+        # if pos.x() >= self.width()-self.BORDER_WIDTH:
+        #     edges |= Qt.Edge.RightEdge
+        # if pos.y() < self.BORDER_WIDTH:
+        #     edges |= Qt.Edge.TopEdge
+        # if pos.y() >= self.height()-self.BORDER_WIDTH:
+        #     edges |= Qt.Edge.BottomEdge
 
         # change cursor
         if et == QEvent.Type.MouseMove and self.windowState() == Qt.WindowState.WindowNoState:


### PR DESCRIPTION
When I run it on Linux and slide the opacity of the mask, I get this error

```
BallonsTranslator/ballontranslator/ui/framelesswindow/fw_qt6/linux/__init__.py", line 59, in eventFilter
    edges |= Qt.Edge.BottomEdge
TypeError: unsupported operand type(s) for |=: 'int' and 'Edge'
```

idk how to fix it but by commenting out the code, it doesn't crash anymore (idk what it does...so yeah)