### PR TITLE
Fixed position bug when copying/pasting

### DIFF
--- a/ui/canvas.py
+++ b/ui/canvas.py
@@ -157,7 +157,7 @@ class Canvas(QGraphicsScene):
     finish_painting = Signal(StrokeImgItem)
     finish_erasing = Signal(StrokeImgItem)
     delete_textblks = Signal(int)
-    copy_textblks = Signal(QPointF)
+    copy_textblks = Signal()
     paste_textblks = Signal(QPointF)
     copy_src_signal = Signal()
     paste_src_signal = Signal()
@@ -786,9 +786,9 @@ class Canvas(QGraphicsScene):
             elif rst == delete_recover_act:
                 self.delete_textblks.emit(1)
             elif rst == copy_act:
-                self.on_copy(pos.toPointF())
+                self.on_copy()
             elif rst == paste_act:
-                self.on_paste(pos.toPointF())
+                self.on_paste()
             elif rst == copy_src_act:
                 self.copy_src_signal.emit()
             elif rst == paste_src_act:
@@ -825,12 +825,10 @@ class Canvas(QGraphicsScene):
             else:
                 self.paste_textblks.emit(p)
 
-    def on_copy(self, p: QPointF = None):
+    def on_copy(self):
         if self.textEditMode():
             if self.have_selected_blkitem:
-                if p is None:
-                    p = self.scene_cursor_pos()
-                self.copy_textblks.emit(p)
+                self.copy_textblks.emit()
 
     def hide_rubber_band(self):
         if self.rubber_band.isVisible():

--- a/ui/scenetext_manager.py
+++ b/ui/scenetext_manager.py
@@ -637,7 +637,7 @@ class SceneTextManager(QObject):
         if len(selected_blks) > 0:
             self.canvas.push_undo_command(DeleteBlkItemsCommand(selected_blks, mode, self))
 
-    def onCopyBlkItems(self, pos: QPointF):
+    def onCopyBlkItems(self):
         selected_blks = self.canvas.selected_text_items()
         if len(selected_blks) == 0 and self.txtblkShapeControl.blk_item is not None:
             selected_blks.append(self.txtblkShapeControl.blk_item)
@@ -649,13 +649,9 @@ class SceneTextManager(QObject):
         if self.canvas.text_change_unsaved():
             self.updateTextBlkList()
 
-        if pos is None:
-            pos = selected_blks[0].blk.xyxy
-            pos_x, pos_y = pos[0], pos[1]
-        else:
-            pos_x, pos_y = pos.x(), pos.y()
-            pos_x = int(pos_x / self.canvas.scale_factor)
-            pos_y = int(pos_y / self.canvas.scale_factor)
+        pos = selected_blks[0].blk.bounding_rect()
+        pos_x = int(pos[0] + pos[2] / 2)
+        pos_y = int(pos[1] + pos[3] / 2)
 
         textlist = []
         for blkitem in selected_blks:


### PR DESCRIPTION
### Fix copy/paste creating in unexpected locations.


![Before fixing](https://github.com/user-attachments/assets/9b452753-d4b4-4fe1-870a-3aa4cdf8ed68)
<p align = "center">
[Before fixing]
</p>

![After fixing](https://github.com/user-attachments/assets/1760da70-2a24-4f27-ba31-e1451e861a35)
<p align = "center">
[After fixing]
</p>

There were two issues.
1. When copying/pasting, event.screenPos() is passed.
- This passes the coordinates based on the entire screen. It is not suitable for preserving the position of the speech bubble. It has been modified to not pass the coordinates.
2. When restoring the coordinates, blk.xyxy is used previously.
- blk.xyxy represents the coordinates of the original language, not the current coordinates. Therefore, it is replaced with blk.bounding_rect().
- Since the distance between the text box and the mouse is inconvenient, it is modified to paste in the center of the mouse.
- This makes the coordinates unnecessary when copying, so it is deleted.