### PR TITLE
Add runtime environment check

### DIFF
--- a/build-macos-app.sh
+++ b/build-macos-app.sh
@@ -20,10 +20,5 @@ pip install pyinstaller
 ditto ../libs data/libs -V
 ditto ../models data/models -V
 
-# Comment lines 217-233 of launch.py
-cp launch.py launch.py.bak # backup launch.py
-sed -i '' '217,233s|^| \#|' launch.py # comment specfied lines
-sed -n '217,233p' launch.py # check if comment is successful
-
 # Build macOS app via pyinstaller
 sudo pyinstaller launch.spec

--- a/build-macos-app.sh
+++ b/build-macos-app.sh
@@ -20,10 +20,10 @@ pip install pyinstaller
 ditto ../libs data/libs -V
 ditto ../models data/models -V
 
-# Comment lines 213-229 of launch.py
+# Comment lines 217-233 of launch.py
 cp launch.py launch.py.bak # backup launch.py
-sed -i '' '213,229s|^| \#|' launch.py # comment specfied lines
-sed -n '213,229p' launch.py # check if comment is successful
+sed -i '' '217,233s|^| \#|' launch.py # comment specfied lines
+sed -n '217,233p' launch.py # check if comment is successful
 
 # Build macOS app via pyinstaller
 sudo pyinstaller launch.spec

--- a/launch.py
+++ b/launch.py
@@ -212,6 +212,9 @@ def main():
     sys.exit(app.exec())
 
 def prepare_environment():
+    if getattr(sys, 'frozen', False):
+        print('Running as app, skip dependency installation')
+        return
 
     req_updated = False
     if sys.platform == 'win32':

--- a/macos-build-script.sh
+++ b/macos-build-script.sh
@@ -77,10 +77,10 @@ unzip 'libopencv_world.4.4.0.dylib.zip' -d data/libs
 unzip 'libpatchmatch_inpaint.dylib.zip' -d data/libs
 rm -rf libopencv_world.4.4.0.dylib.zip libpatchmatch_inpaint.dylib.zip
 
-# Comment lines 213-229 of launch.py
+# Comment lines 217-233 of launch.py
 cp launch.py launch.py.bak # backup launch.py
-sed -i '' '213,229s|^| \#|' launch.py # comment specfied lines
-sed -n '213,229p' launch.py # check if comment is successful
+sed -i '' '217,233s|^| \#|' launch.py # comment specfied lines
+sed -n '217,233p' launch.py # check if comment is successful
 
 # Build macOS app via pyinstaller
 sudo pyinstaller launch.spec

--- a/macos-build-script.sh
+++ b/macos-build-script.sh
@@ -77,11 +77,6 @@ unzip 'libopencv_world.4.4.0.dylib.zip' -d data/libs
 unzip 'libpatchmatch_inpaint.dylib.zip' -d data/libs
 rm -rf libopencv_world.4.4.0.dylib.zip libpatchmatch_inpaint.dylib.zip
 
-# Comment lines 217-233 of launch.py
-cp launch.py launch.py.bak # backup launch.py
-sed -i '' '217,233s|^| \#|' launch.py # comment specfied lines
-sed -n '217,233p' launch.py # check if comment is successful
-
 # Build macOS app via pyinstaller
 sudo pyinstaller launch.spec
 


### PR DESCRIPTION
Fix issue of building macOS app
https://github.com/dmMaze/BallonsTranslator/issues/234#issue-1923804984

Add runtime environment check - execute `prepare_environment()` if running from source code, skip it if running from a pyinstaller packaged app.

- Check if sys.frozen attribute exists to determine if it's a packaged app or source code execution
- Use getattr(sys, 'frozen', False) to check for this attribute
- Inside prepare_environment(), return early if running as a packaged app
- Otherwise execute the dependency installation logic as usual
- This avoids failing pip installs and retries when running the packaged app
- Keeps the prepare_environment() logic unchanged for source code execution
- Print log message when skipping to indicate it's running as an app

Running from source code
<img width="1389" alt="截屏2023-10-04 15 34 25" src="https://github.com/dmMaze/BallonsTranslator/assets/134026642/24c87969-cdfa-4c44-a5d4-656532f4f7ea">

Running from a pyinstaller packaged app will print "Running as app, skip dependency installation"
<img width="1389" alt="截屏2023-10-04 15 25 18" src="https://github.com/dmMaze/BallonsTranslator/assets/134026642/6f3b4a70-c731-4e30-aa96-092592f55b74">