### PR TITLE
fix: nightly 启动脚本传参缺空格

### DIFF
--- a/launch_win_amd_nightly.bat
+++ b/launch_win_amd_nightly.bat
@@ -33,7 +33,7 @@ goto :show_stdout_stderr
 
 
 :launch
-%PYTHON% launch.py --nightly%*
+%PYTHON% launch.py --nightly  %*
 pause
 exit /b
 


### PR DESCRIPTION
参考另外两个 bat 也加了两个空格