### PR TITLE
feat: Added a command-line instruction for batch translation of content within subfolders.

### DIFF
--- a/README.md
+++ b/README.md
@@ -158,6 +158,16 @@ python launch.py --headless --exec_dirs "[DIR_1],[DIR_2]..."
 所有设置 (如检测模型, 原语言目标语言等) 会从 config/config.json 导入。  
 如果渲染字体大小不对, 通过 ```--ldpi ``` 指定 Logical DPI 大小, 通常为 96 和 72。
 
+你也可以使用这段命令翻译，这会弹出界面，并实时展示正在翻译的图片，以更好地展示翻译的进度和正确性：
+``` python
+python launch.py --exec_dirs "[DIR_1],[DIR_2]..."
+```
+
+对于一个包含了多个子文件夹的文件夹，其中每个子文件夹中是若干漫画图片，可以使用这段命令批量处理所有子文件夹：
+``` python
+python script.py --exec-subfolders "[DIR]"
+```
+
 # 自动化模块
 本项目重度依赖 [manga-image-translator](https://github.com/zyddnys/manga-image-translator)，在线服务器和模型训练需要费用，有条件请考虑支持一下
 - Ko-fi: <https://ko-fi.com/voilelabs>

--- a/README_EN.md
+++ b/README_EN.md
@@ -193,6 +193,15 @@ python launch.py --headless --exec_dirs "[DIR_1],[DIR_2]..."
 Note the configuration (source language, target language, inpaint model, etc) will load from config/config.json.  
 If the rendered font size is not right, specify logical DPI manually via ```--ldpi ```, typical values are 96 and 72.
 
+You can also use this command for translation, which will bring up the interface and display the images being translated in real-time, providing a better demonstration of the progress and accuracy of the translations:
+```python
+python launch.py --exec_dirs "[DIR_1],[DIR_2]..."
+```
+
+For a folder that contains multiple subfolders, where each subfolder consists of several comic images, you can use the following command to batch process all subfolders:
+```python
+python script.py --exec-subfolders "[DIR]"
+```
 
 # Automation modules
 This project is heavily dependent upon [manga-image-translator](https://github.com/zyddnys/manga-image-translator), online service and model training is not cheap, please consider to donate the project:  

--- a/launch.py
+++ b/launch.py
@@ -43,7 +43,11 @@ parser.add_argument("--requirements", default='requirements.txt')
 parser.add_argument("--headless", action='store_true', help='run without GUI')
 parser.add_argument("--exec_dirs", default='', help='translation queue (project directories) separated by comma')
 parser.add_argument("--ldpi", default=None, type=float, help='logical dots perinch')
+parser.add_argument("--exec-subfolders", default='', type=str, help='Folder containing subdirectories to be added to --exec_dirs')
 args, _ = parser.parse_known_args()
+if args.exec_subfolders:
+    subfolders = [os.path.join(args.exec_subfolders, d) for d in os.listdir(args.exec_subfolders) if os.path.isdir(os.path.join(args.exec_subfolders, d))]
+    args.exec_dirs = ','.join(subfolders)
 
 
 def is_installed(package):

--- a/ui/mainwindow.py
+++ b/ui/mainwindow.py
@@ -96,8 +96,7 @@ class MainWindow(mainwindow_cls):
                 if osp.exists(proj_dir):
                     self.OpenProj(proj_dir)
 
-        if shared.HEADLESS:
-            self.run_batch(**exec_args)
+        self.run_batch(**exec_args)
 
     def setStyleSheet(self, styleSheet: str) -> None:
         self.imgtrans_progress_msgbox.setStyleSheet(styleSheet)
@@ -864,8 +863,7 @@ class MainWindow(mainwindow_cls):
         self.postprocess_mt_toggle = True
         if pcfg.module.empty_runcache and not shared.HEADLESS:
             self.module_manager.unload_all_models()
-        if shared.HEADLESS:
-            self.run_next_dir()
+        self.run_next_dir()
 
     def postprocess_translations(self, blk_list: List[TextBlock]) -> None:
         src_is_cjk = is_cjk(pcfg.module.translate_source)


### PR DESCRIPTION
For a folder that contains multiple subfolders, where each subfolder includes various comic images, you can use this command to batch process all subfolders:
```python
python script.py --exec-subfolders "[DIR]"
```
For this feature, I've added some lines of code in `launch.py`:
```python
parser.add_argument("--exec-subfolders", default='', type=str, help='Folder containing subdirectories to be added to --exec_dirs')
...
if args.exec_subfolders:
    subfolders = [os.path.join(args.exec_subfolders, d) for d in os.listdir(args.exec_subfolders) if os.path.isdir(os.path.join(args.exec_subfolders, d))]
    args.exec_dirs = ','.join(subfolders)
```

You can also use this command for translation, which will bring up the interface and display the images being translated in real-time, providing a better demonstration of the progress and accuracy of the translations:
```python
python launch.py --exec_dirs "[DIR_1],[DIR_2]..."
```

I have modified the code in the `__init__` function of `mainwindow.py` from:
```python
if shared.HEADLESS:
    self.run_batch(**exec_args)
```
to:
```python
self.run_batch(**exec_args)
```
And changed the code in the `on_imgtrans_pipeline_finished` function from:
```python
if shared.HEADLESS:
    self.run_next_dir()
```
to:
```python
self.run_next_dir()
```

In addition, I have updated the README files to inform users about these new features.