### PR TITLE
fix(security): 2 improvements across 2 files

### DIFF
--- a/ballontranslator/modules/translators/trans_papago.py
+++ b/ballontranslator/modules/translators/trans_papago.py
@@ -28,9 +28,17 @@ class PapagoTranslator(BaseTranslator):
         
         if self.papagoVer is None:
             script = requests.get('https://papago.naver.com', proxies=PROXY)
-            mainJs = re.search(r'\/(main.*\.js)', script.text).group(1)
+            script.raise_for_status()
+            mainJs_match = re.search(r'\/(main.*\.js)', script.text)
+            if not mainJs_match:
+                raise ValueError('Could not find main JS file in Papago response')
+            mainJs = mainJs_match.group(1)
             papagoVerData = requests.get('https://papago.naver.com/' + mainJs, proxies=PROXY)
-            papagoVer = re.search(r'"PPG .*,"(v[^"]*)', papagoVerData.text).group(1)
+            papagoVerData.raise_for_status()
+            papagoVer_match = re.search(r'"PPG .*,"(v[^"]*)', papagoVerData.text)
+            if not papagoVer_match:
+                raise ValueError('Could not find Papago version in JS response')
+            papagoVer = papagoVer_match.group(1)
             self.papagoVer = PapagoTranslator.papagoVer = papagoVer
 
     def _translate(self, src_list: List[str]) -> List[str]:

--- a/scripts/update_translation.py
+++ b/scripts/update_translation.py
@@ -1,5 +1,6 @@
 import os
 import os.path as osp
+import subprocess
 from glob import glob
 
 from qtpy.QtCore import QLocale
@@ -10,10 +11,10 @@ if __name__ == '__main__':
     translate_dir = osp.join(program_dir, 'resources', 'translate')
     translate_path = osp.join(translate_dir, SYSLANG+'.ts')
 
-    cmd = 'pylupdate5 -verbose '+ \
-          ' '.join(glob(osp.join(program_dir, 'ballontranslator/ui/*.py'))) + \
-          ' -ts ' + translate_path
+    cmd = ['pylupdate5', '-verbose'] + \
+          glob(osp.join(program_dir, 'ballontranslator/ui/*.py')) + \
+          ['-ts', translate_path]
     
     print('target language: ', SYSLANG)
-    os.system(cmd)
+    subprocess.run(cmd)
     print(f'Saved to {translate_path}')


### PR DESCRIPTION
## Summary

fix(security): 2 improvements across 2 files

## Problem

**Severity**: `High` | **File**: `scripts/update_translation.py:L14`

The script `scripts/update_translation.py` constructs a shell command by concatenating user-controlled file paths via `glob()` and directly passes it to `os.system()`. If any file path contains shell metacharacters, arbitrary commands can be executed. The `SYSLANG` variable from `QLocale.system().name()` is also used without sanitization.

## Solution

Use `subprocess.run()` with a list of arguments instead of `os.system()`, or properly escape all paths using `shlex.quote()` before concatenating into the command string.

## Changes

- `scripts/update_translation.py` (modified)
- `ballontranslator/modules/translators/trans_papago.py` (modified)