### PR TITLE
Update requirements.txt

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -3,7 +3,7 @@
 PyQt6-Qt6>=6.6.2
 PyQt6>=6.6.1
 numpy
-urllib3==1.25.11 # https://github.com/psf/requests/issues/5740
+urllib3>=1.26.6 # https://github.com/psf/requests/issues/5740
 jaconv
 torch
 torchvision


### PR DESCRIPTION
chatgpt helped me to fix the requirements file for "ModuleNotFoundError: No module named 'urllib3.packages.six.moves'" issues 

It seems like the issue you're facing is with the urllib3 package. To fix this, you can try specifying a version of urllib3 that is compatible with your other packages. You can also try upgrading urllib3 to the latest version. Here's an updated requirements.txt file with a fixed urllib3 version and some other minor adjustments:

PyQt6-Qt6==6.4.2    # for qt>6.4.2 , framelesswindow is broken on windows, and text rendering is wrong on macOS
PyQt6==6.4.2   #PyQt5>=5.15.9
numpy
urllib3>=1.26.6 # https://github.com/psf/requests/issues/5740
jaconv
torch
torchvision
transformers
fugashi
unidic_lite
tqdm
opencv-python
shapely
pyclipper
einops
termcolor
bs4
deepl
qtpy
spacy-pkuseg
sentencepiece
ctranslate2
python-docx
docx2txt
piexif
keyboard
ordered-set
opencc-python-reimplemented
requests
Pillow
beautifulsoup4
colorama
openai
pyyaml
natsort
py7zr
multivolumefile
httpx[socks,brotli]
langdetect
pywin32; sys_platform == 'win32'
winsdk; sys_platform == 'win32'
brotlicffi; sys_platform == 'win32'
pyobjc-core; sys_platform == 'darwin'
pyobjc-framework-cocoa; sys_platform == 'darwin'
pyobjc-framework-coreml; sys_platform == 'darwin'
pyobjc-framework-quartz; sys_platform == 'darwin'
pyobjc-framework-vision; sys_platform == 'darwin'