### PR TITLE
Add a frozen argument and fix an annotation crash

### DIFF
--- a/launch.py
+++ b/launch.py
@@ -56,6 +56,7 @@ parser.add_argument("--exec_dirs", default='', help='translation queue (project 
 parser.add_argument("--ldpi", default=None, type=float, help='logical dots perinch')
 parser.add_argument("--export-translation-txt", action='store_true', help='save translation to txt file once RUN completed')
 parser.add_argument("--export-source-txt", action='store_true', help='save source to txt file once RUN completed')
+parser.add_argument("--frozen", action='store_true', help='run without checking requirements')
 args, _ = parser.parse_known_args()
 
 
@@ -294,6 +295,9 @@ def main():
 def prepare_environment():
     if getattr(sys, 'frozen', False):
         print('Running as app, skip dependency installation')
+        return
+    
+    if args.frozen:
         return
 
     req_updated = False

--- a/modules/translators/trans_eztrans.py
+++ b/modules/translators/trans_eztrans.py
@@ -13,7 +13,7 @@ class MyClient(Client64):
                                        engine_type=engine_type,
                                        dat_path=dat_path)
 
-    def translate(self, src_text: str | list):
+    def translate(self, src_text: "str | list"):
         return self.request32('translate', src_text)
 
 


### PR DESCRIPTION
1. Add `--frozen` argument to prevent reinstalling any requirements. My intention for this is especially to prevent pytorch from downgrading from pre-released version.
2. Enclose `str | list` with a quote so that it won't crash in python 3.8.