### PR TITLE
fix: detect protobuf via google.protobuf import for manga_ocr

### DIFF
--- a/ballontranslator/utils/py_package_manager.py
+++ b/ballontranslator/utils/py_package_manager.py
@@ -26,6 +26,7 @@ DEFAULT_PACKAGE_IMPORT_NAMES = {
     'opencc-python-reimplemented': ['opencc'],
     'pillow': ['PIL'],
     'pillow-jxl-plugin': ['pillow_jxl'],
+    'protobuf': ['google.protobuf'],
     'pyqt5-qt5': [],
     'pyqt6-qt6': [],
     'pywin32': ['win32api'],


### PR DESCRIPTION
`manga_ocr` depends on `protobuf`, which is already mapped to `google.protobuf` in the dependency mapping table.

However, the current dependency check still reports `protobuf` as missing even when `google.protobuf` can be imported successfully.

This PR makes the dependency checker use the existing mapping consistently, fixing false positives such as #1224.