### PR TITLE
Added new command line argument "--headless_continuous"

### DIFF
--- a/launch.py
+++ b/launch.py
@@ -39,6 +39,7 @@ else:
 parser.add_argument("--debug", action='store_true')
 parser.add_argument("--requirements", default='requirements.txt')
 parser.add_argument("--headless", action='store_true', help='run without GUI')
+parser.add_argument("--headless_continuous", action='store_true', help='like headless but will not exit after finishing translation, prompts the user for new exec_dirs until user exits the program')
 parser.add_argument("--exec_dirs", default='', help='translation queue (project directories) separated by comma')
 parser.add_argument("--ldpi", default=None, type=float, help='logical dots perinch')
 parser.add_argument("--export-translation-txt", action='store_true', help='save translation to txt file once RUN completed')
@@ -180,11 +181,12 @@ def main():
     shared.args = args
     shared.DEFAULT_DISPLAY_LANG = QLocale.system().name().replace('en_CN', 'zh_CN')
     shared.HEADLESS = args.headless
+    shared.HEADLESS_CONTINUOUS = args.headless_continuous
     shared.load_cache()
     program_config.load_config(args.config_path)
     config = program_config.pcfg
 
-    if args.headless:
+    if args.headless or args.headless_continuous:
         config.module.load_model_on_demand = True
         config.module.empty_runcache = False
 
@@ -215,7 +217,7 @@ def main():
     setup_logging(shared.LOGGING_PATH)
 
     app_args = sys.argv
-    if args.headless:
+    if args.headless or args.headless_continuous:
         app_args = sys.argv + ['-platform', 'offscreen']
     app = QApplication(app_args)
     app.setApplicationName('BalloonsTranslator')
@@ -228,7 +230,7 @@ def main():
     init_module_registries()
     prepare_local_files_forall()
 
-    if not args.headless:
+    if not args.headless and not args.headless_continuous:
         ps = QGuiApplication.primaryScreen()
         shared.LDPI = ps.logicalDotsPerInch()
         shared.SCREEN_W = ps.geometry().width()
@@ -252,7 +254,7 @@ def main():
             if fnt_idx >= 0:
                 shared.CUSTOM_FONTS.append(QFontDatabase.applicationFontFamilies(fnt_idx)[0])
 
-    if sys.platform == 'win32' and args.headless:
+    if sys.platform == 'win32' and (args.headless or args.headless_continuous):
         # font database does not initialise on windows with qpa -offscreen:
         # whttps://github.com/dmMaze/BallonsTranslator/issues/519
         from qtpy.QtCore import QStandardPaths
@@ -288,7 +290,7 @@ def main():
     BT = ballontrans
     BT.restart_signal.connect(restart)
 
-    if not args.headless:
+    if not args.headless and not args.headless_continuous:
         if shared.SCREEN_W > 1707 and sys.platform == 'win32':   # higher than 2560 (1440p) / 1.5
             # https://github.com/dmMaze/BallonsTranslator/issues/220
             BT.comicTransSplitter.setHandleWidth(7)

--- a/ui/framelesswindow/fw_qt5/utils/linux_utils.py
+++ b/ui/framelesswindow/fw_qt5/utils/linux_utils.py
@@ -159,7 +159,7 @@ class LinuxMoveResize:
 
     @classmethod
     def toggleMaxState(cls, window):
-        if shared.HEADLESS:
+        if shared.HEADLESS or shared.HEADLESS_CONTINUOUS:
             return
         if window.isMaximized():
             window.showNormal()

--- a/ui/framelesswindow/linux_utils.py
+++ b/ui/framelesswindow/linux_utils.py
@@ -35,7 +35,7 @@ class LinuxMoveResize:
 
     @classmethod
     def toggleMaxState(cls, window):
-        if shared.HEADLESS:
+        if shared.HEADLESS or shared.HEADLESS_CONTINUOUS:
             return
         if window.isMaximized():
             window.showNormal()

--- a/ui/framelesswindow/mac_utils.py
+++ b/ui/framelesswindow/mac_utils.py
@@ -63,7 +63,7 @@ class MacMoveResize:
 
     @classmethod
     def toggleMaxState(cls, window):
-        if shared.HEADLESS:
+        if shared.HEADLESS or shared.HEADLESS_CONTINUOUS:
             return
         if window.isMaximized():
             window.showNormal()

--- a/ui/framelesswindow/win32_utils.py
+++ b/ui/framelesswindow/win32_utils.py
@@ -399,7 +399,7 @@ class WindowsMoveResize:
 
     @classmethod
     def toggleMaxState(cls, window):
-        if shared.HEADLESS:
+        if shared.HEADLESS or shared.HEADLESS_CONTINUOUS:
             return
         if QT_VERSION < (6, 8, 0):
             if window.isMaximized():

