### PR TITLE
Quality: hex2bgr uses wrong bitmask (254 instead of 255), silently corrupting color data

### DIFF
--- a/ballontranslator/utils/imgproc_utils.py
+++ b/ballontranslator/utils/imgproc_utils.py
@@ -16,8 +16,8 @@ def smart_resize(src: np.ndarray, target_size, upscale_interpolation=cv2.INTER_L
 
 
 def hex2bgr(hex):
-    gmask = 254 << 8
-    rmask = 254
+    gmask = 255 << 8
+    rmask = 255
     b = hex >> 16
     g = (hex & gmask) >> 8
     r = hex & rmask


### PR DESCRIPTION
## Problem

The bitmask constants use 254 (0xFE) instead of 255 (0xFF). This silently
zeroes out the least significant bit of the red and green channels. For example,
hex color #FFFFFF (white) produces (254, 254, 255) instead of (255, 255, 255).
Every color passed through this function will be slightly wrong. Since this is
used for text/bubble color rendering in a translation app, all translated
text colors could be subtly off.


**Severity**: `high`
**File**: `ballontranslator/utils/imgproc_utils.py`

## Solution

The bitmask constants use 254 (0xFE) instead of 255 (0xFF). This silently
zeroes out the least significant bit of the red and green channels. For example,
hex color #FFFFFF (white) produces (254, 254, 255) instead of (255, 255, 255).
Every color passed through this function will be slightly wrong. Since this is
used for text/bubble color rendering in a translation app, all translated
text colors could be subtly off.


## Changes

- `ballontranslator/utils/imgproc_utils.py` (modified)

## Testing

- [ ] Existing tests pass
- [ ] Manual review completed
- [ ] No new warnings/errors introduced
