### PR TITLE
Added translated documents to pt-BR

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,5 +1,5 @@
 # BallonTranslator
-简体中文 | [English](./README_EN.md) | [Русский](./doc/README_RU.md) | [日本語](./doc/README_JA.md) | [Indonesia](./doc/README_ID.md) | [Tiếng Việt](./doc/README_VI.md)
+简体中文 | [English](./README_EN) | [pt-BR](./doc/README_PT-BR.md) | [Русский](./doc/README_RU.md) | [日本語](./doc/README_JA.md) | [Indonesia](./doc/README_ID.md) | [Tiếng Việt](./doc/README_VI.md)
 
 深度学习辅助漫画翻译工具，支持一键机翻和简单的图像/文本编辑  
 

--- a/README_EN.md
+++ b/README_EN.md
@@ -1,5 +1,5 @@
 # BallonTranslator
-[简体中文](./README.md) | English | [Русский](./doc/README_RU.md) | [日本語](./doc/README_JA.md) | [Indonesia](./doc/README_ID.md) | [Tiếng Việt](./doc/README_VI.md)
+[简体中文](./README.md) | English |[pt-BR](./doc/README_PT-BR.md) | [Русский](./doc/README_RU.md) | [日本語](./doc/README_JA.md) | [Indonesia](./doc/README_ID.md) | [Tiếng Việt](./doc/README_VI.md)
 
 Yet another computer-aided comic/manga translation tool powered by deep learning.
 
