### PR TITLE
fix ModuleNotFoundError: No module named 'cv2'

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -13,7 +13,7 @@ mecab-python3; sys_platform == 'darwin'
 fugashi
 unidic_lite
 tqdm
-opencv-python; sys_platform == 'win32'
+opencv-python; sys_platform == 'win32' or sys_platform == 'linux'
 opencv-python<=4.10.0.82; sys_platform == 'darwin'
 shapely
 pyclipper


### PR DESCRIPTION
Launch in Ubuntu 22.04.4 LTS get this error.

```python3 launch.py```


/home/lmhinnoc/Apps/BallonsTranslator/launch.py:10: DeprecationWarning: pkg_resources is deprecated as an API. See https://setuptools.pypa.io/en/latest/pkg_resources.html
  import pkg_resources
py version:  3.10.12 (main, Nov 20 2023, 15:14:05) [GCC 11.4.0]
py executable:  /usr/bin/python3
version: 1.4.0
branch: dev
Commit hash: 330af93bdad410bccae8faadaaa2f831c8a2e6f1
Traceback (most recent call last):
  File "/home/lmhinnoc/Apps/BallonsTranslator/launch.py", line 288, in <module>
    main()
  File "/home/lmhinnoc/Apps/BallonsTranslator/launch.py", line 156, in main
    from utils import config as program_config
  File "/home/lmhinnoc/Apps/BallonsTranslator/utils/config.py", line 5, in <module>
    from .fontformat import FontFormat
  File "/home/lmhinnoc/Apps/BallonsTranslator/utils/fontformat.py", line 3, in <module>
    from .textblock import TextBlock
  File "/home/lmhinnoc/Apps/BallonsTranslator/utils/textblock.py", line 6, in <module>
    import cv2
ModuleNotFoundError: No module named 'cv2'