--- a/ui/mainwindow.py
+++ b/ui/mainwindow.py
@@ -57,7 +57,7 @@ class PageListView(QListWidget):
 
         return super().contextMenuEvent(e)
 
-mainwindow_cls = Widget if shared.HEADLESS else FramelessWindow
+mainwindow_cls = Widget if (shared.HEADLESS or shared.HEADLESS_CONTINUOUS) else FramelessWindow
 class MainWindow(mainwindow_cls):
 
     imgtrans_proj: ProjImgTrans = ProjImgTrans()
@@ -102,7 +102,7 @@ class MainWindow(mainwindow_cls):
                 if osp.exists(proj_dir):
                     self.OpenProj(proj_dir)
 
-        if shared.HEADLESS:
+        if shared.HEADLESS or shared.HEADLESS_CONTINUOUS:
             self.run_batch(**exec_args)
 
         if shared.ON_MACOS:
@@ -454,7 +454,7 @@ class MainWindow(mainwindow_cls):
         else:
             self.openJsonProj(proj_path)
         
-        if pcfg.let_textstyle_indep_flag and not shared.HEADLESS:
+        if pcfg.let_textstyle_indep_flag and not (shared.HEADLESS or shared.HEADLESS_CONTINUOUS):
             self.load_textstyle_from_proj_dir(from_proj=True)
 
     def load_textstyle_from_proj_dir(self, from_proj=False):
@@ -1272,13 +1272,13 @@ class MainWindow(mainwindow_cls):
         self.backup_blkstyles.clear()
         self._run_imgtrans_wo_textstyle_update = False
         self.postprocess_mt_toggle = True
-        if pcfg.module.empty_runcache and not shared.HEADLESS:
+        if pcfg.module.empty_runcache and not (shared.HEADLESS or shared.HEADLESS_CONTINUOUS):
             self.module_manager.unload_all_models()
         if shared.args.export_translation_txt:
             self.on_export_txt('translation')
         if shared.args.export_source_txt:
             self.on_export_txt('source')
-        if shared.HEADLESS:
+        if shared.HEADLESS or shared.HEADLESS_CONTINUOUS:
             self.run_next_dir()
 
     def postprocess_translations(self, blk_list: List[TextBlock]) -> None:
@@ -1756,9 +1756,20 @@ class MainWindow(mainwindow_cls):
         if len(self.exec_dirs) == 0:
             while self.imsave_thread.isRunning():
                 time.sleep(0.1)
-            LOGGER.info(f'finished translating all dirs, quit app...')
-            self.app.quit()
-            return
+            if shared.HEADLESS_CONTINUOUS:
+                LOGGER.info(f'finished translating all dirs, please enter next dirs to translate (separated by comma). enter "exit" to quit app.')
+                new_exec_dirs = input()
+                if new_exec_dirs.strip().lower() == 'exit':
+                    LOGGER.info(f'exiting app...')
+                    self.app.quit()
+                    return  
+                else:
+                    self.run_batch(new_exec_dirs)
+                    return;
+            else:
+                LOGGER.info(f'finished translating all dirs, quit app...')
+                self.app.quit()
+                return
         d = self.exec_dirs.pop(0)
         
         LOGGER.info(f'translating {d} ...')

--- a/utils/message.py
+++ b/utils/message.py
@@ -29,7 +29,7 @@ def create_error_dialog(exception: Exception, error_msg: str = None, exception_t
         LOGGER.error(error_msg + '\n')
         LOGGER.error(detail_traceback)
 
-        if not shared.HEADLESS:
+        if not shared.HEADLESS and not shared.HEADLESS_CONTINUOUS:
             shared.create_errdialog_in_mainthread(error_msg, detail_traceback, exception_type)
 
 
@@ -38,7 +38,7 @@ def create_info_dialog(info_msg, btn_type=None, modal: bool = False, frame_less:
         Popup a info dialog in main thread
     '''
     LOGGER.info(info_msg)
-    if not shared.HEADLESS:
+    if not shared.HEADLESS and not shared.HEADLESS_CONTINUOUS:
         shared.create_infodialog_in_mainthread({'info_msg': info_msg, 'btn_type': btn_type, 'modal': modal, 'frame_less': frame_less, 'signal_slot_map_list': signal_slot_map_list})
 
 

--- a/utils/shared.py
+++ b/utils/shared.py
@@ -98,6 +98,7 @@ USE_PYSIDE6 = False
 ON_MACOS = sys.platform == 'darwin'
 ON_WINDOWS = sys.platform == 'win32'
 HEADLESS = False
+HEADLESS_CONTINUOUS = False
 DEBUG = False
 args = None
 


### PR DESCRIPTION
Added a new command line argument "--headless_continuous".

The command line argument acts like "--headless" mode. After all directories in "--exec_dirs" have been processed, the user is prompted to enter a new list of directories to process.

This replaces the value in exec_dirs and reruns the processing code already used to handle the provided directories in "--exec_dirs". 