@@ -206,14 +206,14 @@ This project is heavily dependent upon [manga-image-translator](https://github.c
  * Support English and Japanese text detection, training code and more details can be found at [comic-text-detector](https://github.com/dmMaze/comic-text-detector)
 * Support using text detection from [Starriver Cloud (Tuanzi Manga OCR)](https://cloud.stariver.org.cn/). Username and password need to be filled in, and automatic login will be performed each time the program is launched.
 
-   * For detailed instructions, see [Tuanzi OCR Instructions (Chinese only)](doc/Tuanzi_OCR_Instructions.md)
+   * For detailed instructions, see **Tuanzi OCR Instructions**: ([Chinese](doc/团子OCR说明.md) & [Brazilian Portuguese](doc/Manual_TuanziOCR_pt-BR.md) only)
 ## OCR
  * All mit* models are from manga-image-translator, support English, Japanese and Korean recognition and text color extraction.
  * [manga_ocr](https://github.com/kha-white/manga-ocr) is from [kha-white](https://github.com/kha-white), text recognition for Japanese, with the main focus being Japanese manga.
  * Support using OCR from [Starriver Cloud (Tuanzi Manga OCR)](https://cloud.stariver.org.cn/). Username and password need to be filled in, and automatic login will be performed each time the program is launched.
    * The current implementation uses OCR on each textblock individually, resulting in slower speed and no significant improvement in accuracy. It is not recommended. If needed, please use the Tuanzi Detector instead.
    * When using the Tuanzi Detector for text detection, it is recommended to set OCR to none_ocr to directly read the text, saving time and reducing the number of requests.
-   * For detailed instructions, see [Tuanzi OCR Instructions (Chinese only)](doc/Tuanzi_OCR_Instructions.md)
+   * For detailed instructions, see **Tuanzi OCR Instructions**: ([Chinese](doc/团子OCR说明.md) & [Brazilian Portuguese](doc/Manual_TuanziOCR_pt-BR.md) only)
 
 ## Inpainting
   * AOT is from [manga-image-translator](https://github.com/zyddnys/manga-image-translator).

--- a/doc/CHANGELOG_PT-BR.md
+++ b/doc/CHANGELOG_PT-BR.md
@@ -1,0 +1,109 @@
+# Changelogs
+
+### 15/04/2023
+Implementação de download de origem baseada em gallery-dl (#131) graças a [ROKOLYT](https://github.com/ROKOLYT)
+
+### 27/02/2023
+[v1.3.34](https://github.com/dmMaze/BallonsTranslator/releases/tag/v1.3.34) lançado
+1. Corrige atribuição incorreta de orientação para CHT (#96)
+2. Converte CHS para CHT se necessário para Caiyun e DeepL (#100)
+3. Suporte para webp (#85)
+
+### 23/02/2023
+[v1.3.30](https://github.com/dmMaze/BallonsTranslator/releases/tag/v1.3.30) lançado
+1. Migração para PyQt6 para melhor pré-visualização de renderização de texto e [compatibilidade](https://github.com/Nuitka/Nuitka/issues/251) com nuitka
+2. Suporte para definir transparência da camada de texto (#88)
+3. Exportação de logs para data/logs
+
+### 27 de Janeiro de 2023
+**[v1.3.26](https://github.com/dmMaze/BallonsTranslator/releases/tag/v1.3.26) lançado**
+1. Adicionado suporte ao [saladict](https://saladict.crimx.com) (*Dicionário pop-up profissional e tradutor de páginas tudo-em-um*) no mini menu de seleção de texto. [Guia de Instalação](doc/saladict.md)
+<img src = "./src/saladict_doc.jpg">
+
+2. Adicionado substituição de palavras-chave para resultados de OCR e tradução automática [#78](https://github.com/dmMaze/BallonsTranslator/issues/78): Editar -> "Substituição de palavras-chave para tradução automática"
+3. Adicionado importação de pastas por arrastar e soltar [#77](https://github.com/dmMaze/BallonsTranslator/issues/77)
+4. Ocultar blocos de controle ao iniciar a edição de texto. [#81](https://github.com/dmMaze/BallonsTranslator/issues/81)
+5. Correção de bugs
+
+### 08 de Janeiro de 2023
+**[v1.3.22](https://github.com/dmMaze/BallonsTranslator/releases/tag/v1.3.22) lançado**
+1. Adicionado suporte para excluir e restaurar texto removido
+2. Adicionado suporte para redefinir o ângulo
+3. Correção de bugs
+
+### 31 de Dezembro de 2022
+**[v1.3.20](https://github.com/dmMaze/BallonsTranslator/releases/tag/v1.3.20) lançado**
+1. Adaptado para imagens com proporção extrema, como webtoons
+2. Adicionado suporte para colar texto em vários blocos de texto selecionados
+3. Correção de bugs
+4. OCR/Tradução/Inpainting de blocos de texto selecionados: O estilo da letra herdará do bloco selecionado correspondente. ctc_48px é mais recomendado para texto de linha única, mangocr para japonês de várias linhas; é necessário retreinar o modelo de detecção para que ctc48_px seja generalizado para várias linhas. Observe que, se você usar **ctc_48px**, certifique-se de que a caixa esteja no modo vertical e se ajuste o mais próximo possível da linha única de texto.
+<img src="./src/ocrselected.gif" div align=center>
+
+### 29 de Novembro de 2022
+**[v1.3.15](https://github.com/dmMaze/BallonsTranslator/releases/tag/v1.3.15) lançado**
+1. Correção de bugs
+2. Otimização da lógica de salvamento
+3. A forma da ferramenta Caneta/Inpaint pode ser definida como retângulo (experimental)
+
+### 25 de Outubro de 2022
+**[v1.3.14](https://github.com/dmMaze/BallonsTranslator/releases/tag/v1.3.14) lançado**
+1. Correção de bugs
+
+### 30 de Setembro de 2022
+Suporte ao Modo Escuro desde a v1.3.13: Visualizar->Modo Escuro
+
+### 24 de Setembro de 2022
+**[v1.3.12](https://github.com/dmMaze/BallonsTranslator/releases/tag/v1.3.12) lançado**
+1. Adicionado suporte para Pesquisa global (Ctrl+G) e pesquisa na página atual (Ctrl+F)
+2. Pilhas de desfazer locais de cada editor de texto mescladas em uma pilha principal de edição de texto, agora separada da prancheta de desenho
+3. Correção de bugs de importação/exportação de documentos do Word
+4. Reformulação da janela sem moldura baseada em [https://github.com/zhiyiYo/PyQt-Frameless-Window](https://github.com/zhiyiYo/PyQt-Frameless-Window)
+
+### 13 de Setembro de 2022
+**[v1.3.8](https://github.com/dmMaze/BallonsTranslator/releases/tag/v1.3.8) lançado**
+
+1. Correção de bugs e otimização da ferramenta Caneta
+2. Correção de dimensionamento
+3. Adicionado suporte para criação de predefinições de estilo de fonte e efeitos gráficos de texto (sombra e opacidade), veja [https://github.com/dmMaze/BallonsTranslator/pull/38](https://github.com/dmMaze/BallonsTranslator/pull/38)
+4. Adicionado suporte para importação/exportação de documentos do Word (*.docx): [https://github.com/dmMaze/BallonsTranslator/pull/40](https://github.com/dmMaze/BallonsTranslator/pull/40)
+
+### 31 de Agosto de 2022
+**[v1.3.4](https://github.com/dmMaze/BallonsTranslator/releases/tag/v1.3.4) lançado**
+
+1. Adicionado Sugoi Translator (apenas japonês-inglês, criado e autorizado por [mingshiba](https://www.patreon.com/mingshiba)): baixe o [modelo](https://drive.google.com/drive/folders/1KnDlfUM9zbnYFTo6iCbnBaBKabXfnVJm) convertido por [@Snowad14](https://github.com/Snowad14) e coloque "sugoi_translator" na pasta "data".
+2. Adicionado suporte para russo, graças a [bropines](https://github.com/bropines)
+3. Adicionado ajuste de espaçamento entre letras
+4. Reformulação do tipo vertical e correção de bugs de renderização de texto: [https://github.com/dmMaze/BallonsTranslator/pull/30](https://github.com/dmMaze/BallonsTranslator/pull/30)
+
+### 17 de Agosto de 2022
+**[v1.3.0](https://github.com/dmMaze/BallonsTranslator/releases/tag/v1.3.0) lançado**
+
+1. Correção do tradutor DeepL, graças a [@Snowad14](https://github.com/Snowad14)
+2. Correção de bug de tamanho e traçado de fonte que tornava o texto ilegível
+3. Adicionado suporte para formato de fonte global (determina as configurações de formato de fonte usadas pelo modo de tradução automática): no painel de configuração->Diagramação, altere a opção correspondente de "decidir pelo programa" para "usar configuração global" para habilitar. Observe que as configurações globais são os formatos mostrados no painel de formato de fonte à direita quando você não está editando nenhum bloco de texto na cena.
+4. Adicionado novo modelo de inpainting: lama-mpe e definido como padrão
+5. Adicionado suporte para seleção e formatação de vários blocos de texto
+6. Aprimorada a diagramação de mangá->inglês, inglês->chinês (**Layout automático** no painel de configuração->Diagramação, habilitado por padrão), também pode ser aplicado a blocos de texto selecionados usando a opção no menu do botão direito.
+
+<img src="./src/multisel_autolayout.gif" div align=center>
+<p align=center>
+**formatação de texto em lote e auto layout**
+</p>
+
+### 19 de Maio de 2022
+**[v1.2.0](https://github.com/dmMaze/BallonsTranslator/releases/tag/v1.2.0) lançado**
+1. Adicionado suporte ao DeepL, graças a [@Snowad14](https://github.com/Snowad14)
+2. Adicionado novo modelo OCR do manga-image-translator, com suporte a reconhecimento de coreano
+3. Correção de bugs
+
+### 17 de Abril de 2022
+**[v1.1.0](https://github.com/dmMaze/BallonsTranslator/releases/tag/v1.1.0) lançado**
+1. Utilização de qthread para gravar imagens editadas para evitar congelamento ao virar páginas
+2. Otimização da política de inpainting
+3. Adicionada ferramenta de retângulo
+4. Mais atalhos
+5. Correção de bugs
+
+### 09 de Abril de 2022
+
+1. v1.0.0 lançado

--- a/doc/Como_add_um_novo_tradutor.md
+++ b/doc/Como_add_um_novo_tradutor.md
@@ -1,0 +1,171 @@
+## Como Adicionar um Novo Tradutor ao BallonsTranslator
+
+Se você sabe como utilizar a API do tradutor ou o modelo de tradução desejado em Python, siga os passos abaixo para integrá-lo ao BallonsTranslator.
+
+### Implementação da Classe do Tradutor
+
+Se você sabe como chamar a API do tradutor alvo ou modelo de tradução em Python, implemente uma classe em `ballontranslator/dl/translators.__init__.py` da seguinte forma para usá-la no aplicativo. O exemplo a seguir, DummyTranslator, está comentado em `ballontranslator/dl/translator/__init__.py` e pode ser descomentado para testar no programa.
+
+1. **Crie uma nova classe em `ballontranslator/dl/translators/__init__.py`:**
+
+```python
+# "dummy translator" é o nome exibido no aplicativo
+@register_translator('dummy translator')
+class DummyTranslator(BaseTranslator):
+
+    concate_text = True
+
+    # parâmetros exibidos no painel de configuração.
+    # chaves são nomes dos parâmetros, se o tipo do valor for str, será um editor de texto (chave obrigatória)
+    # se o tipo do valor for dict, você precisa especificar o 'type' do parâmetro,
+    # o seguinte 'device' é um seletor, as opções são cpu e cuda, o padrão é cpu
+    params: Dict = {
+        'api_key': '', 
+        'device': {
+            'type': 'selector',
+            'options': ['cpu', 'cuda'],
+            'value': 'cpu'
+        }
+    }
+
+    def _setup_translator(self):
+        '''
+        faça a configuração aqui.
+        as chaves de lang_map são aquelas opções de idiomas exibidas no aplicativo,
+        atribua as chaves de idioma correspondentes aceitas pela API aos idiomas suportados.
+        Apenas os idiomas suportados pelo tradutor são atribuídos aqui, este tradutor suporta apenas japonês e inglês.
+        Para uma lista completa de idiomas, veja LANGMAP_GLOBAL em translator.__init__
+        '''
+        self.lang_map['日本語'] = 'ja'
+        self.lang_map['English'] = 'en'
+        
+    def _translate(self, src_list: List[str]) -> List[str]:
+        '''
+        faça a tradução aqui.
+        Este tradutor não faz nada além de retornar o texto original.
+        '''
+        source = self.lang_map[self.lang_source]
+        target = self.lang_map[self.lang_target]
+        
+        translation = text
+        return translation
+
+    def updateParam(self, param_key: str, param_content):
+        '''
+        necessário apenas se algum estado precisar ser atualizado imediatamente após o usuário alterar os parâmetros do tradutor,
+        por exemplo, se este tradutor for um modelo pytorch, você pode convertê-lo para cpu/gpu aqui.
+        '''
+        super().updateParam(param_key, param_content)
+        if (param_key == 'device'):
+            # obtenha o estado atual dos parâmetros
+            # self.model.to(self.params['device']['value'])
+            pass
+
+    @property
+    def supported_tgt_list(self) -> List[str]:
+        '''
+        necessário apenas se o suporte a idiomas do tradutor for assimétrico,
+        por exemplo, este tradutor suporta apenas inglês -> japonês, não japonês -> inglês.
+        '''
+        return ['English']
+
+    @property
+    def supported_src_list(self) -> List[str]:
+        '''
+        necessário apenas se o suporte a idiomas do tradutor for assimétrico.
+        '''
+        return ['日本語']
+```
+
+- Decore a classe com `@register_translator` e forneça o nome do tradutor que será exibido na interface. No exemplo, o nome passado para o decorador é `'dummy translator'`, tome cuidado para não renomeá-lo com um tradutor existente.
+- A classe deve herdar de `BaseTranslator`.
+
+2. **Defina o atributo `concate_text`:**
+
+```python
+@register_translator('dummy translator')
+class DummyTranslator(BaseTranslator):  
+    concate_text = True  # Se o tradutor aceitar apenas strings concatenadas
+    concate_text = False # Se o tradutor aceitar lista de strings ou modelo offline
+```
+
+- Indique se o tradutor aceita apenas texto concatenado (várias frases em uma única string) ou uma lista de strings.
+- Se for um modelo offline ou uma API que aceita listas de strings, defina como `False`.
+
+3. **Defina os parâmetros (opcional):**
+
+```python
+params: Dict = {
+    'api_key': '',  # Editor de texto para a chave da API
+    'device': {    # Seletor para CPU ou CUDA
+        'type': 'selector',
+        'options': ['cpu', 'cuda'],
+        'value': 'cpu'
+    }
+}
+```
+
+- Crie um dicionário `params` se o tradutor precisar de parâmetros configuráveis pelo usuário. Se não, deixe em branco ou atribua `None`.
+- As chaves do dicionário são os nomes dos parâmetros exibidos na interface. Se o tipo de valor correspondente for str, será exibido no aplicativo como um editor de texto, no exemplo acima, o api_key será um editor de texto com um valor padrão vazio.
+- Os valores podem ser strings (para editores de texto) ou dicionários (neste caso deve ser descrito por 'type', como exemplo acima. O parâmetro 'device' será exibido como um seletor no aplicativo, opções válidas são 'cpu' e 'cuda).
+
+<p align="center">
+<img src="./src/new_translator.png">
+</p>
+<p align="center">
+params exibidos no painel de configuração do aplicativo.
+</p>  
+
+4. **Implemente o método `_setup_translator`:**
+
+```python
+def _setup_translator(self):
+    '''
+    faça a configuração aqui.
+    as chaves de lang_map são aquelas opções de idiomas exibidas no aplicativo,
+    atribua as chaves de idioma correspondentes aceitas pela API aos idiomas suportados.
+    Apenas os idiomas suportados pelo tradutor são atribuídos aqui, este tradutor suporta apenas japonês e inglês.
+    Para uma lista completa de idiomas, veja LANGMAP_GLOBAL em translator.__init__
+    '''
+    self.lang_map['日本語'] = 'ja'
+    self.lang_map['English'] = 'en'
+```
+
+- Realize a configuração do tradutor (inicialização de modelos, autenticação na API, etc.).
+- Mapeie os idiomas exibidos no app para os códigos de idioma aceitos pela API.
+- Consulte `LANGMAP_GLOBAL` em `translator.__init__` para a lista completa de idiomas.
+
+5. **Implemente o método `_translate`:**
+
+```python
+def _translate(self, src_list: List[str]) -> List[str]:
+    '''
+    faça a tradução aqui.
+    Este tradutor não faz nada além de retornar o texto original.
+    '''
+    source = self.lang_map[self.lang_source]
+    target = self.lang_map[self.lang_target]
+    
+    translation = text
+    return translation
+```
+
+- Recebe uma lista de strings (`src_list`) a serem traduzidas.
+- Se `concate_text` for `True`, as strings serão concatenadas antes de serem passadas para o tradutor.
+- Realiza a tradução utilizando a API ou modelo.
+- Retorna uma lista com as strings traduzidas.
+
+### Métodos Opcionais
+
+- **`updateParam(self, param_key: str, param_content)`:**
+    - Implemente se precisar atualizar o estado do tradutor imediatamente após o usuário alterar os parâmetros.
+
+- **`supported_tgt_list(self) -> List[str]`:**
+    - Implemente se o suporte de idiomas do tradutor for assimétrico (por exemplo, só traduz de inglês para japonês).
+
+- **`supported_src_list(self) -> List[str]`:**
+    - Implemente se o suporte de idiomas do tradutor for assimétrico.
+
+### Testes
+
+Após implementar o tradutor, teste-o seguindo o exemplo em `tests/test_translators.py`.

--- a/doc/Manual_TuanziOCR_pt-BR.md
+++ b/doc/Manual_TuanziOCR_pt-BR.md
@@ -1,0 +1,13 @@
+## Referência de Parâmetros de Solicitação (Oficial)
+
+<p align="center">
+<img src="https://github.com/PiDanShouRouZhouXD/BallonsTranslator/assets/38401147/3c3985e9-f36e-41fb-af94-d6a8088e5ccd" width="85%" height="85%">
+</p>
+
+## Descrição do Tuanzi OCR
+
+### Login
+Ao fazer login pela primeira vez, você pode receber mensagens de erro de senha. Se tiver certeza de que a senha está correta, marque e desmarque a opção "force_refresh_token" para forçar um novo login. Salve as configurações e o problema deve ser resolvido.
+
+### Detecção de Texto
+A função de detecção de texto também extrai texto, mas de forma holística (identificação completa). Portanto, ao usar o TuanziOCR, recomendamos não usar a função OCR isoladamente, mas sim combinar a detecção de texto do TuanziOCR com a opção "none_ocr". O TuanziOCR possui filtros integrados para onomatopeias (Reprodução de sons por meio de fonemas/palavras. Alguns exemplos: Ruídos, gritos, sons de animais, etc.) e outros recursos. Para configurações detalhadas, consulte a "Referência de Parâmetros de Solicitação (Oficial)" acima.

--- a/doc/README_ID.md
+++ b/doc/README_ID.md
@@ -1,5 +1,5 @@
 # BallonTranslator
-[简体中文](../README.md) | [English](../README_EN.md) | [Русский](./README_RU.md) | [日本語](./README_JA.md) | Indonesia | [Tiếng Việt](./README_VI.md)
+[简体中文](./README.md) | [English](./README_EN) | [pt-BR](./doc/README_PT-BR.md) | [Русский](./doc/README_RU.md) | [日本語](./doc/README_JA.md) | Indonesia | [Tiếng Việt](./doc/README_VI.md)
 
 Sebuah aplikasi penerjemahan komik/manga yang dibantu oleh deep learning.
 

--- a/doc/README_JA.md
+++ b/doc/README_JA.md
@@ -1,5 +1,5 @@
 # BallonTranslator
-[简体中文](../README.md) | [English](../README_EN.md) | [Русский](./README_RU.md) | 日本語 | [Indonesia](./README_ID.md) | [Tiếng Việt](./README_VI.md)
+[简体中文](./README.md) | [English](./README_EN) | [pt-BR](./doc/README_PT-BR.md) | [Русский](./doc/README_RU.md) | 日本語 | [Indonesia](./doc/README_ID.md) | [Tiếng Việt](./doc/README_VI.md)
 
 ディープラーニングを活用したマンガ翻訳支援ツール。
 

--- a/doc/README_PT-BR.md
+++ b/doc/README_PT-BR.md
@@ -1,0 +1,241 @@
+## BallonTranslator
+
+[Chinês](./README.md) | [Inglês](./README_EN) | pt-BR | [Russo](./doc/README_RU.md) | [Japonês](./doc/README_JA.md) | [Indonésio](./doc/README_ID.md) | [Vietnamita](./doc/README_VI.md)
+
+BallonTranslator é mais uma ferramenta auxiliada por computador, alimentada por deep learning, para a tradução de quadrinhos/mangás.
+
+<img src="doc/src/ui0.jpg" div align=center>
+
+<p align=center>
+**Pré-Visualização**
+</p>
+
+## Recursos
+* **Tradução totalmente automatizada:** 
+  - Detecta, reconhece, remove e traduz textos automaticamente. O desempenho geral depende desses módulos.
+  - A diagramação é baseada na estimativa de formatação do texto original.
+  - Funciona bem com mangás e quadrinhos.
+  - Diagramação aprimorada para mangás->inglês, inglês->chinês (baseado na extração de regiões de balões).
+  
+* **Edição de imagem:**
+  - Permite editar máscaras e inpainting (similar à ferramenta Pincel de Recuperação para Manchas no Photoshop).
+  - Adaptado para imagens com proporção de aspecto extrema, como webtoons.
+  
+* **Edição de texto:**
+  - Suporta formatação de texto e [predefinições de estilo de texto](https://github.com/dmMaze/BallonsTranslator/pull/311). Textos traduzidos podem ser editados interativamente.
+  - Permite localizar e substituir.
+  - Permite exportar/importar para/de documentos do Word.
+
+## Instalação
+
+### No Windows
+Se você não deseja instalar o Python e o Git manualmente e tem acesso à Internet:  
+Baixe o BallonsTranslator_dev_src_with_gitpython.7z do [MEGA](https://mega.nz/folder/gmhmACoD#dkVlZ2nphOkU5-2ACb5dKw) ou [Google Drive](https://drive.google.com/drive/folders/1uElIYRLNakJj-YS0Kd3r3HE-wzeEvrWd?usp=sharing), descompacte e execute launch_win.bat.  
+Execute scripts/local_gitpull.bat para obter a atualização mais recente.
+
+### Executando o código-fonte
+Instale o [Python](https://www.python.org/downloads/release/python-31011) **< 3.12** (não utilize a versão da Microsoft Store) e o [Git](https://git-scm.com/downloads).
+
+```bash
+# Clone este repositório
+$ git clone https://github.com/dmMaze/BallonsTranslator.git ; cd BallonsTranslator
+
+# Inicie o aplicativo
+$ python3 launch.py
+```
+
+Na primeira execução, as bibliotecas necessárias serão instaladas e os modelos serão baixados automaticamente. Se os downloads falharem, você precisará baixar a pasta **data** (ou os arquivos ausentes mencionados no terminal) do [MEGA](https://mega.nz/folder/gmhmACoD#dkVlZ2nphOkU5-2ACb5dKw) ou [Google Drive](https://drive.google.com/drive/folders/1uElIYRLNakJj-YS0Kd3r3HE-wzeEvrWd?usp=sharing) e salvá-la no caminho correspondente na pasta do código-fonte.
+
+## Construindo o aplicativo para macOS (compatível com chips Intel e Apple Silicon)
+
+*Observação: o macOS também pode executar o código-fonte caso o aplicativo não funcione.*
+
+![录屏2023-09-11 14 26 49](https://github.com/hyrulelinks/BallonsTranslator/assets/134026642/647c0fa0-ed37-49d6-bbf4-8a8697bc873e)
+
+#### 1. Preparação
+-  Baixe as bibliotecas e modelos do [MEGA](https://mega.nz/folder/gmhmACoD#dkVlZ2nphOkU5-2ACb5dKw) ou [Google Drive](https://drive.google.com/drive/folders/1uElIYRLNakJj-YS0Kd3r3HE-wzeEvrWd?usp=sharing).
+
+<img width="1268" alt="截屏2023-09-08 13 44 55_7g32SMgxIf" src="https://github.com/dmMaze/BallonsTranslator/assets/134026642/40fbb9b8-a788-4a6e-8e69-0248abaee21a">
+
+-  Coloque todos os recursos baixados em uma pasta chamada `data`. A estrutura final do diretório deve ser semelhante a esta:
+  
+```
+data
+├── libs
+│   └── patchmatch_inpaint.dll
+└── models
+    ├── aot_inpainter.ckpt
+    ├── comictextdetector.pt
+    ├── comictextdetector.pt.onnx
+    ├── lama_mpe.ckpt
+    ├── manga-ocr-base
+    │   ├── README.md
+    │   ├── config.json
+    │   ├── preprocessor_config.json
+    │   ├── pytorch_model.bin
+    │   ├── special_tokens_map.json
+    │   ├── tokenizer_config.json
+    │   └── vocab.txt
+    ├── mit32px_ocr.ckpt
+    ├── mit48pxctc_ocr.ckpt
+    └── pkuseg
+        ├── postag
+        │   ├── features.pkl
+        │   └── weights.npz
+        ├── postag.zip
+        └── spacy_ontonotes
+            ├── features.msgpack
+            └── weights.npz
+
+7 diretórios, 23 arquivos
+```
+
+- Instale a ferramenta de linha de comando pyenv para gerenciar as versões do Python. Recomenda-se a instalação via Homebrew.
+
+```
+# Instalar via Homebrew
+brew install pyenv
+
+# Instalar via script oficial
+curl https://pyenv.run | bash
+
+# Configurar o ambiente shell após a instalação
+echo 'export PYENV_ROOT="$HOME/.pyenv"' >> ~/.zshrc
+echo 'command -v pyenv >/dev/null || export PATH="$PYENV_ROOT/bin:$PATH"' >> ~/.zshrc
+echo 'eval "$(pyenv init -)"' >> ~/.zshrc
+```
+
+#### 2. Construindo o aplicativo
+```
+# Entre no diretório de trabalho `data`
+cd data
+
+# Clone o branch `dev` do repositório
+git clone -b dev https://github.com/dmMaze/BallonsTranslator.git
+
+# Entre no diretório de trabalho `BallonsTranslator`
+cd BallonsTranslator
+
+# Execute o script de construção, que solicitará a senha na etapa pyinstaller, insira a senha e pressione enter
+sh scripts/build-macos-app.sh
+```
+
+> 📌 O aplicativo empacotado está em ./data/BallonsTranslator/dist/BallonsTranslator.app. Arraste o aplicativo para a pasta de aplicativos do macOS para instalar. Pronto para usar sem configurações extras do Python.
+
+
+</details>
+
+Para usar o Sugoi translator (apenas japonês-inglês), baixe o [modelo offline](https://drive.google.com/drive/folders/1KnDlfUM9zbnYFTo6iCbnBaBKabXfnVJm) e mova a pasta "sugoi_translator" para BallonsTranslator/ballontranslator/data/models.
+
+
+# Utilização
+
+**É recomendado executar o programa em um terminal caso ocorra alguma falha e não sejam fornecidas informações, como mostrado no gif a seguir.**
+<img src="doc/src/run.gif">  
+
+- Na primeira execução, selecione o tradutor e defina os idiomas de origem e destino clicando no ícone de configurações.
+- Abra uma pasta contendo as imagens do quadrinho (mangá/manhua/manhwa) que precisa de tradução clicando no ícone de pasta.
+- Clique no botão `Run` e aguarde a conclusão do processo.
+
+Os formatos de fonte, como tamanho e cor, são determinados automaticamente pelo programa neste processo. Você pode pré-determinar esses formatos alterando as opções correspondentes de "decidir pelo programa" para "usar configuração global" no painel de configurações->Diagramação. (As configurações globais são os formatos exibidos no painel de formatação de fonte à direita quando você não está editando nenhum bloco de texto na cena.)
+
+## Edição de Imagem
+
+### Ferramenta de Inpainting
+<img src="doc/src/imgedit_inpaint.gif">
+<p align = "center">
+**Modo de edição de imagem, ferramenta de Inpainting**
+</p>
+
+### Ferramenta Retângulo
+<img src="doc/src/rect_tool.gif">
+<p align = "center">
+**Ferramenta Retângulo**
+</p>
+
+Para 'apagar' resultados indesejados de inpainting, use a ferramenta de inpainting ou a ferramenta retângulo com o **botão direito do mouse** pressionado. O resultado depende da precisão com que o algoritmo ("método 1" e "método 2" no gif) extrai a máscara de texto. O desempenho pode ser pior em textos e fundos complexos.
+
+## Edição de Texto
+<img src="doc/src/textedit.gif">
+<p align = "center">
+**Modo de edição de texto**
+</p>
+
+<img src="doc/src/multisel_autolayout.gif" div align=center>
+<p align=center>
+**Formatação de texto em lote e layout automático**
+</p>
+
+<img src="doc/src/ocrselected.gif" div align=center>
+<p align=center>
+**OCR e tradução de área selecionada**
+</p>
+
+## Atalhos
+* `A`/`D` ou `pageUp`/`Down` para virar a página
+* `Ctrl+Z`, `Ctrl+Shift+Z` para desfazer/refazer a maioria das operações (a pilha de desfazer é limpa ao virar a página).
+* `T` para o modo de edição de texto (ou o botão "T" na barra de ferramentas inferior).
+* `W` para ativar o modo de criação de bloco de texto, arraste o mouse na tela com o botão direito pressionado para adicionar um novo bloco de texto (veja o gif de edição de texto).
+* `P` para o modo de edição de imagem.
+* No modo de edição de imagem, use o controle deslizante no canto inferior direito para controlar a transparência da imagem original.
+* Desative ou ative qualquer módulo automático através da barra de título->executar. Executar com todos os módulos desativados irá refazer as letras e renderizar todo o texto de acordo com as configurações correspondentes.
+* Defina os parâmetros dos módulos automáticos no painel de configuração.
+* `Ctrl++`/`Ctrl+-` (Também `Ctrl+Shift+=`) para redimensionar a imagem.
+* `Ctrl+G`/`Ctrl+F` para pesquisar globalmente/na página atual.
+* `0-9` para ajustar a opacidade da camada de texto.
+* Para edição de texto: negrito - `Ctrl+B`, sublinhado - `Ctrl+U`, itálico - `Ctrl+I`.
+* Defina a sombra e a transparência do texto no painel de estilo de texto -> Efeito.
+
+<img src="doc/src/configpanel.png">
+
+## Modo Headless (Executar sem interface gráfica)
+
+```python
+python launch.py --headless --exec_dirs "[DIR_1],[DIR_2]..."
+```
+
+A configuração (idioma de origem, idioma de destino, modelo de inpainting, etc.) será carregada de config/config.json. Se o tamanho da fonte renderizada não estiver correto, especifique o DPI lógico manualmente através de `--ldpi`. Os valores típicos são 96 e 72.
+
+## Módulos de Automação
+Este projeto depende fortemente do [manga-image-translator](https://github.com/zyddnys/manga-image-translator). Serviços online e treinamento de modelos não são baratos, considere fazer uma doação ao projeto:
+- Ko-fi: [https://ko-fi.com/voilelabs](https://ko-fi.com/voilelabs)
+- Patreon: [https://www.patreon.com/voilelabs](https://www.patreon.com/voilelabs)
+- 爱发电: [https://afdian.net/@voilelabs](https://afdian.net/@voilelabs)
+
+O [Sugoi translator](https://sugoitranslator.com/) foi criado por [mingshiba](https://www.patreon.com/mingshiba).
+
+## Detecção de Texto
+* Suporta detecção de texto em inglês e japonês. O código de treinamento e mais detalhes podem ser encontrados em [comic-text-detector](https://github.com/dmMaze/comic-text-detector).
+* Suporta o uso de detecção de texto do [Starriver Cloud (Tuanzi Manga OCR)](https://cloud.stariver.org.cn/). O nome de usuário e a senha precisam ser preenchidos, e o login automático será realizado a cada vez que o programa for iniciado.
+  * Para instruções detalhadas, consulte [Manual do TuanziOCR](./doc/Manual_TuanziOCR_pt-BR.md).
+
+## OCR
+* Todos os modelos mit* são do manga-image-translator e suportam reconhecimento de inglês, japonês e coreano, além da extração da cor do texto.
+* [manga_ocr](https://github.com/kha-white/manga-ocr) é de [kha-white](https://github.com/kha-white), reconhecimento de texto para japonês, com foco principal em mangás japoneses.
+* Suporta o uso de OCR do [Starriver Cloud (Tuanzi Manga OCR)](https://cloud.stariver.org.cn/). O nome de usuário e a senha precisam ser preenchidos, e o login automático será realizado a cada vez que o programa for iniciado.
+  * A implementação atual usa OCR em cada bloco de texto individualmente, resultando em velocidade mais lenta e sem melhoria significativa na precisão. Não é recomendado. Se necessário, use o Tuanzi Detector.
+  * Ao usar o Tuanzi Detector para detecção de texto, recomenda-se definir o OCR como none_ocr para ler o texto diretamente, economizando tempo e reduzindo o número de solicitações.
+  * Para instruções detalhadas, consulte [Manual do TuanziOCR](./doc/Manual_TuanziOCR_pt-BR.md).
+
+## Inpainting
+* O AOT é do [manga-image-translator](https://github.com/zyddnys/manga-image-translator).
+* Todos os lama* são ajustados usando o [LaMa](https://github.com/advimman/lama).
+* PatchMatch é um algoritmo do [PyPatchMatch](https://github.com/vacancy/PyPatchMatch). Este programa usa uma [versão modificada](https://github.com/dmMaze/PyPatchMatchInpaint) por mim.
+
+## Tradutores
+Tradutores disponíveis: Google, DeepL, ChatGPT, Sugoi, Caiyun, Baidu, Papago e Yandex.
+* O Google desativou o serviço de tradução na China, defina a 'url' correspondente no painel de configuração para *.com.
+* Os tradutores [Caiyun](https://dashboard.caiyunapp.com/), [ChatGPT](https://platform.openai.com/playground), [Yandex](https://yandex.com/dev/translate/), [Baidu](http://developers.baidu.com/) e [DeepL](https://www.deepl.com/docs-api/api-access) exigem um token ou chave de API.
+* DeepL e Sugoi translator (e sua conversão CT2 Translation) graças a [Snowad14](https://github.com/Snowad14).
+* Sugoi traduz do japonês para o inglês completamente offline.
+* [Sakura-13B-Galgame](https://github.com/SakuraLLM/Sakura-13B-Galgame)
+
+Para adicionar um novo tradutor, consulte [Como_add_um_novo_tradutor](doc/Como_add_um_novo_tradutor.md). É simples como criar uma subclasse de uma classe base e implementar duas interfaces. Em seguida, você pode usá-lo no aplicativo. Contribuições para o projeto são bem-vindas.
+
+## FAQ & Diversos
+* Se o seu computador tiver uma GPU Nvidia ou Apple Silicon, o programa habilitará a aceleração de hardware.
+* Adicione suporte para [saladict](https://saladict.crimx.com) (*Dicionário pop-up profissional e tradutor de páginas tudo-em-um*) no mini menu ao selecionar o texto. [Guia de instalação](doc/saladict_pt-br.md).
+* Acelere o desempenho se você tiver um dispositivo [NVIDIA CUDA](https://pytorch.org/docs/stable/notes/cuda.html) ou [AMD ROCm](https://pytorch.org/docs/stable/notes/hip.html), pois a maioria dos módulos usa o [PyTorch](https://pytorch.org/get-started/locally/).
+* As fontes são do seu sistema.
+* Agradecimentos a [bropines](https://github.com/bropines) pela localização para o russo.
+* Adicionado script JSX de exportação para o Photoshop por [bropines](https://github.com/bropines). Para ler as instruções, melhorar o código e apenas explorar como funciona, vá para `scripts/export to photoshop` -> `install_manual.md`.

--- a/doc/README_RU.md
+++ b/doc/README_RU.md
@@ -1,6 +1,6 @@
 # BallonTranslator
 
-[简体中文](../README.md) | [English](../README_EN.md) | Русский | [日本語](./README_JA.md) | [Indonesia](./README_ID.md) | [Tiếng Việt](./README_VI.md)
+[简体中文](./README.md) | [English](./README_EN) | [pt-BR](./doc/README_PT-BR.md) | Русский | [日本語](./doc/README_JA.md) | [Indonesia](./doc/README_ID.md) | [Tiếng Việt](./doc/README_VI.md)
 
 Еще один компьютерный инструмент для перевода комиксов/манги, основанный на глубоком обучении.
 

--- a/doc/README_VI.md
+++ b/doc/README_VI.md
@@ -1,5 +1,5 @@
 # BallonTranslator
-[简体中文](../README.md) | [English](../README_EN.md) | [Русский](./README_RU.md) | [日本語](./README_JA.md) | [Indonesia](./README_ID.md) | Tiếng Việt
+[简体中文](./README.md) | [English](./README_EN) | [pt-BR](./doc/README_PT-BR.md) | [Русский](./doc/README_RU.md) | [日本語](./doc/README_JA.md) | [Indonesia](./doc/README_ID.md) | Tiếng Việt
 
 Lại thêm một công cụ, phần mềm dịch truyện siu xịn khác có áp dụng ML/AI.
 

--- a/doc/saladict_pt-br.md
+++ b/doc/saladict_pt-br.md
@@ -1,0 +1,16 @@
+[English](./saladict.md) | [简体中文](./saladict_chs.md)
+
+**Observação:** Funciona apenas com navegadores que permitem atalhos globais para extensões (atualmente, apenas o Firefox não oferece suporte a atalhos globais).
+
+1. **Instalação:** https://saladict.crimx.com/download.html 
+2. **Configurações do Saladict:**
+    * Habilite "Manter em Segundo Plano".
+    * Habilite "Permissões" - "Ler Área de Transferência".
+3. **Configurações do Navegador (atalhos):**
+    * No navegador (edge://extensions/shortcuts ou chrome://extensions/shortcuts), defina um atalho **global** para "Pesquisar conteúdo da área de transferência no painel autônomo".
+
+<img src="./src/saladictglobalshortcut.jpg" div align=center>
+
+**Importante:** O atalho no navegador deve ser o mesmo que no BallonsTranslator (por padrão, "ALT+S").
+
+<img src="./src/saladictglobalshortcut2.jpg" div align=center>


### PR DESCRIPTION
Added translated documents to pt-BR:
- README_PT-BR.md
- CHANGELOG_PT-BR.md
- Como_add_um_novo_tradutor.md
- saladict_pt-br.md
- Manual_TuanziOCR_pt-BR.md

Added a shortcut to `README_PT-BR.md` in the README.md files of other existing languages.

Fix the path for Chinese Tuanzi OCR Instructions doc in `Tuanzi OCR Instructions (Chinese only)` in `README_EN.md` and added the information/path for the pt-BR document.