### PR TITLE
fix log formatting

### DIFF
--- a/utils/logger.py
+++ b/utils/logger.py
@@ -37,7 +37,7 @@ class ColoredFormatter(logging.Formatter):
                 )
 
             record.levelname2 = colored("{:<7}".format(record.levelname))
-            record.message2 = colored(record.msg)
+            record.message2 = colored(record.getMessage())
 
             asctime2 = datetime.datetime.fromtimestamp(record.created)
             record.asctime2 = termcolor.colored(asctime2, color="green")


### PR DESCRIPTION
Logs from httpx's `_send_single_request` is not formatted correctly, resulting logs like `'HTTP Request: %s %s "%s %d %s"'`.
 
This makes debugging network-related issues harder (e.g. a mistyped 3rd party openai api url).

Fixes it by assessing log message via `LogRecord.getMessage()`. 

see also: https://docs.python.org/3.10/library/logging.html#logging.LogRecord.getMessage