### PR TITLE
add models download script & libpatchmatch.so

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -6,6 +6,7 @@ ballontranslator/data/models
 ballontranslator/data/testpacks/eng_dontupload
 ballontranslator/data/testpacks/testpacks
 release
+libs
 
 tmp.py
 dummy_scripts.py
@@ -20,5 +21,6 @@ ballontranslator/data/logs
 *.zip
 *.ipynb
 *.dll
+*.so
 *.docx
 *.doc

--- a/ballontranslator/dl/inpaint/patch_match.py
+++ b/ballontranslator/dl/inpaint/patch_match.py
@@ -42,7 +42,10 @@ class CMatT(ctypes.Structure):
         ('dtype', ctypes.c_int)
     ]
     
-PMLIB = ctypes.CDLL('data/libs/patchmatch_inpaint.dll')
+try:
+    PMLIB = ctypes.CDLL('data/libs/patchmatch_inpaint.dll')
+except:
+    PMLIB = ctypes.CDLL('data/libs/libpatchmatch.so')
 
 PMLIB.PM_set_random_seed.argtypes = [ctypes.c_uint]
 PMLIB.PM_set_verbose.argtypes = [ctypes.c_int]

--- a/ballontranslator/dl/inpaint/patch_match.py
+++ b/ballontranslator/dl/inpaint/patch_match.py
@@ -42,11 +42,12 @@ class CMatT(ctypes.Structure):
         ('dtype', ctypes.c_int)
     ]
     
-try:
-    PMLIB = ctypes.CDLL('data/libs/patchmatch_inpaint.dll')
-except:
-    PMLIB = ctypes.CDLL('data/libs/libpatchmatch.so')
+if os.name == 'nt':
+    patchmatchlib = 'data/libs/patchmatch_inpaint.dll'
+else:
+    patchmatchlib = 'data/libs/libpatchmatch.so'
 
+PMLIB = ctypes.CDLL(patchmatchlib)
 PMLIB.PM_set_random_seed.argtypes = [ctypes.c_uint]
 PMLIB.PM_set_verbose.argtypes = [ctypes.c_int]
 PMLIB.PM_free_pymat.argtypes = [CMatT]

--- a/ballontranslator/scripts/download_models.sh
+++ b/ballontranslator/scripts/download_models.sh
@@ -1,0 +1,57 @@
+#!/usr/bin/env bash
+
+
+CTD_MODEL_LINK="https://github.com/zyddnys/manga-image-translator/releases/download/beta-0.3/comictextdetector.pt"
+CTD_ONNX_MODEL_LINK="https://github.com/zyddnys/manga-image-translator/releases/download/beta-0.3/comictextdetector.pt.onnx"
+
+AOT_INPAINTER_MODEL_LINK="https://github.com/zyddnys/manga-image-translator/releases/download/beta-0.3/inpainting.ckpt"
+LAMA_MPE_INPAINTER_MODEL_LINK="https://github.com/zyddnys/manga-image-translator/releases/download/beta-0.3/inpainting_lama_mpe.ckpt"
+
+SUGOI_TRANSLATOR_MODEL_LINK="https://github.com/zyddnys/manga-image-translator/releases/download/beta-0.3/sugoi-models.zip"
+
+MANGA_OCR_MODEL_LINK="https://huggingface.co/kha-white/manga-ocr-base"
+MIT48PX_OCR_MODEL_LINK="https://github.com/zyddnys/manga-image-translator/releases/download/beta-0.3/ocr-ctc.zip"
+
+
+pushd $(dirname "$0") &> /dev/null
+
+set -e 
+
+PWD="$(pwd)"
+MODELS_DIR="$PWD/../data/models"
+LIBS_DIR="$PWD/../data/libs"
+
+mkdir -p $MODELS_DIR
+cd $MODELS_DIR
+
+wget -c $CTD_MODEL_LINK
+
+wget -c $CTD_ONNX_MODEL_LINK
+
+wget -c $AOT_INPAINTER_MODEL_LINK -O aot_inpainter.ckpt
+
+wget -c $LAMA_MPE_INPAINTER_MODEL_LINK -O lama_mpe.ckpt
+
+wget -c $SUGOI_TRANSLATOR_MODEL_LINK ; unzip -d sugoi_translator sugoi-models.zip
+
+wget -c $MIT48PX_OCR_MODEL_LINK; unzip ocr-ctc.zip; mv ocr-ctc.ckpt mit48pxctc_ocr.ckpt; rm alphabet-all-v5.txt
+
+git lfs install; git clone $MANGA_OCR_MODEL_LINK
+
+mkdir -p $LIBS_DIR
+echo $LIBS_DIR
+
+git clone --depth 1 https://github.com/vacancy/PyPatchMatch
+cd PyPatchMatch
+
+# TODO
+# idk how to detect if 'pkg-config --cflags opencv' fails because mine does (Arch BTW), 
+# but there's opencv4 on my system and it compiles.
+# an idea is to 'ls opencv*' these paths 'pkg-config --variable pc_path pkg-config' but... to do.
+
+make -j$(nproc)
+mv libpatchmatch.so $LIBS_DIR
+cd ..; rm -rf PyPatchMatch
+
+
+popd &> /dev/null


### PR DESCRIPTION
I want to say and ask a few things:
- added simple bash script to download models and also compile libpatchmatch.so.
- maybe it's a good idea to make a GUI panel to manage if there are missing models and just click to download?
- can't `pip install pkuseg` on python 3.10 but `spacy_pkuseg` works, is it ok to replace `pkuseg` with `spacy_pkuseg` in `requirements.txt`?