### PR TITLE
文本面板增加角度编辑功能

### DIFF
--- a/ballontranslator/ui/fontformat_commands.py
+++ b/ballontranslator/ui/fontformat_commands.py
@@ -10,6 +10,7 @@ except:
 from . import shared_widget as SW
 from ballontranslator.utils.fontformat import FontFormat, px2pt
 from .textitem import TextBlkItem
+from .textedit_commands import RotateItemCommand
 
 global_default_set_kwargs = dict(set_selected=False, restore_cursor=False)
 local_default_set_kwargs = dict(set_selected=True, restore_cursor=True)
@@ -170,6 +171,20 @@ def ffmt_change_line_spacing_type(param_name: str, values: float, act_ffmt: Font
     restore_cursor = not is_global
     for blkitem, value in zip(blkitems, values):
         blkitem.setLineSpacingType(value, restore_cursor=restore_cursor)
+
+
+def ffmt_change_angle(param_name: str, values: float, act_ffmt: FontFormat, is_global: bool, blkitems: List[TextBlkItem] = None, set_focus: bool = False, **kwargs):
+    if is_global:
+        blkitems = SW.canvas.selected_text_items()
+    elif not isinstance(blkitems, list):
+        blkitems = [blkitems]
+
+    blkitems = [blkitem for blkitem in blkitems if blkitem is not None]
+    if len(blkitems) > 0:
+        SW.canvas.push_undo_command(RotateItemCommand(blkitems, values, SW.canvas.txtblkShapeControl))
+
+    if set_focus and not SW.canvas.hasFocus():
+        SW.canvas.setFocus()
 
 
 @font_formating(push_undostack=True)

--- a/ballontranslator/ui/funcmaps.py
+++ b/ballontranslator/ui/funcmaps.py
@@ -5,7 +5,7 @@ from ballontranslator.utils.textblock_mask import canny_flood, connected_canny_f
 
 # Build base function map
 handle_ffmt_change = build_funcmap('ballontranslator.ui.fontformat_commands', 
-                                     list(FontFormat.params().keys()) + ['rel_font_size'], 
+                                     list(FontFormat.params().keys()) + ['rel_font_size', 'angle'], 
                                      'ffmt_change_', verbose=False)
 
 

--- a/ballontranslator/ui/text_panel.py
+++ b/ballontranslator/ui/text_panel.py
@@ -278,6 +278,11 @@ class FontFormatPanel(Widget):
         self.lineSpacingBox.addItems(["1.0", "1.1", "1.2"])
         self.lineSpacingBox.setToolTip(self.tr("Change line spacing"))
         self.lineSpacingBox.param_changed.connect(self.on_param_changed)
+
+        linesp_hlayout = QHBoxLayout()
+        linesp_hlayout.addWidget(self.lineSpacingLabel)
+        linesp_hlayout.addWidget(self.lineSpacingBox)
+        linesp_hlayout.setSpacing(shared.WIDGET_SPACING_CLOSE)
         
         self.colorPicker = ColorPickerLabel(self, param_name='frgb')
         self.colorPicker.setToolTip(self.tr("Change font color"))
@@ -335,6 +340,23 @@ class FontFormatPanel(Widget):
         lettersp_hlayout.addWidget(self.letterSpacingLabel)
         lettersp_hlayout.addWidget(self.letterSpacingBox)
         lettersp_hlayout.setSpacing(shared.WIDGET_SPACING_CLOSE)
+
+        self.angleBox = SizeComboBox([-180, 180], "angle", self)
+        self.angleBox.addItems(["0", "90", "180", "-90"])
+        self.angleBox.setToolTip(self.tr("Angle"))
+        self.angleBox.setMinimumWidth(int(self.angleBox.height() * 2.5))
+        self.angleBox.param_changed.connect(self.on_param_changed)
+
+        self.angleLabel = SizeControlLabel(self, direction=0, transparent_bg=False)
+        self.angleLabel.setObjectName("fontAngleLabel")
+        self.angleLabel.setToolTip(self.tr("Angle"))
+        self.angleLabel.size_ctrl_changed.connect(self.onAngleCtrlChanged)
+        self.angleLabel.btn_released.connect(lambda : self.on_param_changed('angle', self.angleBox.value()))
+
+        angle_hlayout = QHBoxLayout()
+        angle_hlayout.addWidget(self.angleLabel)
+        angle_hlayout.addWidget(self.angleBox)
+        angle_hlayout.setSpacing(shared.WIDGET_SPACING_CLOSE)
         
         self.global_fontfmt_str = self.tr("Global Font Format")
         self.textstyle_panel = TextStylePresetPanel(
@@ -380,8 +402,7 @@ class FontFormatPanel(Widget):
         hl1 = QHBoxLayout()
         hl1.addWidget(self.familybox)
         hl1.addWidget(self.fontsizebox)
-        hl1.addWidget(self.lineSpacingLabel)
-        hl1.addWidget(self.lineSpacingBox)
+        hl1.addLayout(angle_hlayout)
         hl1.setSpacing(4)
         hl1.setContentsMargins(0, 12, 0, 0)
         hl2 = QHBoxLayout()
@@ -396,6 +417,7 @@ class FontFormatPanel(Widget):
         hl3.setAlignment(Qt.AlignmentFlag.AlignCenter)
         hl3.addLayout(stroke_hlayout)
         hl3.addLayout(lettersp_hlayout)
+        hl3.addLayout(linesp_hlayout)
         hl3.setContentsMargins(3, 0, 3, 0)
         hl3.setSpacing(13)
         hl4 = QHBoxLayout()
@@ -470,6 +492,9 @@ class FontFormatPanel(Widget):
             mul = 0.01
         self.lineSpacingBox.setValue(self.lineSpacingBox.value() + delta * mul)
 
+    def onAngleCtrlChanged(self, delta: int):
+        self.angleBox.setValue(round(self.angleBox.value()) + delta)
+
     def set_active_format(self, font_format: FontFormat, multi_size=False):
         C.active_format = font_format
         self.familybox.blockSignals(True)
@@ -487,6 +512,7 @@ class FontFormatPanel(Widget):
         self.strokeWidthBox.setValue(font_format.stroke_width)
         self.lineSpacingBox.setValue(font_format.line_spacing)
         self.letterSpacingBox.setValue(font_format.letter_spacing)
+        self.angleBox.setValue(0 if self.textblk_item is None else self.textblk_item.angle)
         self.verticalChecker.setChecked(font_format.vertical)
         self.formatBtnGroup.boldBtn.setChecked(font_format.bold)
         self.formatBtnGroup.underlineBtn.setChecked(font_format.underline)

--- a/ballontranslator/ui/textedit_commands.py
+++ b/ballontranslator/ui/textedit_commands.py
@@ -120,30 +120,35 @@ class ReshapeItemCommand(QUndoCommand):
 
 
 class RotateItemCommand(QUndoCommand):
-    def __init__(self, item: TextBlkItem, new_angle: float, shape_ctrl: TextBlkShapeControl):
+    def __init__(self, item: Union[TextBlkItem, List[TextBlkItem]], new_angle: float = None, shape_ctrl: TextBlkShapeControl = None):
         super(RotateItemCommand, self).__init__()
-        self.item = item
-        self.old_angle = item.rotation()
+        self.items = item if isinstance(item, list) else [item]
+        self.items = [item for item in self.items if item is not None]
+        self.item = self.items[0] if len(self.items) > 0 else None
+        self.old_angles = [item.rotation() for item in self.items]
+        if new_angle is None and self.item is not None:
+            new_angle = self.item.angle
         self.new_angle = new_angle
         self.shape_ctrl = shape_ctrl
 
     def redo(self):
-        self.item.setRotation(self.new_angle)
-        self.item.blk.angle = self.new_angle
-        if self.shape_ctrl.blk_item == self.item and self.shape_ctrl.rotation() != self.new_angle:
-            self.shape_ctrl.setRotation(self.new_angle)
+        for item in self.items:
+            item.setAngle(self.new_angle)
+            if self.shape_ctrl is not None and self.shape_ctrl.blk_item == item and self.shape_ctrl.rotation() != self.new_angle:
+                self.shape_ctrl.setRotation(self.new_angle)
 
     def undo(self):
-        self.item.setRotation(self.old_angle)
-        self.item.blk.angle = self.old_angle
-        if self.shape_ctrl.blk_item == self.item and self.shape_ctrl.rotation() != self.old_angle:
-            self.shape_ctrl.setRotation(self.old_angle)
+        for item, old_angle in zip(self.items, self.old_angles):
+            item.setAngle(old_angle)
+            if self.shape_ctrl is not None and self.shape_ctrl.blk_item == item and self.shape_ctrl.rotation() != old_angle:
+                self.shape_ctrl.setRotation(old_angle)
 
     def mergeWith(self, command: QUndoCommand):
-        item = command.item
-        if self.item != item:
+        if not isinstance(command, RotateItemCommand):
             return False
-        self.new_angle = item.angle
+        if self.items != command.items:
+            return False
+        self.new_angle = command.new_angle
         return True
 
 

--- a/resources/icons/rotation.svg
+++ b/resources/icons/rotation.svg
@@ -1,0 +1,7 @@
+<svg xmlns="http://www.w3.org/2000/svg" width="128" height="128" viewBox="0 0 24 24" fill="none">
+  <path d="M21 12A9 9 0 1 1 12 3C14.5 3 16.8 4 18.5 5.7L21 8M21 3V8H16"
+        stroke="#697187"
+        stroke-width="1.6"
+        stroke-linecap="round"
+        stroke-linejoin="round" />
+</svg>

--- a/resources/stylesheet.css
+++ b/resources/stylesheet.css
@@ -183,6 +183,14 @@ QLabel#letterSpacingLabel {
     min-height: 28px;
 }
 
+QLabel#fontAngleLabel {
+    image: url(resources/icons/rotation.svg);
+    max-width: 25px;
+    max-height: 25px;
+    min-width: 25px;
+    min-height: 25px;
+}
+
 ColorPickerLabel {
     max-height: 25px;
     min-height: 25px;


### PR DESCRIPTION
### 背景

目前文本框已经支持旋转角度，但在文本面板中没有直接编辑角度的入口。

实际使用过程中，OCR 有时会给文本附带少量不需要的旋转角度，而文本框的角度本身又比较难直接观察，因此需要通过拖动等方式反复调整，不够方便。

因此增加了角度编辑功能，方便直接查看和修改当前文本框角度。

### 改动内容

* 在文本面板中新增角度编辑控件（-180° ~ 180°）
* 支持常用角度快速选择（0 / 90 / 180 / -90）
* 支持拖动图标进行角度微调
* 复用现有 RotateItemCommand，并增加多选文本框支持
* 支持 Undo / Redo
* 调整文本面板布局：

  * 将行高移动到字宽旁边
  * 原行高位置改为角度编辑控件

### 效果

Before：

![修改前](https://raw.githubusercontent.com/banned2054/Picture_online/main/image-202606182126.png)

After：

![修改后](https://raw.githubusercontent.com/banned2054/Picture_online/main/image-202606182136.png)