### PR TITLE
fix: replace bare except with except Exception in shared.py

### DIFF
--- a/utils/shared.py
+++ b/utils/shared.py
@@ -136,7 +136,7 @@ def load_cache():
             try:
                 with open(cache_path, "r", encoding="utf8") as file:
                     cache_data = json.load(file)
-            except:
+            except Exception:
                 print(f'cached file {cache_path} is invalid')
                 cache_data = {}
         else:


### PR DESCRIPTION
## Summary

Replace bare `except:` with `except Exception:` in `utils/shared.py`.

PEP 8 recommends against bare `except:` — it should specify an exception type. Since this catch block handles an error without re-raising (prints and falls back to empty dict), `except Exception:` is the correct replacement.

**Change:**
```python
# Before
try:
    with open(cache_path, "r", encoding="utf8") as file:
        cache_data = json.load(file)
except:
    print(f'cached file {cache_path} is invalid')
    cache_data = {}

# After
except Exception:
    print(f'cached file {cache_path} is invalid')
    cache_data = {}
```

## Testing
No behavior change — style/correctness fix only. Using `except Exception:` avoids catching `SystemExit`, `KeyboardInterrupt`, etc.