### PR TITLE
fix(imread): handle grayscale+alpha (LA) PNGs

### DIFF
--- a/ballontranslator/utils/io_utils.py
+++ b/ballontranslator/utils/io_utils.py
@@ -163,6 +163,9 @@ def imread(imgpath, read_type=cv2.IMREAD_COLOR, max_retry_limit=5, retry_interva
                 img = img.convert('RGB')
             elif img.mode == 'P':
                 img = img.convert('RGBA')
+            elif img.mode == 'LA':
+                # grayscale + alpha (2-channel) isn't handled below; promote to RGBA
+                img = img.convert('RGBA')
             if read_type == cv2.IMREAD_GRAYSCALE:
                 img = img.convert('L')
             img = np.array(img)


### PR DESCRIPTION
PIL 'LA' mode images (8-bit gray + alpha) produced 2-channel arrays because imread only normalized CMYK and P modes. Downstream rendering expects 3/4 channels, so such pages failed to display while RGBA pages on the same project loaded fine.

Promote LA to RGBA before array conversion; the existing all-opaque check then collapses it to RGB.