### PR TITLE
Improvements to font size adjustment

### DIFF
--- a/ui/fontformat_commands.py
+++ b/ui/fontformat_commands.py
@@ -138,9 +138,14 @@ def ffmt_change_stroke_width(param_name: str, values: float, act_ffmt: FontForma
 def ffmt_change_font_size(param_name: str, values: float, act_ffmt: FontFormat, is_global: bool, blkitems: List[TextBlkItem], clip_size=False, **kwargs):
     set_kwargs = global_default_set_kwargs if is_global else local_default_set_kwargs
     for blkitem, value in zip(blkitems, values):
-        if value < 0:
+        if value < 0 and param_name == "font_size":
             continue
-        blkitem.setFontSize(px2pt(value), clip_size=clip_size, **set_kwargs)
+        if param_name == "font_size":
+            setFontSize = blkitem.setFontSize
+            value = px2pt(value)
+        else:
+            setFontSize = blkitem.setRelFontSize
+        setFontSize(value, clip_size=clip_size, **set_kwargs)
 
 @font_formating(push_undostack=True)
 def ffmt_change_alignment(param_name: str, values: float, act_ffmt: FontFormat, is_global: bool, blkitems: List[TextBlkItem], **kwargs):

--- a/ui/scene_textlayout.py
+++ b/ui/scene_textlayout.py
@@ -269,6 +269,9 @@ class SceneTextLayout(QAbstractTextDocumentLayout):
     def documentChanged(self, position: int, charsRemoved: int, charsAdded: int) -> None:
         if not self.relayout_on_changed:
             return
+        self.reLayoutEverything()
+        
+    def reLayoutEverything(self):
         self._doc_text = self.document().toPlainText()
         self._max_font_size = -1
         block = self.document().firstBlock()

--- a/ui/scenetext_manager.py
+++ b/ui/scenetext_manager.py
@@ -1037,6 +1037,7 @@ class SceneTextManager(QObject):
             trans_widget_list.append(self.pairwidget_list[blk.idx].e_trans)
         if len(selected_blks) > 0:
             self.canvas.push_undo_command(ApplyFontformatCommand(selected_blks, trans_widget_list, fontformat))
+            self.formatpanel.set_active_format(fontformat)
 
     def on_transwidget_selection_changed(self):
         selitems = self.canvas.selected_text_items()

--- a/ui/scenetext_manager.py
+++ b/ui/scenetext_manager.py
@@ -591,7 +591,7 @@ class SceneTextManager(QObject):
 
     def onTextBlkItemEndEdit(self, blk_id: int):
         self.canvas.editing_textblkitem = None
-        self.formatpanel.set_textblk_item(None)
+        self.textblk_item_list[blk_id].setSelected(True)
         self.txtblkShapeControl.endEditing()
 
     def editingTextItem(self) -> TextBlkItem:
@@ -685,6 +685,10 @@ class SceneTextManager(QObject):
         if len(blkitem_list) > 0:
             self.canvas.clearSelection()
             self.canvas.push_undo_command(PasteBlkItemsCommand(blkitem_list, pair_widget_list, self))
+            if len(blkitem_list) == 1:
+                self.formatpanel.set_textblk_item(blkitem_list[0])
+            else:
+                self.formatpanel.set_textblk_item(multi_select=True)
 
     def onFormatTextblks(self, fmt: FontFormat = None):
         if fmt is None:
@@ -718,6 +722,10 @@ class SceneTextManager(QObject):
         if self.canvas.textEditMode():
             textitems = self.canvas.selected_text_items()
             self.textEditList.set_selected_list([t.idx for t in textitems])
+            if len(textitems) == 1:
+                self.formatpanel.set_textblk_item(textitems[-1])
+            else:
+                self.formatpanel.set_textblk_item(multi_select=bool(textitems))
 
     def layout_textblk(self, blkitem: TextBlkItem, text: str = None, mask: np.ndarray = None, bounding_rect: List = None, region_rect: List = None):
         

--- a/ui/scenetext_manager.py
+++ b/ui/scenetext_manager.py
@@ -1008,7 +1008,7 @@ class SceneTextManager(QObject):
     def on_push_textitem_undostack(self, num_steps: int, is_formatting: bool):
         blkitem: TextBlkItem = self.sender()
         e_trans = self.pairwidget_list[blkitem.idx].e_trans if not is_formatting else None
-        self.canvas.push_undo_command(TextItemEditCommand(blkitem, e_trans, num_steps), update_pushed_step=is_formatting)
+        self.canvas.push_undo_command(TextItemEditCommand(blkitem, e_trans, num_steps, self.textpanel.formatpanel), update_pushed_step=is_formatting)
 
     def on_push_edit_stack(self, num_steps: int):
         edit: Union[TransTextEdit, SourceTextEdit] = self.sender()

--- a/ui/text_panel.py
+++ b/ui/text_panel.py
@@ -599,10 +599,8 @@ class FontFormatPanel(Widget):
             if not self.restoring_textblk:
                 blk_fmt = textblk_item.get_fontformat()
                 self.textblk_item = textblk_item
-                multi_size = False
-                if not textblk_item.isEditing():
-                    multi_size = textblk_item.isMultiFontSize()
-                self.set_active_format(blk_fmt,multi_size)
+                multi_size = not textblk_item.isEditing() and textblk_item.isMultiFontSize()
+                self.set_active_format(blk_fmt, multi_size)
                 self.textstyle_panel.setTitle(f'TextBlock #{textblk_item.idx}')
 
     def on_effectbtn_clicked(self):

--- a/ui/text_panel.py
+++ b/ui/text_panel.py
@@ -591,7 +591,7 @@ class FontFormatPanel(Widget):
                 self.textblk_item = None
                 self.set_active_format(self.global_format, multi_select)
                 if multi_select:
-                    self.textstyle_panel.setTitle('Grop')
+                    self.textstyle_panel.setTitle('Group')
                 else:
                     self.set_globalfmt_title()
             
@@ -601,15 +601,7 @@ class FontFormatPanel(Widget):
                 self.textblk_item = textblk_item
                 multi_size = False
                 if not textblk_item.isEditing():
-                    cursor = textblk_item.textCursor()
-                    cursor.setPosition(0)
-                    firstFontSize = cursor.charFormat().fontPointSize()
-                    for i in range(0,len(textblk_item.toPlainText())+1):
-                        cursor.setPosition(i)
-                        font_size = cursor.charFormat().fontPointSize()
-                        if not firstFontSize == font_size:
-                            multi_size = True
-                            break
+                    multi_size = textblk_item.isMultiFontSize()
                 self.set_active_format(blk_fmt,multi_size)
                 self.textstyle_panel.setTitle(f'TextBlock #{textblk_item.idx}')
 

--- a/ui/text_panel.py
+++ b/ui/text_panel.py
@@ -148,8 +148,8 @@ class FontSizeBox(QFrame):
         self.fcombobox = SizeComboBox([1, 1000], 'font_size', self)
         self.fcombobox.addItems([
             "5", "5.5", "6.5", "7.5", "8", "9", "10", "10.5",
-            "11", "12", "14", "16", "18", "20", '22', "26", "28", 
-            "36", "48", "56", "72"
+            "11", "12", "14", "16", "18", "20", '22', "26", "28",
+            "36", "48", "56", "72", "93", "123", "163"
         ])
         self.fcombobox.param_changed.connect(self.param_changed)
 
@@ -164,35 +164,55 @@ class FontSizeBox(QFrame):
         hlayout.setSpacing(3)
         hlayout.setContentsMargins(0, 0, 0, 0)
 
-    def getFontSize(self) -> float:
-        return self.fcombobox.value()
+    def getFontSize(self) -> str:
+        return self.fcombobox.currentText()
 
     def onUpBtnClicked(self):
+        raito = 1.25
         size = self.getFontSize()
-        newsize = int(round(size * 1.25))
+        multi_size=False
+        if "+" in size:
+            size = size.strip("+")
+            multi_size=True
+        size = float(size)
+        newsize = int(round(size * raito))
         if newsize == size:
             newsize += 1
         newsize = min(1000, newsize)
         if newsize != size:
-            self.param_changed.emit('font_size', newsize)
-            self.fcombobox.setCurrentText(str(newsize))
-        
+            if not multi_size:
+                self.param_changed.emit('font_size', newsize)
+                self.fcombobox.setCurrentText(str(newsize))
+            else:
+                self.param_changed.emit('rel_font_size', raito)
+                self.fcombobox.setCurrentText(str(newsize)+"+")
+
     def onDownBtnClicked(self):
+        raito = 0.75
         size = self.getFontSize()
-        newsize = int(round(size * 0.75))
+        multi_size=False
+        if "+" in size:
+            size = size.strip("+")
+            multi_size=True
+        size = float(size)
+        newsize = int(round(size * raito))
         if newsize == size:
             newsize -= 1
         newsize = max(1, newsize)
         if newsize != size:
-            self.param_changed.emit('font_size', newsize)
-            self.fcombobox.setCurrentText(str(newsize))
+            if not multi_size:
+                self.param_changed.emit('font_size', newsize)
+                self.fcombobox.setCurrentText(str(newsize))
+            else:
+                self.param_changed.emit('rel_font_size', raito)
+                self.fcombobox.setCurrentText(str(newsize)+"+")
 
 
 class SizeControlLabel(QLabel):
-    
+
     btn_released = Signal()
     size_ctrl_changed = Signal(int)
-    
+
     def __init__(self, parent=None, direction=0, text=''):
         super().__init__(parent)
         if text:
@@ -459,7 +479,7 @@ class FontFormatPanel(Widget):
         return self.textstyle_panel.active_text_style_label
 
     def on_param_changed(self, param_name: str, value):
-        func = FM.handle_ffmt_change.get(param_name)
+        func = FM.handle_ffmt_change.get(param_name if not param_name == "rel_font_size" else "font_size")
         func_kwargs = {}
         if param_name == 'font_size':
             func_kwargs['clip_size'] = True
@@ -506,8 +526,8 @@ class FontFormatPanel(Widget):
         else:
             mul = 0.01
         self.lineSpacingBox.setValue(self.lineSpacingBox.value() + delta * mul)
-            
-    def set_active_format(self, font_format: FontFormat):
+
+    def set_active_format(self, font_format: FontFormat, multi_size=False):
         C.active_format = font_format
         self.familybox.blockSignals(True)
         font_size = round(font_format.font_size, 1)
@@ -515,6 +535,8 @@ class FontFormatPanel(Widget):
             font_size = str(int(font_size))
         else:
             font_size = f'{font_size:.1f}'
+        if multi_size:
+            font_size += "+"
         self.fontsizebox.fcombobox.setCurrentText(font_size)
         self.familybox.setCurrentText(font_format.font_family)
         self.colorPicker.setPickerColor(font_format.foreground_color())
@@ -555,7 +577,7 @@ class FontFormatPanel(Widget):
         if self.global_mode():
             self.set_globalfmt_title()
 
-    def set_textblk_item(self, textblk_item: TextBlkItem = None):
+    def set_textblk_item(self, textblk_item: TextBlkItem = None, multi_select:bool=False):
         if textblk_item is None:
             focus_w = self.app.focusWidget()
             focus_p = None if focus_w is None else focus_w.parentWidget()
@@ -567,13 +589,28 @@ class FontFormatPanel(Widget):
                     focus_on_fmtoptions = True
             if not focus_on_fmtoptions:
                 self.textblk_item = None
-                self.set_active_format(self.global_format)
-                self.set_globalfmt_title()
+                self.set_active_format(self.global_format, multi_select)
+                if multi_select:
+                    self.textstyle_panel.setTitle('Grop')
+                else:
+                    self.set_globalfmt_title()
+            
         else:
             if not self.restoring_textblk:
                 blk_fmt = textblk_item.get_fontformat()
                 self.textblk_item = textblk_item
-                self.set_active_format(blk_fmt)
+                multi_size = False
+                if not textblk_item.isEditing():
+                    cursor = textblk_item.textCursor()
+                    cursor.setPosition(0)
+                    firstFontSize = cursor.charFormat().fontPointSize()
+                    for i in range(0,len(textblk_item.toPlainText())+1):
+                        cursor.setPosition(i)
+                        font_size = cursor.charFormat().fontPointSize()
+                        if not firstFontSize == font_size:
+                            multi_size = True
+                            break
+                self.set_active_format(blk_fmt,multi_size)
                 self.textstyle_panel.setTitle(f'TextBlock #{textblk_item.idx}')
 
     def on_effectbtn_clicked(self):

--- a/ui/textedit_commands.py
+++ b/ui/textedit_commands.py
@@ -273,14 +273,25 @@ class TextItemEditCommand(QUndoCommand):
         if self.op_counter == 0:
             self.op_counter += 1
             return
+        
+        self.blkitem.repaint_on_changed = False
         for _ in range(self.num_steps):
             self.blkitem.redo()
+        self.blkitem.repaint_on_changed = True
+        if self.num_steps > 0:
+            self.blkitem.repaint_background()
+
         if self.edit is not None and not self.is_formatting:
             self.edit.redo()
 
     def undo(self):
+        self.blkitem.repaint_on_changed = False
         for _ in range(self.num_steps):
             self.blkitem.undo()
+        self.blkitem.repaint_on_changed = True
+        if self.num_steps > 0:
+            self.blkitem.repaint_background()
+
         if self.edit is not None:
             self.edit.undo()
 

--- a/ui/textedit_commands.py
+++ b/ui/textedit_commands.py
@@ -10,6 +10,7 @@ except:
 from .textitem import TextBlkItem, TextBlock
 from .textedit_area import TransTextEdit, SourceTextEdit
 from utils.fontformat import FontFormat
+import utils.config as C
 from .misc import doc_replace, doc_replace_no_shift
 from .texteditshapecontrol import TextBlkShapeControl
 from .page_search_widget import PageSearchWidget, Matched
@@ -261,13 +262,14 @@ class ResetAngleCommand(QUndoCommand):
                 self.ctrl.setAngle(angle)
 
 class TextItemEditCommand(QUndoCommand):
-    def __init__(self, blkitem: TextBlkItem, trans_edit: TransTextEdit, num_steps: int):
+    def __init__(self, blkitem: TextBlkItem, trans_edit: TransTextEdit, num_steps: int, formatpanel=None):
         super(TextItemEditCommand, self).__init__()
         self.op_counter = 0
         self.edit = trans_edit
         self.blkitem = blkitem
         self.num_steps = num_steps
         self.is_formatting = blkitem.is_formatting
+        self.formatpanel = formatpanel
 
     def redo(self):
         if self.op_counter == 0:
@@ -281,6 +283,10 @@ class TextItemEditCommand(QUndoCommand):
         if self.num_steps > 0:
             self.blkitem.repaint_background()
 
+        if self.is_formatting and self.blkitem == self.formatpanel.textblk_item:
+            multi_size = not self.blkitem.isEditing() and self.blkitem.isMultiFontSize()
+            self.formatpanel.set_active_format(self.blkitem.get_fontformat(), multi_size)
+
         if self.edit is not None and not self.is_formatting:
             self.edit.redo()
 
@@ -291,6 +297,10 @@ class TextItemEditCommand(QUndoCommand):
         self.blkitem.repaint_on_changed = True
         if self.num_steps > 0:
             self.blkitem.repaint_background()
+
+        if self.is_formatting and self.blkitem == self.formatpanel.textblk_item:
+            multi_size = not self.blkitem.isEditing() and self.blkitem.isMultiFontSize()
+            self.formatpanel.set_active_format(self.blkitem.get_fontformat(), multi_size)
 
         if self.edit is not None:
             self.edit.undo()

--- a/ui/texteditshapecontrol.py
+++ b/ui/texteditshapecontrol.py
@@ -67,8 +67,9 @@ class ControlBlockItem(QGraphicsRectItem):
 
     def mousePressEvent(self, event: QGraphicsSceneMouseEvent) -> None:
         self.ctrl.ctrlblockPressed()
-        blk_item = self.ctrl.blk_item
         if event.button() == Qt.MouseButton.LeftButton:
+            blk_item = self.ctrl.blk_item
+            blk_item.setSelected(True)
             if self.visible_rect.contains(event.pos()):
                 self.ctrl.reshaping = True
                 self.drag_mode = self.DRAG_RESHAPE

--- a/ui/textitem.py
+++ b/ui/textitem.py
@@ -850,9 +850,9 @@ class TextBlkItem(QGraphicsTextItem):
                 it += 1
             block = block.next()
         self.old_undo_steps = new_undo_steps = self.document().availableUndoSteps()
+        self.squeezeBoundingRect(True)
         self.layout.relayout_on_changed = True
         self.layout.reLayoutEverything()
-        self.squeezeBoundingRect(True)
         self.repaint_background()
         new_steps = new_undo_steps - old_undo_steps
         self.push_undo_stack.emit(new_steps, self.is_formatting)

--- a/ui/textitem.py
+++ b/ui/textitem.py
@@ -801,6 +801,22 @@ class TextBlkItem(QGraphicsTextItem):
         if repaint_background:
             self.update()
 
+    def setRelFontSize(self, value: float, repaint_background: bool = False, set_selected: bool = False, restore_cursor: bool = False, clip_size: bool = False, **kwargs):
+        cursor = self.textCursor()
+        old_sizes = []
+        for i in range(len(self.toPlainText())):
+            cursor.setPosition(i)
+            cursor.setPosition(i+1, QTextCursor.MoveMode.KeepAnchor)
+            old_sizes.append(cursor.charFormat().fontPointSize())
+        for i in range(len(self.toPlainText())):
+            cursor.setPosition(i)
+            cursor.setPosition(i+1, QTextCursor.MoveMode.KeepAnchor)
+            self.setTextCursor(cursor)
+            newvalue = round(old_sizes[i] * value,2)
+            self.setFontSize(newvalue, repaint_background, True, restore_cursor, clip_size, **kwargs)
+            cursor.clearSelection()
+            self.squeezeBoundingRect()
+
     def setFontSize(self, value: float, repaint_background: bool = False, set_selected: bool = False, restore_cursor: bool = False, clip_size: bool = False, **kwargs):
         '''
         value should be point size

--- a/ui/textitem.py
+++ b/ui/textitem.py
@@ -816,6 +816,7 @@ class TextBlkItem(QGraphicsTextItem):
             self.setFontSize(newvalue, repaint_background, True, restore_cursor, clip_size, **kwargs)
             cursor.clearSelection()
             self.squeezeBoundingRect()
+        cursor.setPosition(0)
 
     def setFontSize(self, value: float, repaint_background: bool = False, set_selected: bool = False, restore_cursor: bool = False, clip_size: bool = False, **kwargs):
         '''

--- a/ui/textitem.py
+++ b/ui/textitem.py
@@ -515,6 +515,22 @@ class TextBlkItem(QGraphicsTextItem):
                 it += 1
             block = block.next()
         return False
+    
+    def minFontSize(self, to_px=True):
+        doc = self.document()
+        block = doc.firstBlock()
+        min_font_size = self.textCursor().charFormat().fontPointSize()
+        while block.isValid():
+            it = block.begin()
+            while not it.atEnd():
+                fragment = it.fragment()
+                font_size = fragment.charFormat().fontPointSize()
+                min_font_size = min(min_font_size, font_size)
+                it += 1
+            block = block.next()
+        if to_px:
+            min_font_size = pt2px(min_font_size)
+        return min_font_size
 
     def mouseDoubleClickEvent(self, event: QGraphicsSceneMouseEvent) -> None:
         if not self.isEditing():
@@ -577,7 +593,10 @@ class TextBlkItem(QGraphicsTextItem):
         fontformat.frgb = [color.red(), color.green(), color.blue()]
         fontformat.font_weight = font.weight()
         fontformat.font_family = font.family()
-        fontformat.font_size = pt2px(font.pointSizeF())
+        if self.isEditing():
+            fontformat.font_size = pt2px(font.pointSizeF())
+        else:
+            fontformat.font_size = self.minFontSize()
         fontformat.bold = font.bold()
         fontformat.underline = font.underline()
         fontformat.italic = font.italic()


### PR DESCRIPTION
### Improvements to font size adjustment


![before_fix_font_size](https://github.com/user-attachments/assets/508f7651-4a99-46f7-ae18-ab0325877caf)
<p align = "center">
[Before fixing]
</p>

![after_fix_font_size](https://github.com/user-attachments/assets/02574848-86c5-44ff-9160-d03623568639)
<p align = "center">
[After fixing]
</p>

Improvements
- Find out the current font size just by selecting the text box
- Change font size based on current size
- Box is selected even when changing size

----
todo
- I don't know how to block undo_stack while changing the size of each letter individually.
- ~~With the current code, selected text does not respect individual sizes when editing.~~ <-I tried it and it was comfortable and natural.