### PR TITLE
Add optional spellcheck

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -63,3 +63,7 @@ install_venv.bat
 install-BT.cmd
 download_models.bat
 Ultralytics/settings.json
+
+# Spellcheck dictionaries
+config/custom_dictionary.txt
+data/dictionaries/

--- a/ballontranslator/modules/package_import_names.py
+++ b/ballontranslator/modules/package_import_names.py
@@ -9,6 +9,7 @@ PACKAGE_IMPORT_NAMES = {
     'jaconv': ['jaconv'],
     'msl-loadlib': ['msl'],
     'openai': ['openai'],
+    'pyspellchecker': ['spellchecker'],
     'pyobjc-framework-vision': ['Vision', 'objc'],
     'pyyaml': ['yaml'],
     'safetensors': ['safetensors'],

--- a/ballontranslator/ui/configpanel.py
+++ b/ballontranslator/ui/configpanel.py
@@ -373,20 +373,21 @@ class WordListItemWidget(QWidget):
     def __init__(self, word, on_delete_callback, parent=None):
         super().__init__(parent)
         layout = QHBoxLayout(self)
-        layout.setContentsMargins(8, 2, 8, 2)
-        layout.setSpacing(8)
+        layout.setContentsMargins(12, 6, 12, 6)
+        layout.setSpacing(12)
 
         self.label = QLabel(word, self)
-        self.label.setStyleSheet("font-family: 'Segoe UI', Arial; font-size: 12px;")
+        self.label.setStyleSheet("font-family: 'Segoe UI', Arial; font-size: 13px; font-weight: 500;")
 
         self.delete_btn = QPushButton("🗑", self)
-        self.delete_btn.setFixedSize(24, 24)
+        self.delete_btn.setFixedSize(28, 28)
+        self.delete_btn.setToolTip(self.tr("Delete word"))
         self.delete_btn.setStyleSheet("""
             QPushButton {
                 background-color: transparent;
                 color: #ff4d4d;
                 border: none;
-                font-size: 14px;
+                font-size: 15px;
                 font-weight: bold;
                 padding: 0px;
                 min-width: 0px;
@@ -394,6 +395,8 @@ class WordListItemWidget(QWidget):
             }
             QPushButton:hover {
                 color: #ff1a1a;
+                background-color: rgba(255, 77, 77, 12%);
+                border-radius: 4px;
             }
         """)
         self.delete_btn.clicked.connect(lambda: on_delete_callback(word))
@@ -416,22 +419,25 @@ class AddWordItemWidget(QWidget):
     def __init__(self, on_add_callback, parent=None):
         super().__init__(parent)
         layout = QHBoxLayout(self)
-        layout.setContentsMargins(8, 2, 8, 2)
-        layout.setSpacing(8)
+        layout.setContentsMargins(12, 6, 12, 6)
+        layout.setSpacing(12)
 
         self.input_field = QLineEdit(self)
         self.input_field.setPlaceholderText(self.tr("Add new word..."))
+        self.input_field.setFixedHeight(30)
+        self.input_field.setStyleSheet("font-family: 'Segoe UI', Arial; font-size: 13px;")
         self.input_field.returnPressed.connect(self.trigger_add)
 
         self.add_btn = QPushButton("+", self)
-        self.add_btn.setFixedSize(24, 24)
+        self.add_btn.setFixedSize(30, 30)
+        self.add_btn.setToolTip(self.tr("Add word"))
         self.add_btn.setStyleSheet("""
             QPushButton {
                 padding: 0px;
                 min-width: 0px;
                 min-height: 0px;
                 font-weight: bold;
-                font-size: 14px;
+                font-size: 16px;
             }
         """)
         self.add_btn.clicked.connect(self.trigger_add)
@@ -452,7 +458,7 @@ class DictionaryManagerDialog(QDialog):
     def __init__(self, parent=None):
         super().__init__(parent)
         self.setWindowTitle(self.tr("Custom Dictionary Manager"))
-        self.resize(360, 480)
+        self.resize(450, 520)
 
         from ballontranslator.utils.spellcheck import SpellCheckManager
         self.manager = SpellCheckManager.get_instance()

--- a/ballontranslator/ui/configpanel.py
+++ b/ballontranslator/ui/configpanel.py
@@ -544,15 +544,23 @@ class DictionaryManagerDialog(QDialog):
         self.list_widget.setItemWidget(input_item, input_widget)
 
     def add_word(self, word):
-        if word and word not in self.manager.custom_words:
-            self.manager.add_to_dictionary(word)
+        word_lower = word.lower()
+        if word_lower and word_lower not in self.manager.custom_words:
+            self.manager.custom_words.add(word_lower)
             self.populate_list()
 
     def delete_word(self, word):
-        self.manager.custom_words.discard(word)
+        word_lower = word.lower()
+        self.manager.custom_words.discard(word_lower)
+        self.populate_list()
+
+    def done(self, r):
+        super().done(r)
         self.manager._save_custom_dictionary()
         self.manager.notify_config_changed()
-        self.populate_list()
+        for hl in list(self.manager.highlighters):
+            hl.clear_cache()
+            hl.rehighlight()
 
 
 class ConfigPanel(QDialog):

--- a/ballontranslator/ui/configpanel.py
+++ b/ballontranslator/ui/configpanel.py
@@ -16,7 +16,7 @@ from ballontranslator.utils.network_mirrors import (
 )
 from ballontranslator.utils.shared import CONFIG_FONTSIZE_CONTENT, CONFIG_FONTSIZE_TABLE, CONFIG_COMBOBOX_SHORT, CONFIG_COMBOBOX_LONG, CONFIG_COMBOBOX_MIDEAN
 from .module_parse_widgets import InpaintConfigPanel, TextDetectConfigPanel, TranslatorConfigPanel, OCRConfigPanel
-from ballontranslator.ui.spellcheck import dictionary_urls
+from ballontranslator.ui.spellcheck import DICTIONARY_URLS, SpellCheckManager, DictionaryManagerDialog, DictDownloadThread
 
 
 LAYOUT_SET_MINIMUM_SIZE = getattr(getattr(QLayout, 'SizeConstraint', QLayout), 'SetMinimumSize')
@@ -341,7 +341,7 @@ class ConfigPanel(QDialog):
     reload_textstyle = Signal(bool)
     show_only_custom_font = Signal(bool)
 
-    dictionary_urls = dictionary_urls
+    dictionary_urls = DICTIONARY_URLS
 
 
     def __init__(self, *args, **kwargs) -> None:
@@ -679,25 +679,21 @@ class ConfigPanel(QDialog):
         self.add_ext_btn.setEnabled(enabled)
         self.remove_ext_btn.setEnabled(enabled)
         self.spellcheck_distance_spin.setEnabled(enabled)
-        from ballontranslator.ui.spellcheck import SpellCheckManager
         SpellCheckManager.get_instance().notify_config_changed()
         self.save_config.emit()
 
     def on_spellcheck_on_source_changed(self):
         enabled = self.spellcheck_on_source_checker.isChecked()
         pcfg.spellcheck_on_source_enabled = enabled
-        from ballontranslator.ui.spellcheck import SpellCheckManager
         SpellCheckManager.get_instance().notify_config_changed()
         self.save_config.emit()
 
     def on_spellcheck_distance_changed(self):
         pcfg.spellcheck_distance = self.spellcheck_distance_spin.value()
-        from ballontranslator.ui.spellcheck import SpellCheckManager
         SpellCheckManager.get_instance().notify_config_changed()
         self.save_config.emit()
 
     def open_words_manager(self):
-        from ballontranslator.ui.spellcheck import DictionaryManagerDialog
         dialog = DictionaryManagerDialog(self)
         dialog.exec_()
 
@@ -737,7 +733,6 @@ class ConfigPanel(QDialog):
                     enabled_files.append(fname)
 
             pcfg.spellcheck_repo_dicts = ",".join(enabled_files)
-            from ballontranslator.ui.spellcheck import SpellCheckManager
             SpellCheckManager.get_instance().notify_config_changed()
             self.save_config.emit()
         finally:
@@ -755,7 +750,6 @@ class ConfigPanel(QDialog):
         progress = QProgressDialog(self.tr("Downloading dictionary..."), self.tr("Cancel"), 0, 100, self)
         progress.setWindowModality(Qt.WindowModality.WindowModal)
 
-        from ballontranslator.ui.spellcheck import DictDownloadThread
         thread = DictDownloadThread(url, save_path)
 
         def on_progress(downloaded, total):
@@ -820,7 +814,6 @@ class ConfigPanel(QDialog):
         for idx in range(self.external_dicts_list.count()):
             paths.append(self.external_dicts_list.item(idx).text())
         pcfg.spellcheck_external_dict_path = ";".join(paths)
-        from ballontranslator.ui.spellcheck import SpellCheckManager
         SpellCheckManager.get_instance().notify_config_changed()
         self.save_config.emit()
 

--- a/ballontranslator/ui/configpanel.py
+++ b/ballontranslator/ui/configpanel.py
@@ -373,11 +373,11 @@ class WordListItemWidget(QWidget):
     def __init__(self, word, on_delete_callback, parent=None):
         super().__init__(parent)
         layout = QHBoxLayout(self)
-        layout.setContentsMargins(8, 4, 8, 4)
+        layout.setContentsMargins(8, 2, 8, 2)
         layout.setSpacing(8)
 
         self.label = QLabel(word, self)
-        self.label.setStyleSheet("color: #ffffff; font-family: 'Segoe UI', Arial; font-size: 12px;")
+        self.label.setStyleSheet("font-family: 'Segoe UI', Arial; font-size: 12px;")
 
         self.delete_btn = QPushButton("🗑", self)
         self.delete_btn.setFixedSize(24, 24)
@@ -388,11 +388,12 @@ class WordListItemWidget(QWidget):
                 border: none;
                 font-size: 14px;
                 font-weight: bold;
+                padding: 0px;
+                min-width: 0px;
+                min-height: 0px;
             }
             QPushButton:hover {
-                background-color: #ff4d4d;
-                color: #ffffff;
-                border-radius: 3px;
+                color: #ff1a1a;
             }
         """)
         self.delete_btn.clicked.connect(lambda: on_delete_callback(word))
@@ -415,37 +416,22 @@ class AddWordItemWidget(QWidget):
     def __init__(self, on_add_callback, parent=None):
         super().__init__(parent)
         layout = QHBoxLayout(self)
-        layout.setContentsMargins(8, 4, 8, 4)
+        layout.setContentsMargins(8, 2, 8, 2)
         layout.setSpacing(8)
 
         self.input_field = QLineEdit(self)
         self.input_field.setPlaceholderText(self.tr("Add new word..."))
-        self.input_field.setStyleSheet("""
-            QLineEdit {
-                background-color: #2b2b2d;
-                color: #ffffff;
-                border: 1px solid #45474a;
-                border-radius: 3px;
-                padding: 2px 6px;
-                font-family: 'Segoe UI', Arial;
-                font-size: 12px;
-            }
-        """)
         self.input_field.returnPressed.connect(self.trigger_add)
 
         self.add_btn = QPushButton("+", self)
         self.add_btn.setFixedSize(24, 24)
         self.add_btn.setStyleSheet("""
             QPushButton {
-                background-color: #1e93e5;
-                color: #ffffff;
-                border: none;
-                border-radius: 3px;
+                padding: 0px;
+                min-width: 0px;
+                min-height: 0px;
                 font-weight: bold;
                 font-size: 14px;
-            }
-            QPushButton:hover {
-                background-color: #1a7abf;
             }
         """)
         self.add_btn.clicked.connect(self.trigger_add)
@@ -475,38 +461,10 @@ class DictionaryManagerDialog(QDialog):
         layout.setContentsMargins(10, 10, 10, 10)
 
         self.list_widget = QListWidget(self)
-        self.list_widget.setStyleSheet("""
-            QListWidget {
-                background-color: #1e1e1f;
-                border: 1px solid #45474a;
-                border-radius: 4px;
-            }
-            QListWidget::item {
-                background-color: transparent;
-                border-bottom: 1px solid #2b2b2d;
-            }
-            QListWidget::item:hover {
-                background-color: #2b2b2d;
-            }
-        """)
         layout.addWidget(self.list_widget)
 
         self.close_btn = QPushButton(self.tr("Close"), self)
         self.close_btn.setFixedHeight(32)
-        self.close_btn.setStyleSheet("""
-            QPushButton {
-                background-color: #3b3d40;
-                color: #ffffff;
-                border: 1px solid #45474a;
-                border-radius: 4px;
-                font-family: 'Segoe UI', Arial;
-                font-size: 12px;
-                font-weight: bold;
-            }
-            QPushButton:hover {
-                background-color: #1e93e5;
-            }
-        """)
         self.close_btn.clicked.connect(self.accept)
         layout.addWidget(self.close_btn)
 

--- a/ballontranslator/ui/configpanel.py
+++ b/ballontranslator/ui/configpanel.py
@@ -330,6 +330,127 @@ class ConfigTable(QTreeView):
                 self.section_pressed.emit(section_key)
 
 
+from qtpy.QtCore import QThread
+
+class DictDownloadThread(QThread):
+    progress = Signal(int, int)
+    finished = Signal(bool, str)
+
+    def __init__(self, url, save_path):
+        super().__init__()
+        self.url = url
+        self.save_path = save_path
+        import threading
+        self.cancel_event = threading.Event()
+
+    def run(self):
+        try:
+            import os
+            from ballontranslator.utils.download_util import download_url_to_file
+
+            def progress_callback(payload):
+                if payload.get('event') == 'file_progress':
+                    self.progress.emit(payload.get('downloaded', 0), payload.get('total', 0))
+
+            os.makedirs(os.path.dirname(self.save_path), exist_ok=True)
+            download_url_to_file(
+                self.url,
+                self.save_path,
+                progress_callback=progress_callback,
+                cancel_event=self.cancel_event
+            )
+            self.finished.emit(True, "")
+        except Exception as e:
+            self.finished.emit(False, str(e))
+
+    def cancel(self):
+        self.cancel_event.set()
+
+
+from qtpy.QtWidgets import QListWidget, QInputDialog, QHBoxLayout, QVBoxLayout, QPushButton, QLineEdit, QDialog
+
+class DictionaryManagerDialog(QDialog):
+    def __init__(self, parent=None):
+        super().__init__(parent)
+        self.setWindowTitle(self.tr("Custom Dictionary Manager"))
+        self.resize(360, 480)
+
+        from ballontranslator.utils.spellcheck import SpellCheckManager
+        self.manager = SpellCheckManager.get_instance()
+
+        layout = QVBoxLayout(self)
+
+        # Word list
+        self.list_widget = QListWidget(self)
+        self.list_widget.itemDoubleClicked.connect(self.edit_word)
+        layout.addWidget(self.list_widget)
+
+        # Input block
+        input_layout = QHBoxLayout()
+        self.word_input = QLineEdit(self)
+        self.word_input.setPlaceholderText(self.tr("Enter new word..."))
+        self.word_input.returnPressed.connect(self.add_word)
+        self.add_btn = QPushButton(self.tr("Add Word"), self)
+        self.add_btn.clicked.connect(self.add_word)
+
+        input_layout.addWidget(self.word_input)
+        input_layout.addWidget(self.add_btn)
+        layout.addLayout(input_layout)
+
+        # Action buttons
+        actions_layout = QHBoxLayout()
+        self.delete_btn = QPushButton(self.tr("Delete Selected"), self)
+        self.delete_btn.clicked.connect(self.delete_selected)
+        self.close_btn = QPushButton(self.tr("Close"), self)
+        self.close_btn.clicked.connect(self.accept)
+
+        actions_layout.addWidget(self.delete_btn)
+        actions_layout.addWidget(self.close_btn)
+        layout.addLayout(actions_layout)
+
+        self.populate_list()
+
+    def populate_list(self):
+        self.list_widget.clear()
+        for word in sorted(self.manager.custom_words):
+            self.list_widget.addItem(word)
+
+    def add_word(self):
+        word = self.word_input.text().strip().lower()
+        if word and word not in self.manager.custom_words:
+            self.manager.add_to_dictionary(word)
+            self.word_input.clear()
+            self.populate_list()
+
+    def delete_selected(self):
+        selected_items = self.list_widget.selectedItems()
+        if not selected_items:
+            return
+        for item in selected_items:
+            word = item.text()
+            self.manager.custom_words.discard(word)
+        self.manager._save_custom_dictionary()
+        self.manager.notify_config_changed()
+        self.populate_list()
+
+    def edit_word(self, item):
+        old_word = item.text()
+        new_word, ok = QInputDialog.getText(
+            self,
+            self.tr("Edit Word"),
+            self.tr("Edit word:"),
+            text=old_word
+        )
+        if ok:
+            new_word = new_word.strip().lower()
+            if new_word and new_word != old_word:
+                self.manager.custom_words.discard(old_word)
+                self.manager.custom_words.add(new_word)
+                self.manager._save_custom_dictionary()
+                self.manager.notify_config_changed()
+                self.populate_list()
+
+
 class ConfigPanel(QDialog):
 
     save_config = Signal()
@@ -338,6 +459,45 @@ class ConfigPanel(QDialog):
     check_update = Signal()
     reload_textstyle = Signal(bool)
     show_only_custom_font = Signal(bool)
+
+    dictionary_urls = {
+        "Arabic (ar)": "https://raw.githubusercontent.com/LibreOffice/dictionaries/master/ar/ar.dic",
+        "Belarusian (be_BY)": "https://raw.githubusercontent.com/LibreOffice/dictionaries/master/be_BY/be_BY.dic",
+        "Bulgarian (bg_BG)": "https://raw.githubusercontent.com/LibreOffice/dictionaries/master/bg_BG/bg_BG.dic",
+        "Bosnian (bs_BA)": "https://raw.githubusercontent.com/LibreOffice/dictionaries/master/bs_BA/bs_BA.dic",
+        "Catalan (ca)": "https://raw.githubusercontent.com/LibreOffice/dictionaries/master/ca/ca.dic",
+        "Czech (cs_CZ)": "https://raw.githubusercontent.com/LibreOffice/dictionaries/master/cs_CZ/cs_CZ.dic",
+        "Danish (da_DK)": "https://raw.githubusercontent.com/LibreOffice/dictionaries/master/da_DK/da_DK.dic",
+        "German (de_DE)": "https://raw.githubusercontent.com/LibreOffice/dictionaries/master/de/de_DE.dic",
+        "Greek (el_GR)": "https://raw.githubusercontent.com/LibreOffice/dictionaries/master/el_GR/el_GR.dic",
+        "English (en_US)": "https://raw.githubusercontent.com/LibreOffice/dictionaries/master/en/en_US.dic",
+        "English (en_GB)": "https://raw.githubusercontent.com/LibreOffice/dictionaries/master/en/en_GB.dic",
+        "Spanish (es_ES)": "https://raw.githubusercontent.com/LibreOffice/dictionaries/master/es/es_ES.dic",
+        "Estonian (et_EE)": "https://raw.githubusercontent.com/LibreOffice/dictionaries/master/et_EE/et_EE.dic",
+        "Persian (fa_IR)": "https://raw.githubusercontent.com/LibreOffice/dictionaries/master/fa_IR/fa_IR.dic",
+        "French (fr_FR)": "https://raw.githubusercontent.com/LibreOffice/dictionaries/master/fr_FR/fr_FR.dic",
+        "Croatian (hr_HR)": "https://raw.githubusercontent.com/LibreOffice/dictionaries/master/hr_HR/hr_HR.dic",
+        "Hungarian (hu_HU)": "https://raw.githubusercontent.com/LibreOffice/dictionaries/master/hu_HU/hu_HU.dic",
+        "Indonesian (id)": "https://raw.githubusercontent.com/LibreOffice/dictionaries/master/id/id.dic",
+        "Icelandic (is)": "https://raw.githubusercontent.com/LibreOffice/dictionaries/master/is/is.dic",
+        "Italian (it_IT)": "https://raw.githubusercontent.com/LibreOffice/dictionaries/master/it_IT/it_IT.dic",
+        "Korean (ko_KR)": "https://raw.githubusercontent.com/LibreOffice/dictionaries/master/ko_KR/ko_KR.dic",
+        "Lithuanian (lt_LT)": "https://raw.githubusercontent.com/LibreOffice/dictionaries/master/lt_LT/lt_LT.dic",
+        "Latvian (lv_LV)": "https://raw.githubusercontent.com/LibreOffice/dictionaries/master/lv_LV/lv_LV.dic",
+        "Dutch (nl_NL)": "https://raw.githubusercontent.com/LibreOffice/dictionaries/master/nl_NL/nl_NL.dic",
+        "Polish (pl_PL)": "https://raw.githubusercontent.com/LibreOffice/dictionaries/master/pl_PL/pl_PL.dic",
+        "Portuguese (pt_BR)": "https://raw.githubusercontent.com/LibreOffice/dictionaries/master/pt_BR/pt_BR.dic",
+        "Portuguese (pt_PT)": "https://raw.githubusercontent.com/LibreOffice/dictionaries/master/pt_PT/pt_PT.dic",
+        "Romanian (ro_RO)": "https://raw.githubusercontent.com/LibreOffice/dictionaries/master/ro/ro_RO.dic",
+        "Russian (ru_RU)": "https://raw.githubusercontent.com/LibreOffice/dictionaries/master/ru_RU/ru_RU.dic",
+        "Russian (Large - all inflections) (ru_RU)": "https://raw.githubusercontent.com/danakt/russian-words/master/russian.txt",
+        "Slovak (sk_SK)": "https://raw.githubusercontent.com/LibreOffice/dictionaries/master/sk_SK/sk_SK.dic",
+        "Slovenian (sl_SI)": "https://raw.githubusercontent.com/LibreOffice/dictionaries/master/sl_SI/sl_SI.dic",
+        "Swedish (sv_SE)": "https://raw.githubusercontent.com/LibreOffice/dictionaries/master/sv_SE/sv_SE.dic",
+        "Turkish (tr_TR)": "https://raw.githubusercontent.com/LibreOffice/dictionaries/master/tr_TR/tr_TR.dic",
+        "Ukrainian (uk_UA)": "https://raw.githubusercontent.com/LibreOffice/dictionaries/master/uk_UA/uk_UA.dic",
+        "Vietnamese (vi)": "https://raw.githubusercontent.com/LibreOffice/dictionaries/master/vi/vi.dic"
+    }
 
     def __init__(self, *args, **kwargs) -> None:
         super().__init__(*args, **kwargs)
@@ -361,6 +521,7 @@ class ConfigPanel(QDialog):
         label_translator = self.tr('Translator')
         label_application = self.tr('Application')
         label_typesetting = self.tr('Typesetting')
+        label_spellcheck = self.tr('Spell Checker')
 
         moduleConfigPanel = self.addConfigBlock(label_modules, moduleTableItem, 'modules')
         dlConfigPanel = self.addConfigBlock(label_text_det, moduleTableItem, 'detector')
@@ -369,6 +530,7 @@ class ConfigPanel(QDialog):
         translatorConfigPanel = self.addConfigBlock(label_translator, moduleTableItem, 'translator')
         applicationConfigPanel = self.addConfigBlock(label_application, generalTableItem, 'application')
         typesettingConfigPanel = self.addConfigBlock(label_typesetting, generalTableItem, 'typesetting')
+        spellcheckConfigPanel = self.addConfigBlock(label_spellcheck, generalTableItem, 'spellcheck')
         
         self.empty_runcache_checker, empty_runcache_subblock = checkbox_with_label(self.tr('Empty cache after RUN'), discription=self.tr('Empty cache after RUN to save memory.'))
         moduleConfigPanel.vlayout.addWidget(empty_runcache_subblock)
@@ -418,6 +580,51 @@ class ConfigPanel(QDialog):
 
         self.check_update_on_startup_checker, _ = applicationConfigPanel.addCheckBox(self.tr('Check update on startup'))
         self.check_update_on_startup_checker.stateChanged.connect(self.on_check_update_onstartup_changed)
+
+        self.spellcheck_checker, _ = spellcheckConfigPanel.addCheckBox(self.tr('Enable Spell Checker'))
+        self.spellcheck_checker.stateChanged.connect(self.on_spellcheck_changed)
+
+        # Dictionary Words Manager Button
+        self.manage_words_btn = QPushButton(parent=self)
+        self.manage_words_btn.setText(self.tr("Dictionary Words..."))
+        self.manage_words_btn.clicked.connect(self.open_words_manager)
+        self.manage_words_btn.setFixedHeight(PUSHBTN_FIXED_HEIGHT)
+        spellcheckConfigPanel.addBlockWidget(self.manage_words_btn)
+
+        # Repository Dictionaries List
+        repo_layout = QVBoxLayout()
+        repo_label = ConfigTextLabel(self.tr("Repository Dictionaries"), CONFIG_FONTSIZE_CONTENT, QFont.Weight.Bold)
+        repo_layout.addWidget(repo_label)
+
+        self.repo_dicts_list = QListWidget(self)
+        self.repo_dicts_list.setFixedHeight(150)
+        self.repo_dicts_list.itemChanged.connect(self.on_repo_dict_item_changed)
+        repo_layout.addWidget(self.repo_dicts_list)
+
+        spellcheckConfigPanel.addBlockWidget(repo_layout)
+
+        # External Dictionaries List
+        ext_layout = QVBoxLayout()
+        ext_label = ConfigTextLabel(self.tr("External Dictionaries"), CONFIG_FONTSIZE_CONTENT, QFont.Weight.Bold)
+        ext_layout.addWidget(ext_label)
+
+        self.external_dicts_list = QListWidget(self)
+        self.external_dicts_list.setFixedHeight(120)
+        ext_layout.addWidget(self.external_dicts_list)
+
+        ext_btns_layout = QHBoxLayout()
+        self.add_ext_btn = QPushButton(self.tr("Add Dictionary..."), self)
+        self.add_ext_btn.clicked.connect(self.add_external_dictionary)
+        self.add_ext_btn.setFixedHeight(PUSHBTN_FIXED_HEIGHT)
+        self.remove_ext_btn = QPushButton(self.tr("Remove Selected"), self)
+        self.remove_ext_btn.clicked.connect(self.remove_external_dictionary)
+        self.remove_ext_btn.setFixedHeight(PUSHBTN_FIXED_HEIGHT)
+
+        ext_btns_layout.addWidget(self.add_ext_btn)
+        ext_btns_layout.addWidget(self.remove_ext_btn)
+        ext_layout.addLayout(ext_btns_layout)
+
+        self.spellcheck_subblock = spellcheckConfigPanel.addBlockWidget(ext_layout)
 
         update_status_widget = QWidget()
         update_status_layout = QHBoxLayout(update_status_widget)
@@ -584,6 +791,129 @@ class ConfigPanel(QDialog):
     def on_check_update_onstartup_changed(self):
         pcfg.check_update_on_startup = self.check_update_on_startup_checker.isChecked()
 
+    def on_spellcheck_changed(self):
+        enabled = self.spellcheck_checker.isChecked()
+        pcfg.spellcheck_enabled = enabled
+        self.manage_words_btn.setEnabled(enabled)
+        self.repo_dicts_list.setEnabled(enabled)
+        self.external_dicts_list.setEnabled(enabled)
+        self.add_ext_btn.setEnabled(enabled)
+        self.remove_ext_btn.setEnabled(enabled)
+        from ballontranslator.utils.spellcheck import SpellCheckManager
+        SpellCheckManager.get_instance().notify_config_changed()
+        self.save_config.emit()
+
+    def open_words_manager(self):
+        dialog = DictionaryManagerDialog(self)
+        dialog.exec_()
+
+    def on_repo_dict_item_changed(self, item):
+        self.repo_dicts_list.blockSignals(True)
+        try:
+            from qtpy.QtCore import Qt
+            import os
+            from ballontranslator.utils.shared import PROGRAM_PATH
+
+            url, filename = item.data(Qt.ItemDataRole.UserRole)
+            save_path = os.path.join(PROGRAM_PATH, 'data', 'dictionaries', filename)
+
+            if item.checkState() == Qt.CheckState.Checked:
+                if not os.path.exists(save_path):
+                    success = self.download_repo_dict_sync(url, filename)
+                    if not success:
+                        item.setCheckState(Qt.CheckState.Unchecked)
+                    else:
+                        lang_name = ""
+                        for k, v in self.dictionary_urls.items():
+                            if v == url:
+                                lang_name = k
+                                break
+                        if lang_name:
+                            item.setText(self.tr(lang_name) + self.tr(" (Installed local)"))
+
+            enabled_files = []
+            for idx in range(self.repo_dicts_list.count()):
+                it = self.repo_dicts_list.item(idx)
+                if it.checkState() == Qt.CheckState.Checked:
+                    _, fname = it.data(Qt.ItemDataRole.UserRole)
+                    enabled_files.append(fname)
+
+            pcfg.spellcheck_repo_dicts = ",".join(enabled_files)
+            from ballontranslator.utils.spellcheck import SpellCheckManager
+            SpellCheckManager.get_instance().notify_config_changed()
+            self.save_config.emit()
+        finally:
+            self.repo_dicts_list.blockSignals(False)
+
+    def download_repo_dict_sync(self, url, filename):
+        import os
+        from ballontranslator.utils.shared import PROGRAM_PATH
+        from qtpy.QtWidgets import QProgressDialog
+        from qtpy.QtCore import Qt
+
+        save_path = os.path.join(PROGRAM_PATH, 'data', 'dictionaries', filename)
+
+        progress = QProgressDialog(self.tr("Downloading dictionary..."), self.tr("Cancel"), 0, 100, self)
+        progress.setWindowModality(Qt.WindowModality.WindowModal)
+
+        thread = DictDownloadThread(url, save_path)
+        download_success = [False]
+
+        def on_progress(downloaded, total):
+            if total > 0:
+                percent = int(downloaded * 100 / total)
+                progress.setValue(percent)
+
+        def on_finished(success, err):
+            progress.close()
+            if success:
+                download_success[0] = True
+                from qtpy.QtWidgets import QMessageBox
+                QMessageBox.information(self, self.tr("Download Complete"), self.tr("Dictionary downloaded successfully!"))
+            else:
+                if "cancelled" not in err.lower():
+                    from qtpy.QtWidgets import QMessageBox
+                    QMessageBox.warning(self, self.tr("Download Failed"), self.tr("Failed to download dictionary: ") + err)
+
+        thread.progress.connect(on_progress)
+        thread.finished.connect(on_finished)
+        progress.canceled.connect(thread.cancel)
+
+        self.active_download_thread = thread
+        thread.start()
+        progress.exec_()
+        thread.wait()
+        return download_success[0]
+
+    def add_external_dictionary(self):
+        from qtpy.QtWidgets import QFileDialog
+        path, _ = QFileDialog.getOpenFileName(
+            self,
+            self.tr("Select Dictionary File"),
+            "",
+            self.tr("Dictionary files (*.txt *.dic)")
+        )
+        if path:
+            self.external_dicts_list.addItem(path)
+            self.update_external_dicts_config()
+
+    def remove_external_dictionary(self):
+        selected_items = self.external_dicts_list.selectedItems()
+        if not selected_items:
+            return
+        for item in selected_items:
+            self.external_dicts_list.takeItem(self.external_dicts_list.row(item))
+        self.update_external_dicts_config()
+
+    def update_external_dicts_config(self):
+        paths = []
+        for idx in range(self.external_dicts_list.count()):
+            paths.append(self.external_dicts_list.item(idx).text())
+        pcfg.spellcheck_external_dict_path = ";".join(paths)
+        from ballontranslator.utils.spellcheck import SpellCheckManager
+        SpellCheckManager.get_instance().notify_config_changed()
+        self.save_config.emit()
+
     def setLatestVersion(self, version: str):
         self.latest_version_label.setText(self.tr('Latest version: ') + version)
 
@@ -728,10 +1058,54 @@ class ConfigPanel(QDialog):
 
     def setupConfig(self):
         self.blockSignals(True)
+        import os
+        from ballontranslator.utils import shared
 
         if pcfg.open_recent_on_startup:
             self.open_on_startup_checker.setChecked(True)
         self.check_update_on_startup_checker.setChecked(pcfg.check_update_on_startup)
+        
+        # Setup repository dictionaries
+        active_repos = pcfg.spellcheck_repo_dicts.split(',')
+        active_repos = [x.strip() for x in active_repos if x.strip()]
+        
+        self.repo_dicts_list.blockSignals(True)
+        self.repo_dicts_list.clear()
+        from qtpy.QtWidgets import QListWidgetItem
+        from qtpy.QtCore import Qt
+        
+        for lang_name, url in self.dictionary_urls.items():
+            filename = url.split('/')[-1]
+            dict_path = os.path.join(shared.PROGRAM_PATH, 'data', 'dictionaries', filename)
+
+            display_text = self.tr(lang_name)
+            if os.path.exists(dict_path):
+                display_text += self.tr(" (Installed local)")
+
+            item = QListWidgetItem(display_text, self.repo_dicts_list)
+            item.setData(Qt.ItemDataRole.UserRole, (url, filename))
+            item.setFlags(item.flags() | Qt.ItemFlag.ItemIsUserCheckable)
+
+            if filename in active_repos:
+                item.setCheckState(Qt.CheckState.Checked)
+            else:
+                item.setCheckState(Qt.CheckState.Unchecked)
+        self.repo_dicts_list.blockSignals(False)
+
+        # Setup external dictionaries
+        self.external_dicts_list.clear()
+        ext_paths = pcfg.spellcheck_external_dict_path.split(';')
+        for p in ext_paths:
+            p = p.strip()
+            if p:
+                self.external_dicts_list.addItem(p)
+
+        self.spellcheck_checker.setChecked(pcfg.spellcheck_enabled)
+        self.manage_words_btn.setEnabled(pcfg.spellcheck_enabled)
+        self.repo_dicts_list.setEnabled(pcfg.spellcheck_enabled)
+        self.external_dicts_list.setEnabled(pcfg.spellcheck_enabled)
+        self.add_ext_btn.setEnabled(pcfg.spellcheck_enabled)
+        self.remove_ext_btn.setEnabled(pcfg.spellcheck_enabled)
         self.huggingface_mirror_combobox.setCurrentText(mirror_to_display(
             pcfg.mirrors.huggingface,
             none_label=self.tr('None'),

--- a/ballontranslator/ui/configpanel.py
+++ b/ballontranslator/ui/configpanel.py
@@ -426,10 +426,10 @@ class ConfigPanel(QDialog):
         self.check_update_on_startup_checker, _ = applicationConfigPanel.addCheckBox(self.tr('Check update on startup'))
         self.check_update_on_startup_checker.stateChanged.connect(self.on_check_update_onstartup_changed)
 
-        self.spellcheck_checker, _ = spellcheckConfigPanel.addCheckBox(self.tr('Enable Spell Checker'))
+        self.spellcheck_checker, _ = spellcheckConfigPanel.addCheckBox(self.tr('Enable'))
         self.spellcheck_checker.stateChanged.connect(self.on_spellcheck_changed)
 
-        self.spellcheck_on_source_checker, _ = spellcheckConfigPanel.addCheckBox(self.tr('Enable Spell Checker on Source Blocks'))
+        self.spellcheck_on_source_checker, _ = spellcheckConfigPanel.addCheckBox(self.tr('Apply for source text'))
         self.spellcheck_on_source_checker.stateChanged.connect(self.on_spellcheck_on_source_changed)
 
         # Edit Distance Spinbox
@@ -765,8 +765,8 @@ class ConfigPanel(QDialog):
                 try:
                     item.setCheckState(Qt.CheckState.Checked)
                     # Remove " (Installed local)" if it exists, then append it
-                    clean_text = item.text().replace(self.tr(" (Installed local)"), "")
-                    item.setText(clean_text + self.tr(" (Installed local)"))
+                    clean_text = item.text().replace(self.tr(" - Installed"), "")
+                    item.setText(clean_text + self.tr(" - Installed"))
                 finally:
                     self.repo_dicts_list.blockSignals(False)
                 
@@ -984,7 +984,7 @@ class ConfigPanel(QDialog):
             display_text = self.tr(lang_name)
             exists = os.path.exists(dict_path)
             if exists:
-                display_text += self.tr(" (Installed local)")
+                display_text += self.tr(" - Installed")
 
             item = QListWidgetItem(display_text, self.repo_dicts_list)
             item.setData(Qt.ItemDataRole.UserRole, (url, filename))

--- a/ballontranslator/ui/configpanel.py
+++ b/ballontranslator/ui/configpanel.py
@@ -574,27 +574,27 @@ class ConfigPanel(QDialog):
 
     dictionary_urls = {
         "Arabic (ar)": "https://raw.githubusercontent.com/LibreOffice/dictionaries/master/ar/ar.dic",
-        "Belarusian (be_BY)": "https://raw.githubusercontent.com/LibreOffice/dictionaries/master/be_BY/be_BY.dic",
+        "Belarusian (be_BY)": "https://raw.githubusercontent.com/LibreOffice/dictionaries/master/be_BY/be-official.dic",
         "Bulgarian (bg_BG)": "https://raw.githubusercontent.com/LibreOffice/dictionaries/master/bg_BG/bg_BG.dic",
         "Bosnian (bs_BA)": "https://raw.githubusercontent.com/LibreOffice/dictionaries/master/bs_BA/bs_BA.dic",
-        "Catalan (ca)": "https://raw.githubusercontent.com/LibreOffice/dictionaries/master/ca/ca.dic",
+        "Catalan (ca)": "https://raw.githubusercontent.com/LibreOffice/dictionaries/master/ca/dictionaries/ca.dic",
         "Czech (cs_CZ)": "https://raw.githubusercontent.com/LibreOffice/dictionaries/master/cs_CZ/cs_CZ.dic",
         "Danish (da_DK)": "https://raw.githubusercontent.com/LibreOffice/dictionaries/master/da_DK/da_DK.dic",
-        "German (de_DE)": "https://raw.githubusercontent.com/LibreOffice/dictionaries/master/de/de_DE.dic",
+        "German (de_DE)": "https://raw.githubusercontent.com/LibreOffice/dictionaries/master/de/de_DE_frami.dic",
         "Greek (el_GR)": "https://raw.githubusercontent.com/LibreOffice/dictionaries/master/el_GR/el_GR.dic",
         "English (en_US)": "https://raw.githubusercontent.com/LibreOffice/dictionaries/master/en/en_US.dic",
         "English (en_GB)": "https://raw.githubusercontent.com/LibreOffice/dictionaries/master/en/en_GB.dic",
         "Spanish (es_ES)": "https://raw.githubusercontent.com/LibreOffice/dictionaries/master/es/es_ES.dic",
         "Estonian (et_EE)": "https://raw.githubusercontent.com/LibreOffice/dictionaries/master/et_EE/et_EE.dic",
-        "Persian (fa_IR)": "https://raw.githubusercontent.com/LibreOffice/dictionaries/master/fa_IR/fa_IR.dic",
-        "French (fr_FR)": "https://raw.githubusercontent.com/LibreOffice/dictionaries/master/fr_FR/fr_FR.dic",
+        "Persian (fa_IR)": "https://raw.githubusercontent.com/LibreOffice/dictionaries/master/fa_IR/fa-IR.dic",
+        "French (fr_FR)": "https://raw.githubusercontent.com/LibreOffice/dictionaries/master/fr_FR/fr.dic",
         "Croatian (hr_HR)": "https://raw.githubusercontent.com/LibreOffice/dictionaries/master/hr_HR/hr_HR.dic",
         "Hungarian (hu_HU)": "https://raw.githubusercontent.com/LibreOffice/dictionaries/master/hu_HU/hu_HU.dic",
-        "Indonesian (id)": "https://raw.githubusercontent.com/LibreOffice/dictionaries/master/id/id.dic",
+        "Indonesian (id)": "https://raw.githubusercontent.com/LibreOffice/dictionaries/master/id/id_ID.dic",
         "Icelandic (is)": "https://raw.githubusercontent.com/LibreOffice/dictionaries/master/is/is.dic",
         "Italian (it_IT)": "https://raw.githubusercontent.com/LibreOffice/dictionaries/master/it_IT/it_IT.dic",
         "Korean (ko_KR)": "https://raw.githubusercontent.com/LibreOffice/dictionaries/master/ko_KR/ko_KR.dic",
-        "Lithuanian (lt_LT)": "https://raw.githubusercontent.com/LibreOffice/dictionaries/master/lt_LT/lt_LT.dic",
+        "Lithuanian (lt_LT)": "https://raw.githubusercontent.com/LibreOffice/dictionaries/master/lt_LT/lt.dic",
         "Latvian (lv_LV)": "https://raw.githubusercontent.com/LibreOffice/dictionaries/master/lv_LV/lv_LV.dic",
         "Dutch (nl_NL)": "https://raw.githubusercontent.com/LibreOffice/dictionaries/master/nl_NL/nl_NL.dic",
         "Polish (pl_PL)": "https://raw.githubusercontent.com/LibreOffice/dictionaries/master/pl_PL/pl_PL.dic",
@@ -605,10 +605,10 @@ class ConfigPanel(QDialog):
         "Russian (Large - all inflections) (ru_RU)": "https://raw.githubusercontent.com/danakt/russian-words/master/russian.txt",
         "Slovak (sk_SK)": "https://raw.githubusercontent.com/LibreOffice/dictionaries/master/sk_SK/sk_SK.dic",
         "Slovenian (sl_SI)": "https://raw.githubusercontent.com/LibreOffice/dictionaries/master/sl_SI/sl_SI.dic",
-        "Swedish (sv_SE)": "https://raw.githubusercontent.com/LibreOffice/dictionaries/master/sv_SE/sv_SE.dic",
+        "Swedish (sv_SE)": "https://raw.githubusercontent.com/LibreOffice/dictionaries/master/sv_SE/dictionaries/sv_SE.dic",
         "Turkish (tr_TR)": "https://raw.githubusercontent.com/LibreOffice/dictionaries/master/tr_TR/tr_TR.dic",
         "Ukrainian (uk_UA)": "https://raw.githubusercontent.com/LibreOffice/dictionaries/master/uk_UA/uk_UA.dic",
-        "Vietnamese (vi)": "https://raw.githubusercontent.com/LibreOffice/dictionaries/master/vi/vi.dic"
+        "Vietnamese (vi)": "https://raw.githubusercontent.com/LibreOffice/dictionaries/master/vi/vi_VN.dic"
     }
 
     def __init__(self, *args, **kwargs) -> None:
@@ -695,6 +695,9 @@ class ConfigPanel(QDialog):
 
         self.spellcheck_checker, _ = spellcheckConfigPanel.addCheckBox(self.tr('Enable Spell Checker'))
         self.spellcheck_checker.stateChanged.connect(self.on_spellcheck_changed)
+
+        self.spellcheck_skip_cjk_checker, _ = spellcheckConfigPanel.addCheckBox(self.tr('Skip CJK (Chinese, Japanese, Korean)'))
+        self.spellcheck_skip_cjk_checker.stateChanged.connect(self.on_spellcheck_skip_cjk_changed)
 
         # Edit Distance Spinbox
         from qtpy.QtWidgets import QSpinBox
@@ -942,6 +945,13 @@ class ConfigPanel(QDialog):
         self.add_ext_btn.setEnabled(enabled)
         self.remove_ext_btn.setEnabled(enabled)
         self.spellcheck_distance_spin.setEnabled(enabled)
+        self.spellcheck_skip_cjk_checker.setEnabled(enabled)
+        from ballontranslator.utils.spellcheck import SpellCheckManager
+        SpellCheckManager.get_instance().notify_config_changed()
+        self.save_config.emit()
+
+    def on_spellcheck_skip_cjk_changed(self):
+        pcfg.spellcheck_skip_cjk = self.spellcheck_skip_cjk_checker.isChecked()
         from ballontranslator.utils.spellcheck import SpellCheckManager
         SpellCheckManager.get_instance().notify_config_changed()
         self.save_config.emit()
@@ -957,30 +967,33 @@ class ConfigPanel(QDialog):
         dialog.exec_()
 
     def on_repo_dict_item_changed(self, item):
+        from qtpy.QtCore import Qt
+        import os
+        from ballontranslator.utils.shared import PROGRAM_PATH
+        from ballontranslator.utils.logger import logger as LOGGER
+
+        url, filename = item.data(Qt.ItemDataRole.UserRole)
+        save_path = os.path.join(PROGRAM_PATH, 'data', 'dictionaries', filename)
+
+        LOGGER.info(f"on_repo_dict_item_changed: item={item.text()}, checkState={item.checkState()}")
+
+        if item.checkState() == Qt.CheckState.Checked:
+            if not os.path.exists(save_path):
+                # Uncheck immediately so it doesn't look enabled while downloading
+                self.repo_dicts_list.blockSignals(True)
+                item.setCheckState(Qt.CheckState.Unchecked)
+                self.repo_dicts_list.blockSignals(False)
+                
+                # Start async download
+                self.download_repo_dict_async(item, url, filename)
+                return
+
+        self.save_repo_dicts_config()
+
+    def save_repo_dicts_config(self):
         self.repo_dicts_list.blockSignals(True)
         try:
             from qtpy.QtCore import Qt
-            import os
-            from ballontranslator.utils.shared import PROGRAM_PATH
-
-            url, filename = item.data(Qt.ItemDataRole.UserRole)
-            save_path = os.path.join(PROGRAM_PATH, 'data', 'dictionaries', filename)
-
-            if item.checkState() == Qt.CheckState.Checked:
-                if not os.path.exists(save_path):
-                    success = self.download_repo_dict_sync(url, filename)
-                    if not success:
-                        item.setCheckState(Qt.CheckState.Unchecked)
-                    else:
-                        item.setCheckState(Qt.CheckState.Checked)
-                        lang_name = ""
-                        for k, v in self.dictionary_urls.items():
-                            if v == url:
-                                lang_name = k
-                                break
-                        if lang_name:
-                            item.setText(self.tr(lang_name) + self.tr(" (Installed local)"))
-
             enabled_files = []
             for idx in range(self.repo_dicts_list.count()):
                 it = self.repo_dicts_list.item(idx)
@@ -995,11 +1008,12 @@ class ConfigPanel(QDialog):
         finally:
             self.repo_dicts_list.blockSignals(False)
 
-    def download_repo_dict_sync(self, url, filename):
+    def download_repo_dict_async(self, item, url, filename):
         import os
         from ballontranslator.utils.shared import PROGRAM_PATH
         from qtpy.QtWidgets import QProgressDialog
         from qtpy.QtCore import Qt
+        from ballontranslator.utils.logger import logger as LOGGER
 
         save_path = os.path.join(PROGRAM_PATH, 'data', 'dictionaries', filename)
 
@@ -1007,7 +1021,6 @@ class ConfigPanel(QDialog):
         progress.setWindowModality(Qt.WindowModality.WindowModal)
 
         thread = DictDownloadThread(url, save_path)
-        download_success = [False]
 
         def on_progress(downloaded, total):
             if total > 0:
@@ -1017,10 +1030,22 @@ class ConfigPanel(QDialog):
         def on_finished(success, err):
             progress.close()
             if success:
-                download_success[0] = True
+                LOGGER.info(f"download_repo_dict_async: successful download of {filename}")
+                self.repo_dicts_list.blockSignals(True)
+                try:
+                    item.setCheckState(Qt.CheckState.Checked)
+                    # Remove " (Installed local)" if it exists, then append it
+                    clean_text = item.text().replace(self.tr(" (Installed local)"), "")
+                    item.setText(clean_text + self.tr(" (Installed local)"))
+                finally:
+                    self.repo_dicts_list.blockSignals(False)
+                
+                self.save_repo_dicts_config()
+                
                 from qtpy.QtWidgets import QMessageBox
                 QMessageBox.information(self, self.tr("Download Complete"), self.tr("Dictionary downloaded successfully!"))
             else:
+                LOGGER.warning(f"download_repo_dict_async: download failed for {filename}: {err}")
                 if "cancelled" not in err.lower():
                     from qtpy.QtWidgets import QMessageBox
                     QMessageBox.warning(self, self.tr("Download Failed"), self.tr("Failed to download dictionary: ") + err)
@@ -1033,7 +1058,6 @@ class ConfigPanel(QDialog):
         thread.start()
         progress.exec_()
         thread.wait()
-        return download_success[0]
 
     def add_external_dictionary(self):
         from qtpy.QtWidgets import QFileDialog
@@ -1229,18 +1253,28 @@ class ConfigPanel(QDialog):
             dict_path = os.path.join(shared.PROGRAM_PATH, 'data', 'dictionaries', filename)
 
             display_text = self.tr(lang_name)
-            if os.path.exists(dict_path):
+            exists = os.path.exists(dict_path)
+            if exists:
                 display_text += self.tr(" (Installed local)")
 
             item = QListWidgetItem(display_text, self.repo_dicts_list)
             item.setData(Qt.ItemDataRole.UserRole, (url, filename))
             item.setFlags(item.flags() | Qt.ItemFlag.ItemIsUserCheckable)
 
-            if filename in active_repos:
+            if filename in active_repos and exists:
                 item.setCheckState(Qt.CheckState.Checked)
             else:
                 item.setCheckState(Qt.CheckState.Unchecked)
         self.repo_dicts_list.blockSignals(False)
+
+        # Synchronize config to remove any manually deleted dictionaries
+        enabled_files = []
+        for idx in range(self.repo_dicts_list.count()):
+            it = self.repo_dicts_list.item(idx)
+            if it.checkState() == Qt.CheckState.Checked:
+                _, fname = it.data(Qt.ItemDataRole.UserRole)
+                enabled_files.append(fname)
+        pcfg.spellcheck_repo_dicts = ",".join(enabled_files)
 
         # Setup external dictionaries
         self.external_dicts_list.clear()
@@ -1253,6 +1287,8 @@ class ConfigPanel(QDialog):
         self.spellcheck_checker.setChecked(pcfg.spellcheck_enabled)
         self.spellcheck_distance_spin.setValue(getattr(pcfg, 'spellcheck_distance', 1))
         self.spellcheck_distance_spin.setEnabled(pcfg.spellcheck_enabled)
+        self.spellcheck_skip_cjk_checker.setChecked(getattr(pcfg, 'spellcheck_skip_cjk', True))
+        self.spellcheck_skip_cjk_checker.setEnabled(pcfg.spellcheck_enabled)
         self.manage_words_btn.setEnabled(pcfg.spellcheck_enabled)
         self.repo_dicts_list.setEnabled(pcfg.spellcheck_enabled)
         self.external_dicts_list.setEnabled(pcfg.spellcheck_enabled)

--- a/ballontranslator/ui/configpanel.py
+++ b/ballontranslator/ui/configpanel.py
@@ -704,7 +704,19 @@ class ConfigPanel(QDialog):
         dist_layout.addWidget(dist_label)
         dist_layout.addWidget(self.spellcheck_distance_spin)
         dist_layout.insertStretch(-1)
-        spellcheckConfigPanel.addBlockWidget(dist_layout)
+
+        dist_block = QVBoxLayout()
+        dist_block.setContentsMargins(0, 0, 0, 0)
+        dist_block.setSpacing(4)
+        dist_block.addLayout(dist_layout)
+
+        desc_label = ConfigTextLabel(
+            self.tr("Max spelling difference in letters. Higher values search deeper but perform slower."),
+            CONFIG_FONTSIZE_CONTENT - 2,
+            QFont.Weight.Normal
+        )
+        dist_block.addWidget(desc_label)
+        spellcheckConfigPanel.addBlockWidget(dist_block)
 
         # Dictionary Words Manager Button
         self.manage_words_btn = QPushButton(parent=self)

--- a/ballontranslator/ui/configpanel.py
+++ b/ballontranslator/ui/configpanel.py
@@ -696,9 +696,6 @@ class ConfigPanel(QDialog):
         self.spellcheck_checker, _ = spellcheckConfigPanel.addCheckBox(self.tr('Enable Spell Checker'))
         self.spellcheck_checker.stateChanged.connect(self.on_spellcheck_changed)
 
-        self.spellcheck_skip_cjk_checker, _ = spellcheckConfigPanel.addCheckBox(self.tr('Skip CJK (Chinese, Japanese, Korean)'))
-        self.spellcheck_skip_cjk_checker.stateChanged.connect(self.on_spellcheck_skip_cjk_changed)
-
         # Edit Distance Spinbox
         from qtpy.QtWidgets import QSpinBox
         self.spellcheck_distance_spin = QSpinBox(self)
@@ -945,13 +942,6 @@ class ConfigPanel(QDialog):
         self.add_ext_btn.setEnabled(enabled)
         self.remove_ext_btn.setEnabled(enabled)
         self.spellcheck_distance_spin.setEnabled(enabled)
-        self.spellcheck_skip_cjk_checker.setEnabled(enabled)
-        from ballontranslator.utils.spellcheck import SpellCheckManager
-        SpellCheckManager.get_instance().notify_config_changed()
-        self.save_config.emit()
-
-    def on_spellcheck_skip_cjk_changed(self):
-        pcfg.spellcheck_skip_cjk = self.spellcheck_skip_cjk_checker.isChecked()
         from ballontranslator.utils.spellcheck import SpellCheckManager
         SpellCheckManager.get_instance().notify_config_changed()
         self.save_config.emit()
@@ -1287,8 +1277,6 @@ class ConfigPanel(QDialog):
         self.spellcheck_checker.setChecked(pcfg.spellcheck_enabled)
         self.spellcheck_distance_spin.setValue(getattr(pcfg, 'spellcheck_distance', 1))
         self.spellcheck_distance_spin.setEnabled(pcfg.spellcheck_enabled)
-        self.spellcheck_skip_cjk_checker.setChecked(getattr(pcfg, 'spellcheck_skip_cjk', True))
-        self.spellcheck_skip_cjk_checker.setEnabled(pcfg.spellcheck_enabled)
         self.manage_words_btn.setEnabled(pcfg.spellcheck_enabled)
         self.repo_dicts_list.setEnabled(pcfg.spellcheck_enabled)
         self.external_dicts_list.setEnabled(pcfg.spellcheck_enabled)

--- a/ballontranslator/ui/configpanel.py
+++ b/ballontranslator/ui/configpanel.py
@@ -1,6 +1,12 @@
+import os
 from typing import List, Union, Tuple
 
-from qtpy.QtWidgets import QApplication, QPushButton, QLayout, QGridLayout, QHBoxLayout, QVBoxLayout, QTreeView, QWidget, QLabel, QSizePolicy, QSpacerItem, QCheckBox, QSplitter, QScrollArea, QLineEdit, QDialog, QStackedWidget, QMessageBox, QListWidget
+from qtpy.QtWidgets import (
+    QApplication, QPushButton, QLayout, QGridLayout, QHBoxLayout, QVBoxLayout,
+    QTreeView, QWidget, QLabel, QSizePolicy, QSpacerItem, QCheckBox,
+    QSplitter, QScrollArea, QLineEdit, QDialog, QStackedWidget, QMessageBox,
+    QListWidget, QSpinBox, QProgressDialog, QFileDialog, QListWidgetItem
+)
 from qtpy.QtCore import Qt, Signal, QSize, QEvent, QItemSelection
 from qtpy.QtGui import QStandardItem, QStandardItemModel, QMouseEvent, QFont, QIntValidator, QValidator, QFocusEvent
 
@@ -14,7 +20,8 @@ from ballontranslator.utils.network_mirrors import (
     mirror_from_display,
     mirror_to_display,
 )
-from ballontranslator.utils.shared import CONFIG_FONTSIZE_CONTENT, CONFIG_FONTSIZE_TABLE, CONFIG_COMBOBOX_SHORT, CONFIG_COMBOBOX_LONG, CONFIG_COMBOBOX_MIDEAN
+from ballontranslator.utils.shared import CONFIG_FONTSIZE_CONTENT, CONFIG_FONTSIZE_TABLE, CONFIG_COMBOBOX_SHORT, CONFIG_COMBOBOX_LONG, CONFIG_COMBOBOX_MIDEAN, PROGRAM_PATH
+from ballontranslator.utils.logger import logger as LOGGER
 from .module_parse_widgets import InpaintConfigPanel, TextDetectConfigPanel, TranslatorConfigPanel, OCRConfigPanel
 from ballontranslator.ui.spellcheck import DICTIONARY_URLS, SpellCheckManager, DictionaryManagerDialog, DictDownloadThread
 
@@ -433,7 +440,6 @@ class ConfigPanel(QDialog):
         self.spellcheck_on_source_checker.stateChanged.connect(self.on_spellcheck_on_source_changed)
 
         # Edit Distance Spinbox
-        from qtpy.QtWidgets import QSpinBox
         self.spellcheck_distance_spin = QSpinBox(self)
         self.spellcheck_distance_spin.setRange(1, 4)
         self.spellcheck_distance_spin.setFixedWidth(CONFIG_COMBOBOX_SHORT)
@@ -698,11 +704,6 @@ class ConfigPanel(QDialog):
         dialog.exec_()
 
     def on_repo_dict_item_changed(self, item):
-        from qtpy.QtCore import Qt
-        import os
-        from ballontranslator.utils.shared import PROGRAM_PATH
-        from ballontranslator.utils.logger import logger as LOGGER
-
         url, filename = item.data(Qt.ItemDataRole.UserRole)
         save_path = os.path.join(PROGRAM_PATH, 'data', 'dictionaries', filename)
 
@@ -724,7 +725,6 @@ class ConfigPanel(QDialog):
     def save_repo_dicts_config(self):
         self.repo_dicts_list.blockSignals(True)
         try:
-            from qtpy.QtCore import Qt
             enabled_files = []
             for idx in range(self.repo_dicts_list.count()):
                 it = self.repo_dicts_list.item(idx)
@@ -739,12 +739,6 @@ class ConfigPanel(QDialog):
             self.repo_dicts_list.blockSignals(False)
 
     def download_repo_dict_async(self, item, url, filename):
-        import os
-        from ballontranslator.utils.shared import PROGRAM_PATH
-        from qtpy.QtWidgets import QProgressDialog
-        from qtpy.QtCore import Qt
-        from ballontranslator.utils.logger import logger as LOGGER
-
         save_path = os.path.join(PROGRAM_PATH, 'data', 'dictionaries', filename)
 
         progress = QProgressDialog(self.tr("Downloading dictionary..."), self.tr("Cancel"), 0, 100, self)
@@ -772,12 +766,10 @@ class ConfigPanel(QDialog):
                 
                 self.save_repo_dicts_config()
                 
-                from qtpy.QtWidgets import QMessageBox
                 QMessageBox.information(self, self.tr("Download Complete"), self.tr("Dictionary downloaded successfully!"))
             else:
                 LOGGER.warning(f"download_repo_dict_async: download failed for {filename}: {err}")
                 if "cancelled" not in err.lower():
-                    from qtpy.QtWidgets import QMessageBox
                     QMessageBox.warning(self, self.tr("Download Failed"), self.tr("Failed to download dictionary: ") + err)
 
         thread.progress.connect(on_progress)
@@ -790,7 +782,6 @@ class ConfigPanel(QDialog):
         thread.wait()
 
     def add_external_dictionary(self):
-        from qtpy.QtWidgets import QFileDialog
         path, _ = QFileDialog.getOpenFileName(
             self,
             self.tr("Select Dictionary File"),
@@ -961,8 +952,6 @@ class ConfigPanel(QDialog):
 
     def setupConfig(self):
         self.blockSignals(True)
-        import os
-        from ballontranslator.utils import shared
 
         if pcfg.open_recent_on_startup:
             self.open_on_startup_checker.setChecked(True)
@@ -974,12 +963,10 @@ class ConfigPanel(QDialog):
         
         self.repo_dicts_list.blockSignals(True)
         self.repo_dicts_list.clear()
-        from qtpy.QtWidgets import QListWidgetItem
-        from qtpy.QtCore import Qt
         
         for lang_name, url in self.dictionary_urls.items():
             filename = url.split('/')[-1]
-            dict_path = os.path.join(shared.PROGRAM_PATH, 'data', 'dictionaries', filename)
+            dict_path = os.path.join(PROGRAM_PATH, 'data', 'dictionaries', filename)
 
             display_text = self.tr(lang_name)
             exists = os.path.exists(dict_path)

--- a/ballontranslator/ui/configpanel.py
+++ b/ballontranslator/ui/configpanel.py
@@ -927,6 +927,7 @@ class ConfigPanel(QDialog):
                     if not success:
                         item.setCheckState(Qt.CheckState.Unchecked)
                     else:
+                        item.setCheckState(Qt.CheckState.Checked)
                         lang_name = ""
                         for k, v in self.dictionary_urls.items():
                             if v == url:

--- a/ballontranslator/ui/configpanel.py
+++ b/ballontranslator/ui/configpanel.py
@@ -372,26 +372,30 @@ from qtpy.QtWidgets import QListWidget, QInputDialog, QHBoxLayout, QVBoxLayout, 
 class WordListItemWidget(QWidget):
     def __init__(self, word, on_delete_callback, parent=None):
         super().__init__(parent)
+        self.setFixedHeight(36)
         layout = QHBoxLayout(self)
-        layout.setContentsMargins(12, 6, 12, 6)
+        layout.setContentsMargins(12, 0, 12, 0)
         layout.setSpacing(12)
 
         self.label = QLabel(word, self)
-        self.label.setStyleSheet("font-family: 'Segoe UI', Arial; font-size: 13px; font-weight: 500;")
+        self.label.setStyleSheet("font-family: 'Segoe UI', Arial; font-size: 13px; font-weight: 500; background-color: transparent;")
 
-        self.delete_btn = QPushButton("🗑", self)
-        self.delete_btn.setFixedSize(28, 28)
+        self.delete_btn = QPushButton("×", self)
+        self.delete_btn.setFixedSize(24, 24)
         self.delete_btn.setToolTip(self.tr("Delete word"))
+        self.delete_btn.setFocusPolicy(Qt.FocusPolicy.NoFocus)
         self.delete_btn.setStyleSheet("""
             QPushButton {
                 background-color: transparent;
                 color: #ff4d4d;
                 border: none;
-                font-size: 15px;
+                font-size: 18px;
                 font-weight: bold;
                 padding: 0px;
-                min-width: 0px;
-                min-height: 0px;
+                min-width: 24px;
+                max-width: 24px;
+                min-height: 24px;
+                max-height: 24px;
             }
             QPushButton:hover {
                 color: #ff1a1a;
@@ -401,6 +405,8 @@ class WordListItemWidget(QWidget):
         """)
         self.delete_btn.clicked.connect(lambda: on_delete_callback(word))
         self.delete_btn.setVisible(False)
+        self.delete_btn.setAutoDefault(False)
+        self.delete_btn.setDefault(False)
 
         layout.addWidget(self.label)
         layout.addStretch()
@@ -418,26 +424,49 @@ class WordListItemWidget(QWidget):
 class AddWordItemWidget(QWidget):
     def __init__(self, on_add_callback, parent=None):
         super().__init__(parent)
+        self.setFixedHeight(36)
         layout = QHBoxLayout(self)
-        layout.setContentsMargins(12, 6, 12, 6)
+        layout.setContentsMargins(12, 0, 12, 0)
         layout.setSpacing(12)
 
         self.input_field = QLineEdit(self)
         self.input_field.setPlaceholderText(self.tr("Add new word..."))
-        self.input_field.setFixedHeight(30)
+        self.input_field.setFixedHeight(26)
         self.input_field.setStyleSheet("font-family: 'Segoe UI', Arial; font-size: 13px;")
-        self.input_field.returnPressed.connect(self.trigger_add)
+        
+        # Override keyPressEvent to prevent Enter key from propagating and closing QDialog
+        def input_key_press(event):
+            from qtpy.QtCore import Qt
+            if event.key() in (Qt.Key.Key_Return, Qt.Key.Key_Enter):
+                self.trigger_add()
+                event.accept()
+            else:
+                QLineEdit.keyPressEvent(self.input_field, event)
+        self.input_field.keyPressEvent = input_key_press
 
         self.add_btn = QPushButton("+", self)
-        self.add_btn.setFixedSize(30, 30)
+        self.add_btn.setFixedSize(26, 26)
         self.add_btn.setToolTip(self.tr("Add word"))
+        self.add_btn.setFocusPolicy(Qt.FocusPolicy.NoFocus)
+        self.add_btn.setAutoDefault(False)
+        self.add_btn.setDefault(False)
         self.add_btn.setStyleSheet("""
             QPushButton {
+                background-color: #3b3d40;
+                color: #ffffff;
+                border: 1px solid #45474a;
+                border-radius: 4px;
                 padding: 0px;
-                min-width: 0px;
-                min-height: 0px;
+                min-width: 26px;
+                max-width: 26px;
+                min-height: 26px;
+                max-height: 26px;
                 font-weight: bold;
-                font-size: 16px;
+                font-size: 14px;
+            }
+            QPushButton:hover {
+                background-color: #1e93e5;
+                border-color: #1e93e5;
             }
         """)
         self.add_btn.clicked.connect(self.trigger_add)
@@ -467,10 +496,29 @@ class DictionaryManagerDialog(QDialog):
         layout.setContentsMargins(10, 10, 10, 10)
 
         self.list_widget = QListWidget(self)
+        self.list_widget.setSelectionMode(QListWidget.SelectionMode.NoSelection)
+        self.list_widget.setStyleSheet("""
+            QListWidget {
+                outline: 0;
+            }
+            QListWidget::item {
+                background-color: transparent;
+            }
+            QListWidget::item:selected {
+                background-color: transparent;
+                color: inherit;
+            }
+            QListWidget::item:hover {
+                background-color: rgba(255, 255, 255, 6%);
+                border-radius: 4px;
+            }
+        """)
         layout.addWidget(self.list_widget)
 
         self.close_btn = QPushButton(self.tr("Close"), self)
         self.close_btn.setFixedHeight(32)
+        self.close_btn.setAutoDefault(False)
+        self.close_btn.setDefault(False)
         self.close_btn.clicked.connect(self.accept)
         layout.addWidget(self.close_btn)
 
@@ -479,19 +527,19 @@ class DictionaryManagerDialog(QDialog):
     def populate_list(self):
         self.list_widget.clear()
         from qtpy.QtWidgets import QListWidgetItem
-        from qtpy.QtCore import Qt
+        from qtpy.QtCore import Qt, QSize
 
         for word in sorted(self.manager.custom_words):
             item = QListWidgetItem(self.list_widget)
             widget = WordListItemWidget(word, self.delete_word, self)
-            item.setSizeHint(widget.sizeHint())
+            item.setSizeHint(QSize(0, 36))
             self.list_widget.addItem(item)
             self.list_widget.setItemWidget(item, widget)
 
         input_item = QListWidgetItem(self.list_widget)
         input_item.setFlags(input_item.flags() & ~Qt.ItemFlag.ItemIsSelectable)
         input_widget = AddWordItemWidget(self.add_word, self)
-        input_item.setSizeHint(input_widget.sizeHint())
+        input_item.setSizeHint(QSize(0, 36))
         self.list_widget.addItem(input_item)
         self.list_widget.setItemWidget(input_item, input_widget)
 

--- a/ballontranslator/ui/configpanel.py
+++ b/ballontranslator/ui/configpanel.py
@@ -1,6 +1,6 @@
 from typing import List, Union, Tuple
 
-from qtpy.QtWidgets import QApplication, QPushButton, QLayout, QGridLayout, QHBoxLayout, QVBoxLayout, QTreeView, QWidget, QLabel, QSizePolicy, QSpacerItem, QCheckBox, QSplitter, QScrollArea, QLineEdit, QDialog, QStackedWidget, QMessageBox
+from qtpy.QtWidgets import QApplication, QPushButton, QLayout, QGridLayout, QHBoxLayout, QVBoxLayout, QTreeView, QWidget, QLabel, QSizePolicy, QSpacerItem, QCheckBox, QSplitter, QScrollArea, QLineEdit, QDialog, QStackedWidget, QMessageBox, QListWidget
 from qtpy.QtCore import Qt, Signal, QSize, QEvent, QItemSelection
 from qtpy.QtGui import QStandardItem, QStandardItemModel, QMouseEvent, QFont, QIntValidator, QValidator, QFocusEvent
 
@@ -16,6 +16,8 @@ from ballontranslator.utils.network_mirrors import (
 )
 from ballontranslator.utils.shared import CONFIG_FONTSIZE_CONTENT, CONFIG_FONTSIZE_TABLE, CONFIG_COMBOBOX_SHORT, CONFIG_COMBOBOX_LONG, CONFIG_COMBOBOX_MIDEAN
 from .module_parse_widgets import InpaintConfigPanel, TextDetectConfigPanel, TranslatorConfigPanel, OCRConfigPanel
+from ballontranslator.ui.spellcheck import dictionary_urls
+
 
 LAYOUT_SET_MINIMUM_SIZE = getattr(getattr(QLayout, 'SizeConstraint', QLayout), 'SetMinimumSize')
 PUSHBTN_FIXED_HEIGHT = 32
@@ -330,239 +332,6 @@ class ConfigTable(QTreeView):
                 self.section_pressed.emit(section_key)
 
 
-from qtpy.QtCore import QThread
-
-class DictDownloadThread(QThread):
-    progress = Signal(int, int)
-    finished = Signal(bool, str)
-
-    def __init__(self, url, save_path):
-        super().__init__()
-        self.url = url
-        self.save_path = save_path
-        import threading
-        self.cancel_event = threading.Event()
-
-    def run(self):
-        try:
-            import os
-            from ballontranslator.utils.download_util import download_url_to_file
-
-            def progress_callback(payload):
-                if payload.get('event') == 'file_progress':
-                    self.progress.emit(payload.get('downloaded', 0), payload.get('total', 0))
-
-            os.makedirs(os.path.dirname(self.save_path), exist_ok=True)
-            download_url_to_file(
-                self.url,
-                self.save_path,
-                progress_callback=progress_callback,
-                cancel_event=self.cancel_event
-            )
-            self.finished.emit(True, "")
-        except Exception as e:
-            self.finished.emit(False, str(e))
-
-    def cancel(self):
-        self.cancel_event.set()
-
-
-from qtpy.QtWidgets import QListWidget, QInputDialog, QHBoxLayout, QVBoxLayout, QPushButton, QLineEdit, QDialog, QLabel, QWidget
-
-class WordListItemWidget(QWidget):
-    def __init__(self, word, on_delete_callback, parent=None):
-        super().__init__(parent)
-        self.setFixedHeight(36)
-        layout = QHBoxLayout(self)
-        layout.setContentsMargins(12, 0, 12, 0)
-        layout.setSpacing(12)
-
-        self.label = QLabel(word, self)
-        self.label.setStyleSheet("font-family: 'Segoe UI', Arial; font-size: 13px; font-weight: 500; background-color: transparent;")
-
-        self.delete_btn = QPushButton("×", self)
-        self.delete_btn.setFixedSize(24, 24)
-        self.delete_btn.setToolTip(self.tr("Delete word"))
-        self.delete_btn.setFocusPolicy(Qt.FocusPolicy.NoFocus)
-        self.delete_btn.setStyleSheet("""
-            QPushButton {
-                background-color: transparent;
-                color: #ff4d4d;
-                border: none;
-                font-size: 18px;
-                font-weight: bold;
-                padding: 0px;
-                min-width: 24px;
-                max-width: 24px;
-                min-height: 24px;
-                max-height: 24px;
-            }
-            QPushButton:hover {
-                color: #ff1a1a;
-                background-color: rgba(255, 77, 77, 12%);
-                border-radius: 4px;
-            }
-        """)
-        self.delete_btn.clicked.connect(lambda: on_delete_callback(word))
-        self.delete_btn.setVisible(False)
-        self.delete_btn.setAutoDefault(False)
-        self.delete_btn.setDefault(False)
-
-        layout.addWidget(self.label)
-        layout.addStretch()
-        layout.addWidget(self.delete_btn)
-
-    def enterEvent(self, event):
-        self.delete_btn.setVisible(True)
-        super().enterEvent(event)
-
-    def leaveEvent(self, event):
-        self.delete_btn.setVisible(False)
-        super().leaveEvent(event)
-
-
-class AddWordItemWidget(QWidget):
-    def __init__(self, on_add_callback, parent=None):
-        super().__init__(parent)
-        self.setFixedHeight(36)
-        layout = QHBoxLayout(self)
-        layout.setContentsMargins(12, 0, 12, 0)
-        layout.setSpacing(12)
-
-        self.input_field = QLineEdit(self)
-        self.input_field.setPlaceholderText(self.tr("Add new word..."))
-        self.input_field.setFixedHeight(26)
-        self.input_field.setStyleSheet("font-family: 'Segoe UI', Arial; font-size: 13px;")
-        
-        # Override keyPressEvent to prevent Enter key from propagating and closing QDialog
-        def input_key_press(event):
-            from qtpy.QtCore import Qt
-            if event.key() in (Qt.Key.Key_Return, Qt.Key.Key_Enter):
-                self.trigger_add()
-                event.accept()
-            else:
-                QLineEdit.keyPressEvent(self.input_field, event)
-        self.input_field.keyPressEvent = input_key_press
-
-        self.add_btn = QPushButton("+", self)
-        self.add_btn.setFixedSize(26, 26)
-        self.add_btn.setToolTip(self.tr("Add word"))
-        self.add_btn.setFocusPolicy(Qt.FocusPolicy.NoFocus)
-        self.add_btn.setAutoDefault(False)
-        self.add_btn.setDefault(False)
-        self.add_btn.setStyleSheet("""
-            QPushButton {
-                background-color: #3b3d40;
-                color: #ffffff;
-                border: 1px solid #45474a;
-                border-radius: 4px;
-                padding: 0px;
-                min-width: 26px;
-                max-width: 26px;
-                min-height: 26px;
-                max-height: 26px;
-                font-weight: bold;
-                font-size: 14px;
-            }
-            QPushButton:hover {
-                background-color: #1e93e5;
-                border-color: #1e93e5;
-            }
-        """)
-        self.add_btn.clicked.connect(self.trigger_add)
-
-        layout.addWidget(self.input_field)
-        layout.addWidget(self.add_btn)
-        self.on_add_callback = on_add_callback
-
-    def trigger_add(self):
-        word = self.input_field.text().strip().lower()
-        if word:
-            self.on_add_callback(word)
-            self.input_field.clear()
-            self.input_field.setFocus()
-
-
-class DictionaryManagerDialog(QDialog):
-    def __init__(self, parent=None):
-        super().__init__(parent)
-        self.setWindowTitle(self.tr("Custom Dictionary Manager"))
-        self.resize(450, 520)
-
-        from ballontranslator.utils.spellcheck import SpellCheckManager
-        self.manager = SpellCheckManager.get_instance()
-
-        layout = QVBoxLayout(self)
-        layout.setContentsMargins(10, 10, 10, 10)
-
-        self.list_widget = QListWidget(self)
-        self.list_widget.setSelectionMode(QListWidget.SelectionMode.NoSelection)
-        self.list_widget.setStyleSheet("""
-            QListWidget {
-                outline: 0;
-            }
-            QListWidget::item {
-                background-color: transparent;
-            }
-            QListWidget::item:selected {
-                background-color: transparent;
-                color: inherit;
-            }
-            QListWidget::item:hover {
-                background-color: rgba(255, 255, 255, 6%);
-                border-radius: 4px;
-            }
-        """)
-        layout.addWidget(self.list_widget)
-
-        self.close_btn = QPushButton(self.tr("Close"), self)
-        self.close_btn.setFixedHeight(32)
-        self.close_btn.setAutoDefault(False)
-        self.close_btn.setDefault(False)
-        self.close_btn.clicked.connect(self.accept)
-        layout.addWidget(self.close_btn)
-
-        self.populate_list()
-
-    def populate_list(self):
-        self.list_widget.clear()
-        from qtpy.QtWidgets import QListWidgetItem
-        from qtpy.QtCore import Qt, QSize
-
-        for word in sorted(self.manager.custom_words):
-            item = QListWidgetItem(self.list_widget)
-            widget = WordListItemWidget(word, self.delete_word, self)
-            item.setSizeHint(QSize(0, 36))
-            self.list_widget.addItem(item)
-            self.list_widget.setItemWidget(item, widget)
-
-        input_item = QListWidgetItem(self.list_widget)
-        input_item.setFlags(input_item.flags() & ~Qt.ItemFlag.ItemIsSelectable)
-        input_widget = AddWordItemWidget(self.add_word, self)
-        input_item.setSizeHint(QSize(0, 36))
-        self.list_widget.addItem(input_item)
-        self.list_widget.setItemWidget(input_item, input_widget)
-
-    def add_word(self, word):
-        word_lower = word.lower()
-        if word_lower and word_lower not in self.manager.custom_words:
-            self.manager.custom_words.add(word_lower)
-            self.populate_list()
-
-    def delete_word(self, word):
-        word_lower = word.lower()
-        self.manager.custom_words.discard(word_lower)
-        self.populate_list()
-
-    def done(self, r):
-        super().done(r)
-        self.manager._save_custom_dictionary()
-        self.manager.notify_config_changed()
-        for hl in list(self.manager.highlighters):
-            hl.clear_cache()
-            hl.rehighlight()
-
-
 class ConfigPanel(QDialog):
 
     save_config = Signal()
@@ -572,44 +341,8 @@ class ConfigPanel(QDialog):
     reload_textstyle = Signal(bool)
     show_only_custom_font = Signal(bool)
 
-    dictionary_urls = {
-        "Arabic (ar)": "https://raw.githubusercontent.com/LibreOffice/dictionaries/master/ar/ar.dic",
-        "Belarusian (be_BY)": "https://raw.githubusercontent.com/LibreOffice/dictionaries/master/be_BY/be-official.dic",
-        "Bulgarian (bg_BG)": "https://raw.githubusercontent.com/LibreOffice/dictionaries/master/bg_BG/bg_BG.dic",
-        "Bosnian (bs_BA)": "https://raw.githubusercontent.com/LibreOffice/dictionaries/master/bs_BA/bs_BA.dic",
-        "Catalan (ca)": "https://raw.githubusercontent.com/LibreOffice/dictionaries/master/ca/dictionaries/ca.dic",
-        "Czech (cs_CZ)": "https://raw.githubusercontent.com/LibreOffice/dictionaries/master/cs_CZ/cs_CZ.dic",
-        "Danish (da_DK)": "https://raw.githubusercontent.com/LibreOffice/dictionaries/master/da_DK/da_DK.dic",
-        "German (de_DE)": "https://raw.githubusercontent.com/LibreOffice/dictionaries/master/de/de_DE_frami.dic",
-        "Greek (el_GR)": "https://raw.githubusercontent.com/LibreOffice/dictionaries/master/el_GR/el_GR.dic",
-        "English (en_US)": "https://raw.githubusercontent.com/LibreOffice/dictionaries/master/en/en_US.dic",
-        "English (en_GB)": "https://raw.githubusercontent.com/LibreOffice/dictionaries/master/en/en_GB.dic",
-        "Spanish (es_ES)": "https://raw.githubusercontent.com/LibreOffice/dictionaries/master/es/es_ES.dic",
-        "Estonian (et_EE)": "https://raw.githubusercontent.com/LibreOffice/dictionaries/master/et_EE/et_EE.dic",
-        "Persian (fa_IR)": "https://raw.githubusercontent.com/LibreOffice/dictionaries/master/fa_IR/fa-IR.dic",
-        "French (fr_FR)": "https://raw.githubusercontent.com/LibreOffice/dictionaries/master/fr_FR/fr.dic",
-        "Croatian (hr_HR)": "https://raw.githubusercontent.com/LibreOffice/dictionaries/master/hr_HR/hr_HR.dic",
-        "Hungarian (hu_HU)": "https://raw.githubusercontent.com/LibreOffice/dictionaries/master/hu_HU/hu_HU.dic",
-        "Indonesian (id)": "https://raw.githubusercontent.com/LibreOffice/dictionaries/master/id/id_ID.dic",
-        "Icelandic (is)": "https://raw.githubusercontent.com/LibreOffice/dictionaries/master/is/is.dic",
-        "Italian (it_IT)": "https://raw.githubusercontent.com/LibreOffice/dictionaries/master/it_IT/it_IT.dic",
-        "Korean (ko_KR)": "https://raw.githubusercontent.com/LibreOffice/dictionaries/master/ko_KR/ko_KR.dic",
-        "Lithuanian (lt_LT)": "https://raw.githubusercontent.com/LibreOffice/dictionaries/master/lt_LT/lt.dic",
-        "Latvian (lv_LV)": "https://raw.githubusercontent.com/LibreOffice/dictionaries/master/lv_LV/lv_LV.dic",
-        "Dutch (nl_NL)": "https://raw.githubusercontent.com/LibreOffice/dictionaries/master/nl_NL/nl_NL.dic",
-        "Polish (pl_PL)": "https://raw.githubusercontent.com/LibreOffice/dictionaries/master/pl_PL/pl_PL.dic",
-        "Portuguese (pt_BR)": "https://raw.githubusercontent.com/LibreOffice/dictionaries/master/pt_BR/pt_BR.dic",
-        "Portuguese (pt_PT)": "https://raw.githubusercontent.com/LibreOffice/dictionaries/master/pt_PT/pt_PT.dic",
-        "Romanian (ro_RO)": "https://raw.githubusercontent.com/LibreOffice/dictionaries/master/ro/ro_RO.dic",
-        "Russian (ru_RU)": "https://raw.githubusercontent.com/LibreOffice/dictionaries/master/ru_RU/ru_RU.dic",
-        "Russian (Large - all inflections) (ru_RU)": "https://raw.githubusercontent.com/danakt/russian-words/master/russian.txt",
-        "Slovak (sk_SK)": "https://raw.githubusercontent.com/LibreOffice/dictionaries/master/sk_SK/sk_SK.dic",
-        "Slovenian (sl_SI)": "https://raw.githubusercontent.com/LibreOffice/dictionaries/master/sl_SI/sl_SI.dic",
-        "Swedish (sv_SE)": "https://raw.githubusercontent.com/LibreOffice/dictionaries/master/sv_SE/dictionaries/sv_SE.dic",
-        "Turkish (tr_TR)": "https://raw.githubusercontent.com/LibreOffice/dictionaries/master/tr_TR/tr_TR.dic",
-        "Ukrainian (uk_UA)": "https://raw.githubusercontent.com/LibreOffice/dictionaries/master/uk_UA/uk_UA.dic",
-        "Vietnamese (vi)": "https://raw.githubusercontent.com/LibreOffice/dictionaries/master/vi/vi_VN.dic"
-    }
+    dictionary_urls = dictionary_urls
+
 
     def __init__(self, *args, **kwargs) -> None:
         super().__init__(*args, **kwargs)
@@ -695,6 +428,9 @@ class ConfigPanel(QDialog):
 
         self.spellcheck_checker, _ = spellcheckConfigPanel.addCheckBox(self.tr('Enable Spell Checker'))
         self.spellcheck_checker.stateChanged.connect(self.on_spellcheck_changed)
+
+        self.spellcheck_on_source_checker, _ = spellcheckConfigPanel.addCheckBox(self.tr('Enable Spell Checker on Source Blocks'))
+        self.spellcheck_on_source_checker.stateChanged.connect(self.on_spellcheck_on_source_changed)
 
         # Edit Distance Spinbox
         from qtpy.QtWidgets import QSpinBox
@@ -936,23 +672,32 @@ class ConfigPanel(QDialog):
     def on_spellcheck_changed(self):
         enabled = self.spellcheck_checker.isChecked()
         pcfg.spellcheck_enabled = enabled
+        self.spellcheck_on_source_checker.setEnabled(enabled)
         self.manage_words_btn.setEnabled(enabled)
         self.repo_dicts_list.setEnabled(enabled)
         self.external_dicts_list.setEnabled(enabled)
         self.add_ext_btn.setEnabled(enabled)
         self.remove_ext_btn.setEnabled(enabled)
         self.spellcheck_distance_spin.setEnabled(enabled)
-        from ballontranslator.utils.spellcheck import SpellCheckManager
+        from ballontranslator.ui.spellcheck import SpellCheckManager
+        SpellCheckManager.get_instance().notify_config_changed()
+        self.save_config.emit()
+
+    def on_spellcheck_on_source_changed(self):
+        enabled = self.spellcheck_on_source_checker.isChecked()
+        pcfg.spellcheck_on_source_enabled = enabled
+        from ballontranslator.ui.spellcheck import SpellCheckManager
         SpellCheckManager.get_instance().notify_config_changed()
         self.save_config.emit()
 
     def on_spellcheck_distance_changed(self):
         pcfg.spellcheck_distance = self.spellcheck_distance_spin.value()
-        from ballontranslator.utils.spellcheck import SpellCheckManager
+        from ballontranslator.ui.spellcheck import SpellCheckManager
         SpellCheckManager.get_instance().notify_config_changed()
         self.save_config.emit()
 
     def open_words_manager(self):
+        from ballontranslator.ui.spellcheck import DictionaryManagerDialog
         dialog = DictionaryManagerDialog(self)
         dialog.exec_()
 
@@ -992,7 +737,7 @@ class ConfigPanel(QDialog):
                     enabled_files.append(fname)
 
             pcfg.spellcheck_repo_dicts = ",".join(enabled_files)
-            from ballontranslator.utils.spellcheck import SpellCheckManager
+            from ballontranslator.ui.spellcheck import SpellCheckManager
             SpellCheckManager.get_instance().notify_config_changed()
             self.save_config.emit()
         finally:
@@ -1010,6 +755,7 @@ class ConfigPanel(QDialog):
         progress = QProgressDialog(self.tr("Downloading dictionary..."), self.tr("Cancel"), 0, 100, self)
         progress.setWindowModality(Qt.WindowModality.WindowModal)
 
+        from ballontranslator.ui.spellcheck import DictDownloadThread
         thread = DictDownloadThread(url, save_path)
 
         def on_progress(downloaded, total):
@@ -1074,7 +820,7 @@ class ConfigPanel(QDialog):
         for idx in range(self.external_dicts_list.count()):
             paths.append(self.external_dicts_list.item(idx).text())
         pcfg.spellcheck_external_dict_path = ";".join(paths)
-        from ballontranslator.utils.spellcheck import SpellCheckManager
+        from ballontranslator.ui.spellcheck import SpellCheckManager
         SpellCheckManager.get_instance().notify_config_changed()
         self.save_config.emit()
 
@@ -1275,6 +1021,8 @@ class ConfigPanel(QDialog):
                 self.external_dicts_list.addItem(p)
 
         self.spellcheck_checker.setChecked(pcfg.spellcheck_enabled)
+        self.spellcheck_on_source_checker.setChecked(getattr(pcfg, 'spellcheck_on_source_enabled', False))
+        self.spellcheck_on_source_checker.setEnabled(pcfg.spellcheck_enabled)
         self.spellcheck_distance_spin.setValue(getattr(pcfg, 'spellcheck_distance', 1))
         self.spellcheck_distance_spin.setEnabled(pcfg.spellcheck_enabled)
         self.manage_words_btn.setEnabled(pcfg.spellcheck_enabled)

--- a/ballontranslator/ui/configpanel.py
+++ b/ballontranslator/ui/configpanel.py
@@ -688,6 +688,24 @@ class ConfigPanel(QDialog):
         self.spellcheck_checker, _ = spellcheckConfigPanel.addCheckBox(self.tr('Enable Spell Checker'))
         self.spellcheck_checker.stateChanged.connect(self.on_spellcheck_changed)
 
+        # Edit Distance Spinbox
+        from qtpy.QtWidgets import QSpinBox
+        self.spellcheck_distance_spin = QSpinBox(self)
+        self.spellcheck_distance_spin.setRange(1, 4)
+        self.spellcheck_distance_spin.setFixedWidth(CONFIG_COMBOBOX_SHORT)
+        self.spellcheck_distance_spin.setToolTip(self.tr("Higher value, slower analysis"))
+        self.spellcheck_distance_spin.valueChanged.connect(self.on_spellcheck_distance_changed)
+
+        dist_layout = QHBoxLayout()
+        dist_layout.setContentsMargins(0, 0, 0, 0)
+        dist_layout.setSpacing(12)
+        dist_label = ConfigTextLabel(self.tr("Edit Distance"), CONFIG_FONTSIZE_CONTENT, QFont.Weight.Normal)
+        dist_label.setToolTip(self.tr("Higher value, slower analysis"))
+        dist_layout.addWidget(dist_label)
+        dist_layout.addWidget(self.spellcheck_distance_spin)
+        dist_layout.insertStretch(-1)
+        spellcheckConfigPanel.addBlockWidget(dist_layout)
+
         # Dictionary Words Manager Button
         self.manage_words_btn = QPushButton(parent=self)
         self.manage_words_btn.setText(self.tr("Dictionary Words..."))
@@ -903,6 +921,13 @@ class ConfigPanel(QDialog):
         self.external_dicts_list.setEnabled(enabled)
         self.add_ext_btn.setEnabled(enabled)
         self.remove_ext_btn.setEnabled(enabled)
+        self.spellcheck_distance_spin.setEnabled(enabled)
+        from ballontranslator.utils.spellcheck import SpellCheckManager
+        SpellCheckManager.get_instance().notify_config_changed()
+        self.save_config.emit()
+
+    def on_spellcheck_distance_changed(self):
+        pcfg.spellcheck_distance = self.spellcheck_distance_spin.value()
         from ballontranslator.utils.spellcheck import SpellCheckManager
         SpellCheckManager.get_instance().notify_config_changed()
         self.save_config.emit()
@@ -1206,6 +1231,8 @@ class ConfigPanel(QDialog):
                 self.external_dicts_list.addItem(p)
 
         self.spellcheck_checker.setChecked(pcfg.spellcheck_enabled)
+        self.spellcheck_distance_spin.setValue(getattr(pcfg, 'spellcheck_distance', 1))
+        self.spellcheck_distance_spin.setEnabled(pcfg.spellcheck_enabled)
         self.manage_words_btn.setEnabled(pcfg.spellcheck_enabled)
         self.repo_dicts_list.setEnabled(pcfg.spellcheck_enabled)
         self.external_dicts_list.setEnabled(pcfg.spellcheck_enabled)

--- a/ballontranslator/ui/configpanel.py
+++ b/ballontranslator/ui/configpanel.py
@@ -367,7 +367,100 @@ class DictDownloadThread(QThread):
         self.cancel_event.set()
 
 
-from qtpy.QtWidgets import QListWidget, QInputDialog, QHBoxLayout, QVBoxLayout, QPushButton, QLineEdit, QDialog
+from qtpy.QtWidgets import QListWidget, QInputDialog, QHBoxLayout, QVBoxLayout, QPushButton, QLineEdit, QDialog, QLabel, QWidget
+
+class WordListItemWidget(QWidget):
+    def __init__(self, word, on_delete_callback, parent=None):
+        super().__init__(parent)
+        layout = QHBoxLayout(self)
+        layout.setContentsMargins(8, 4, 8, 4)
+        layout.setSpacing(8)
+
+        self.label = QLabel(word, self)
+        self.label.setStyleSheet("color: #ffffff; font-family: 'Segoe UI', Arial; font-size: 12px;")
+
+        self.delete_btn = QPushButton("🗑", self)
+        self.delete_btn.setFixedSize(24, 24)
+        self.delete_btn.setStyleSheet("""
+            QPushButton {
+                background-color: transparent;
+                color: #ff4d4d;
+                border: none;
+                font-size: 14px;
+                font-weight: bold;
+            }
+            QPushButton:hover {
+                background-color: #ff4d4d;
+                color: #ffffff;
+                border-radius: 3px;
+            }
+        """)
+        self.delete_btn.clicked.connect(lambda: on_delete_callback(word))
+        self.delete_btn.setVisible(False)
+
+        layout.addWidget(self.label)
+        layout.addStretch()
+        layout.addWidget(self.delete_btn)
+
+    def enterEvent(self, event):
+        self.delete_btn.setVisible(True)
+        super().enterEvent(event)
+
+    def leaveEvent(self, event):
+        self.delete_btn.setVisible(False)
+        super().leaveEvent(event)
+
+
+class AddWordItemWidget(QWidget):
+    def __init__(self, on_add_callback, parent=None):
+        super().__init__(parent)
+        layout = QHBoxLayout(self)
+        layout.setContentsMargins(8, 4, 8, 4)
+        layout.setSpacing(8)
+
+        self.input_field = QLineEdit(self)
+        self.input_field.setPlaceholderText(self.tr("Add new word..."))
+        self.input_field.setStyleSheet("""
+            QLineEdit {
+                background-color: #2b2b2d;
+                color: #ffffff;
+                border: 1px solid #45474a;
+                border-radius: 3px;
+                padding: 2px 6px;
+                font-family: 'Segoe UI', Arial;
+                font-size: 12px;
+            }
+        """)
+        self.input_field.returnPressed.connect(self.trigger_add)
+
+        self.add_btn = QPushButton("+", self)
+        self.add_btn.setFixedSize(24, 24)
+        self.add_btn.setStyleSheet("""
+            QPushButton {
+                background-color: #1e93e5;
+                color: #ffffff;
+                border: none;
+                border-radius: 3px;
+                font-weight: bold;
+                font-size: 14px;
+            }
+            QPushButton:hover {
+                background-color: #1a7abf;
+            }
+        """)
+        self.add_btn.clicked.connect(self.trigger_add)
+
+        layout.addWidget(self.input_field)
+        layout.addWidget(self.add_btn)
+        self.on_add_callback = on_add_callback
+
+    def trigger_add(self):
+        word = self.input_field.text().strip().lower()
+        if word:
+            self.on_add_callback(word)
+            self.input_field.clear()
+            self.input_field.setFocus()
+
 
 class DictionaryManagerDialog(QDialog):
     def __init__(self, parent=None):
@@ -379,76 +472,75 @@ class DictionaryManagerDialog(QDialog):
         self.manager = SpellCheckManager.get_instance()
 
         layout = QVBoxLayout(self)
+        layout.setContentsMargins(10, 10, 10, 10)
 
-        # Word list
         self.list_widget = QListWidget(self)
-        self.list_widget.itemDoubleClicked.connect(self.edit_word)
+        self.list_widget.setStyleSheet("""
+            QListWidget {
+                background-color: #1e1e1f;
+                border: 1px solid #45474a;
+                border-radius: 4px;
+            }
+            QListWidget::item {
+                background-color: transparent;
+                border-bottom: 1px solid #2b2b2d;
+            }
+            QListWidget::item:hover {
+                background-color: #2b2b2d;
+            }
+        """)
         layout.addWidget(self.list_widget)
 
-        # Input block
-        input_layout = QHBoxLayout()
-        self.word_input = QLineEdit(self)
-        self.word_input.setPlaceholderText(self.tr("Enter new word..."))
-        self.word_input.returnPressed.connect(self.add_word)
-        self.add_btn = QPushButton(self.tr("Add Word"), self)
-        self.add_btn.clicked.connect(self.add_word)
-
-        input_layout.addWidget(self.word_input)
-        input_layout.addWidget(self.add_btn)
-        layout.addLayout(input_layout)
-
-        # Action buttons
-        actions_layout = QHBoxLayout()
-        self.delete_btn = QPushButton(self.tr("Delete Selected"), self)
-        self.delete_btn.clicked.connect(self.delete_selected)
         self.close_btn = QPushButton(self.tr("Close"), self)
+        self.close_btn.setFixedHeight(32)
+        self.close_btn.setStyleSheet("""
+            QPushButton {
+                background-color: #3b3d40;
+                color: #ffffff;
+                border: 1px solid #45474a;
+                border-radius: 4px;
+                font-family: 'Segoe UI', Arial;
+                font-size: 12px;
+                font-weight: bold;
+            }
+            QPushButton:hover {
+                background-color: #1e93e5;
+            }
+        """)
         self.close_btn.clicked.connect(self.accept)
-
-        actions_layout.addWidget(self.delete_btn)
-        actions_layout.addWidget(self.close_btn)
-        layout.addLayout(actions_layout)
+        layout.addWidget(self.close_btn)
 
         self.populate_list()
 
     def populate_list(self):
         self.list_widget.clear()
-        for word in sorted(self.manager.custom_words):
-            self.list_widget.addItem(word)
+        from qtpy.QtWidgets import QListWidgetItem
+        from qtpy.QtCore import Qt
 
-    def add_word(self):
-        word = self.word_input.text().strip().lower()
+        for word in sorted(self.manager.custom_words):
+            item = QListWidgetItem(self.list_widget)
+            widget = WordListItemWidget(word, self.delete_word, self)
+            item.setSizeHint(widget.sizeHint())
+            self.list_widget.addItem(item)
+            self.list_widget.setItemWidget(item, widget)
+
+        input_item = QListWidgetItem(self.list_widget)
+        input_item.setFlags(input_item.flags() & ~Qt.ItemFlag.ItemIsSelectable)
+        input_widget = AddWordItemWidget(self.add_word, self)
+        input_item.setSizeHint(input_widget.sizeHint())
+        self.list_widget.addItem(input_item)
+        self.list_widget.setItemWidget(input_item, input_widget)
+
+    def add_word(self, word):
         if word and word not in self.manager.custom_words:
             self.manager.add_to_dictionary(word)
-            self.word_input.clear()
             self.populate_list()
 
-    def delete_selected(self):
-        selected_items = self.list_widget.selectedItems()
-        if not selected_items:
-            return
-        for item in selected_items:
-            word = item.text()
-            self.manager.custom_words.discard(word)
+    def delete_word(self, word):
+        self.manager.custom_words.discard(word)
         self.manager._save_custom_dictionary()
         self.manager.notify_config_changed()
         self.populate_list()
-
-    def edit_word(self, item):
-        old_word = item.text()
-        new_word, ok = QInputDialog.getText(
-            self,
-            self.tr("Edit Word"),
-            self.tr("Edit word:"),
-            text=old_word
-        )
-        if ok:
-            new_word = new_word.strip().lower()
-            if new_word and new_word != old_word:
-                self.manager.custom_words.discard(old_word)
-                self.manager.custom_words.add(new_word)
-                self.manager._save_custom_dictionary()
-                self.manager.notify_config_changed()
-                self.populate_list()
 
 
 class ConfigPanel(QDialog):

--- a/ballontranslator/ui/framelesswindow/fw_qt6/win_frameless_window.py
+++ b/ballontranslator/ui/framelesswindow/fw_qt6/win_frameless_window.py
@@ -173,10 +173,10 @@ class WindowsFramelessWindowBase:
             return True, result
         elif msg.message == win32con.WM_SETFOCUS and isSystemBorderAccentEnabled():
             self.windowEffect.setBorderAccentColor(self.winId(), getSystemAccentColor())
-            return True, 0
+            return False, 0
         elif msg.message == win32con.WM_KILLFOCUS:
             self.windowEffect.removeBorderAccentColor(self.winId())
-            return True, 0
+            return False, 0
 
         return False, 0
 

--- a/ballontranslator/ui/spellcheck.py
+++ b/ballontranslator/ui/spellcheck.py
@@ -1,11 +1,61 @@
 import os
 import re
 import weakref
+import threading
 from typing import List, Set
-from qtpy.QtGui import QSyntaxHighlighter, QTextCharFormat, QColor
-from qtpy.QtCore import Qt
 
-from . import shared
+from qtpy.QtCore import Qt, QTimer, QThread, Signal, QSize
+from qtpy.QtGui import QSyntaxHighlighter, QTextCharFormat, QColor
+from qtpy.QtWidgets import (
+    QListWidget, QHBoxLayout, QVBoxLayout, QPushButton,
+    QLineEdit, QDialog, QLabel, QWidget, QListWidgetItem
+)
+
+from ballontranslator.utils import shared
+from ballontranslator.utils.config import pcfg
+from ballontranslator.utils.download_util import download_url_to_file
+from ballontranslator.utils.logger import logger as LOGGER
+
+# Predefined dictionary repository URLs mapping language names to LibreOffice raw URLs.
+dictionary_urls = {
+    "Arabic (ar)": "https://raw.githubusercontent.com/LibreOffice/dictionaries/master/ar/ar.dic",
+    "Belarusian (be_BY)": "https://raw.githubusercontent.com/LibreOffice/dictionaries/master/be_BY/be-official.dic",
+    "Bulgarian (bg_BG)": "https://raw.githubusercontent.com/LibreOffice/dictionaries/master/bg_BG/bg_BG.dic",
+    "Bosnian (bs_BA)": "https://raw.githubusercontent.com/LibreOffice/dictionaries/master/bs_BA/bs_BA.dic",
+    "Catalan (ca)": "https://raw.githubusercontent.com/LibreOffice/dictionaries/master/ca/dictionaries/ca.dic",
+    "Czech (cs_CZ)": "https://raw.githubusercontent.com/LibreOffice/dictionaries/master/cs_CZ/cs_CZ.dic",
+    "Danish (da_DK)": "https://raw.githubusercontent.com/LibreOffice/dictionaries/master/da_DK/da_DK.dic",
+    "German (de_DE)": "https://raw.githubusercontent.com/LibreOffice/dictionaries/master/de/de_DE_frami.dic",
+    "Greek (el_GR)": "https://raw.githubusercontent.com/LibreOffice/dictionaries/master/el_GR/el_GR.dic",
+    "English (en_US)": "https://raw.githubusercontent.com/LibreOffice/dictionaries/master/en/en_US.dic",
+    "English (en_GB)": "https://raw.githubusercontent.com/LibreOffice/dictionaries/master/en/en_GB.dic",
+    "Spanish (es_ES)": "https://raw.githubusercontent.com/LibreOffice/dictionaries/master/es/es_ES.dic",
+    "Estonian (et_EE)": "https://raw.githubusercontent.com/LibreOffice/dictionaries/master/et_EE/et_EE.dic",
+    "Persian (fa_IR)": "https://raw.githubusercontent.com/LibreOffice/dictionaries/master/fa_IR/fa-IR.dic",
+    "French (fr_FR)": "https://raw.githubusercontent.com/LibreOffice/dictionaries/master/fr_FR/fr.dic",
+    "Croatian (hr_HR)": "https://raw.githubusercontent.com/LibreOffice/dictionaries/master/hr_HR/hr_HR.dic",
+    "Hungarian (hu_HU)": "https://raw.githubusercontent.com/LibreOffice/dictionaries/master/hu_HU/hu_HU.dic",
+    "Indonesian (id)": "https://raw.githubusercontent.com/LibreOffice/dictionaries/master/id/id_ID.dic",
+    "Icelandic (is)": "https://raw.githubusercontent.com/LibreOffice/dictionaries/master/is/is.dic",
+    "Italian (it_IT)": "https://raw.githubusercontent.com/LibreOffice/dictionaries/master/it_IT/it_IT.dic",
+    "Korean (ko_KR)": "https://raw.githubusercontent.com/LibreOffice/dictionaries/master/ko_KR/ko_KR.dic",
+    "Lithuanian (lt_LT)": "https://raw.githubusercontent.com/LibreOffice/dictionaries/master/lt_LT/lt.dic",
+    "Latvian (lv_LV)": "https://raw.githubusercontent.com/LibreOffice/dictionaries/master/lv_LV/lv_LV.dic",
+    "Dutch (nl_NL)": "https://raw.githubusercontent.com/LibreOffice/dictionaries/master/nl_NL/nl_NL.dic",
+    "Polish (pl_PL)": "https://raw.githubusercontent.com/LibreOffice/dictionaries/master/pl_PL/pl_PL.dic",
+    "Portuguese (pt_BR)": "https://raw.githubusercontent.com/LibreOffice/dictionaries/master/pt_BR/pt_BR.dic",
+    "Portuguese (pt_PT)": "https://raw.githubusercontent.com/LibreOffice/dictionaries/master/pt_PT/pt_PT.dic",
+    "Romanian (ro_RO)": "https://raw.githubusercontent.com/LibreOffice/dictionaries/master/ro/ro_RO.dic",
+    "Russian (ru_RU)": "https://raw.githubusercontent.com/LibreOffice/dictionaries/master/ru_RU/ru_RU.dic",
+    "Russian (Large - all inflections) (ru_RU)": "https://raw.githubusercontent.com/danakt/russian-words/master/russian.txt",
+    "Slovak (sk_SK)": "https://raw.githubusercontent.com/LibreOffice/dictionaries/master/sk_SK/sk_SK.dic",
+    "Slovenian (sl_SI)": "https://raw.githubusercontent.com/LibreOffice/dictionaries/master/sl_SI/sl_SI.dic",
+    "Swedish (sv_SE)": "https://raw.githubusercontent.com/LibreOffice/dictionaries/master/sv_SE/dictionaries/sv_SE.dic",
+    "Turkish (tr_TR)": "https://raw.githubusercontent.com/LibreOffice/dictionaries/master/tr_TR/tr_TR.dic",
+    "Ukrainian (uk_UA)": "https://raw.githubusercontent.com/LibreOffice/dictionaries/master/uk_UA/uk_UA.dic",
+    "Vietnamese (vi)": "https://raw.githubusercontent.com/LibreOffice/dictionaries/master/vi/vi_VN.dic"
+}
+
 
 class SpellCheckManager:
     """SpellCheckManager manages spell checking, custom dictionaries, and suggestion retrieval.
@@ -84,7 +134,6 @@ class SpellCheckManager:
                 if word:
                     target_set.add(word)
         except Exception as e:
-            from ballontranslator.utils.logger import logger as LOGGER
             LOGGER.error(f"Error reading dictionary file {path}: {e}")
 
     def load_external_dictionary(self):
@@ -95,8 +144,6 @@ class SpellCheckManager:
         """
         temp_words = set()
         try:
-            from ballontranslator.utils.config import pcfg
-            
             # Load enabled repository dictionaries
             repo_dicts = getattr(pcfg, 'spellcheck_repo_dicts', '').split(',')
             loaded_repos = 0
@@ -117,13 +164,11 @@ class SpellCheckManager:
                     self._parse_and_load_file_to_set(path, temp_words)
                     loaded_externals += 1
                     
-            from ballontranslator.utils.logger import logger as LOGGER
             LOGGER.info(
                 f"SpellCheckManager: loaded {len(temp_words)} words "
                 f"(from {loaded_repos} repo dictionaries, {loaded_externals} external dictionaries)"
             )
         except Exception as e:
-            from ballontranslator.utils.logger import logger as LOGGER
             LOGGER.error(f"Error loading dictionaries: {e}")
             
         self.external_words = temp_words
@@ -131,9 +176,6 @@ class SpellCheckManager:
             hl.clear_cache()
 
     def load_spellchecker_async(self):
-        from ballontranslator.utils.config import pcfg
-        from ballontranslator.utils.logger import logger as LOGGER
-
         if not getattr(pcfg, 'spellcheck_enabled', True):
             if self.spell is not None or self.external_words:
                 self.spell = None
@@ -144,7 +186,6 @@ class SpellCheckManager:
                     hl.rehighlight()
             return
 
-        import threading
         if hasattr(self, '_loading_thread') and self._loading_thread and self._loading_thread.is_alive():
             self._reload_queued = True
             return
@@ -204,7 +245,6 @@ class SpellCheckManager:
 
                 self.external_words = temp_words
 
-                from qtpy.QtCore import QTimer
                 def gui_notify():
                     for hl in list(self.highlighters):
                         hl.clear_cache()
@@ -236,7 +276,6 @@ class SpellCheckManager:
         >>> manager = SpellCheckManager.get_instance()
         >>> manager.load_spellchecker()
         """
-        from ballontranslator.utils.config import pcfg
         distance = getattr(pcfg, 'spellcheck_distance', 1)
         if self.spell is not None:
             if getattr(self.spell, '_distance', 1) == distance:
@@ -248,10 +287,8 @@ class SpellCheckManager:
             from spellchecker import SpellChecker
             # Load English and Russian dictionaries with configured distance
             self.spell = SpellChecker(language=['en', 'ru'], distance=distance)
-            from ballontranslator.utils.logger import logger as LOGGER
             LOGGER.info(f"SpellChecker initialized with languages: en, ru (distance={distance})")
         except Exception as e:
-            from ballontranslator.utils.logger import logger as LOGGER
             LOGGER.error(f"Failed to load SpellChecker: {e}")
             self.spell = None
 
@@ -339,6 +376,8 @@ class SpellCheckManager:
 
     def notify_config_changed(self):
         """Notifies all registered highlighters that config changed, clearing cache."""
+        for hl in list(self.highlighters):
+            hl.clear_cache()
         self.load_spellchecker_async()
 
 
@@ -374,12 +413,26 @@ class SpellCheckHighlighter(QSyntaxHighlighter):
             pass
 
     def highlightBlock(self, text):
-        from ballontranslator.utils.config import pcfg
         # Check if spellcheck is enabled in settings and if spellchecker package is installed
         if not getattr(pcfg, 'spellcheck_enabled', True):
             return
         if not self.manager.is_available():
             return
+
+        # Check if editor is a Source block editor and if spell checking on source is enabled
+        editor = self.parent()
+        from qtpy.QtWidgets import QTextEdit
+        if editor and not isinstance(editor, QTextEdit):
+            # Fallback if document was passed
+            doc_parent = editor.parent()
+            if doc_parent and isinstance(doc_parent, QTextEdit):
+                editor = doc_parent
+        
+        if editor and isinstance(editor, QTextEdit):
+            editor_class = editor.__class__.__name__
+            if editor_class == 'SourceTextEdit':
+                if not getattr(pcfg, 'spellcheck_on_source_enabled', False):
+                    return
 
         # Pattern matches words in any language using Unicode character classes
         pattern = r'\b[^\W\d_]+\b'
@@ -396,3 +449,248 @@ class SpellCheckHighlighter(QSyntaxHighlighter):
                 start = match.start()
                 length = match.end() - start
                 self.setFormat(start, length, self.misspelled_format)
+
+
+class DictDownloadThread(QThread):
+    """QThread to handle dictionary downloads in the background.
+
+    >>> thread = DictDownloadThread("http://example.com/dict.dic", "save/path.dic")
+    >>> isinstance(thread, DictDownloadThread)
+    True
+    """
+    progress = Signal(int, int)
+    finished = Signal(bool, str)
+
+    def __init__(self, url, save_path):
+        super().__init__()
+        self.url = url
+        self.save_path = save_path
+        self.cancel_event = threading.Event()
+
+    def run(self):
+        try:
+            os.makedirs(os.path.dirname(self.save_path), exist_ok=True)
+            download_url_to_file(
+                self.url,
+                self.save_path,
+                progress_callback=self._progress_callback,
+                cancel_event=self.cancel_event
+            )
+            self.finished.emit(True, "")
+        except Exception as e:
+            self.finished.emit(False, str(e))
+
+    def _progress_callback(self, payload):
+        if payload.get('event') == 'file_progress':
+            self.progress.emit(payload.get('downloaded', 0), payload.get('total', 0))
+
+    def cancel(self):
+        self.cancel_event.set()
+
+
+class WordListItemWidget(QWidget):
+    """Custom QWidget representing a single custom word in the manager dialog.
+
+    >>> widget = WordListItemWidget("hello", lambda w: None)
+    >>> isinstance(widget, WordListItemWidget)
+    True
+    """
+    def __init__(self, word, on_delete_callback, parent=None):
+        super().__init__(parent)
+        self.setFixedHeight(36)
+        layout = QHBoxLayout(self)
+        layout.setContentsMargins(12, 0, 12, 0)
+        layout.setSpacing(12)
+
+        self.label = QLabel(word, self)
+        self.label.setStyleSheet("font-family: 'Segoe UI', Arial; font-size: 13px; font-weight: 500; background-color: transparent;")
+
+        self.delete_btn = QPushButton("×", self)
+        self.delete_btn.setFixedSize(24, 24)
+        self.delete_btn.setToolTip(self.tr("Delete word"))
+        self.delete_btn.setFocusPolicy(Qt.FocusPolicy.NoFocus)
+        self.delete_btn.setStyleSheet("""
+            QPushButton {
+                background-color: transparent;
+                color: #ff4d4d;
+                border: none;
+                font-size: 18px;
+                font-weight: bold;
+                padding: 0px;
+                min-width: 24px;
+                max-width: 24px;
+                min-height: 24px;
+                max-height: 24px;
+            }
+            QPushButton:hover {
+                color: #ff1a1a;
+                background-color: rgba(255, 77, 77, 12%);
+                border-radius: 4px;
+            }
+        """)
+        self.delete_btn.clicked.connect(lambda: on_delete_callback(word))
+        self.delete_btn.setVisible(False)
+        self.delete_btn.setAutoDefault(False)
+        self.delete_btn.setDefault(False)
+
+        layout.addWidget(self.label)
+        layout.addStretch()
+        layout.addWidget(self.delete_btn)
+
+    def enterEvent(self, event):
+        self.delete_btn.setVisible(True)
+        super().enterEvent(event)
+
+    def leaveEvent(self, event):
+        self.delete_btn.setVisible(False)
+        super().leaveEvent(event)
+
+
+class AddWordItemWidget(QWidget):
+    """Custom QWidget containing input line and add button for entering custom words.
+
+    >>> widget = AddWordItemWidget(lambda w: None)
+    >>> isinstance(widget, AddWordItemWidget)
+    True
+    """
+    def __init__(self, on_add_callback, parent=None):
+        super().__init__(parent)
+        self.setFixedHeight(36)
+        layout = QHBoxLayout(self)
+        layout.setContentsMargins(12, 0, 12, 0)
+        layout.setSpacing(12)
+
+        self.input_field = QLineEdit(self)
+        self.input_field.setPlaceholderText(self.tr("Add new word..."))
+        self.input_field.setFixedHeight(26)
+        self.input_field.setStyleSheet("font-family: 'Segoe UI', Arial; font-size: 13px;")
+        
+        # Override keyPressEvent to prevent Enter key from propagating and closing QDialog
+        def input_key_press(event):
+            if event.key() in (Qt.Key.Key_Return, Qt.Key.Key_Enter):
+                self.trigger_add()
+                event.accept()
+            else:
+                QLineEdit.keyPressEvent(self.input_field, event)
+        self.input_field.keyPressEvent = input_key_press
+
+        self.add_btn = QPushButton("+", self)
+        self.add_btn.setFixedSize(26, 26)
+        self.add_btn.setToolTip(self.tr("Add word"))
+        self.add_btn.setFocusPolicy(Qt.FocusPolicy.NoFocus)
+        self.add_btn.setAutoDefault(False)
+        self.add_btn.setDefault(False)
+        self.add_btn.setStyleSheet("""
+            QPushButton {
+                background-color: #3b3d40;
+                color: #ffffff;
+                border: 1px solid #45474a;
+                border-radius: 4px;
+                padding: 0px;
+                min-width: 26px;
+                max-width: 26px;
+                min-height: 26px;
+                max-height: 26px;
+                font-weight: bold;
+                font-size: 14px;
+            }
+            QPushButton:hover {
+                background-color: #1e93e5;
+                border-color: #1e93e5;
+            }
+        """)
+        self.add_btn.clicked.connect(self.trigger_add)
+
+        layout.addWidget(self.input_field)
+        layout.addWidget(self.add_btn)
+        self.on_add_callback = on_add_callback
+
+    def trigger_add(self):
+        word = self.input_field.text().strip().lower()
+        if word:
+            self.on_add_callback(word)
+            self.input_field.clear()
+            self.input_field.setFocus()
+
+
+class DictionaryManagerDialog(QDialog):
+    """Dialog allowing users to manage their custom dictionary list.
+
+    >>> dialog = DictionaryManagerDialog(None)
+    >>> isinstance(dialog, DictionaryManagerDialog)
+    True
+    """
+    def __init__(self, parent=None):
+        super().__init__(parent)
+        self.setWindowTitle(self.tr("Custom Dictionary Manager"))
+        self.resize(450, 520)
+
+        self.manager = SpellCheckManager.get_instance()
+
+        layout = QVBoxLayout(self)
+        layout.setContentsMargins(10, 10, 10, 10)
+
+        self.list_widget = QListWidget(self)
+        self.list_widget.setSelectionMode(QListWidget.SelectionMode.NoSelection)
+        self.list_widget.setStyleSheet("""
+            QListWidget {
+                outline: 0;
+            }
+            QListWidget::item {
+                background-color: transparent;
+            }
+            QListWidget::item:selected {
+                background-color: transparent;
+                color: inherit;
+            }
+            QListWidget::item:hover {
+                background-color: rgba(255, 255, 255, 6%);
+                border-radius: 4px;
+            }
+        """)
+        layout.addWidget(self.list_widget)
+
+        self.close_btn = QPushButton(self.tr("Close"), self)
+        self.close_btn.setFixedHeight(32)
+        self.close_btn.setAutoDefault(False)
+        self.close_btn.setDefault(False)
+        self.close_btn.clicked.connect(self.accept)
+        layout.addWidget(self.close_btn)
+
+        self.populate_list()
+
+    def populate_list(self):
+        self.list_widget.clear()
+
+        for word in sorted(self.manager.custom_words):
+            item = QListWidgetItem(self.list_widget)
+            widget = WordListItemWidget(word, self.delete_word, self)
+            item.setSizeHint(QSize(0, 36))
+            self.list_widget.addItem(item)
+            self.list_widget.setItemWidget(item, widget)
+
+        input_item = QListWidgetItem(self.list_widget)
+        input_item.setFlags(input_item.flags() & ~Qt.ItemFlag.ItemIsSelectable)
+        input_widget = AddWordItemWidget(self.add_word, self)
+        input_item.setSizeHint(QSize(0, 36))
+        self.list_widget.addItem(input_item)
+        self.list_widget.setItemWidget(input_item, input_widget)
+
+    def add_word(self, word):
+        word_lower = word.lower()
+        if word_lower and word_lower not in self.manager.custom_words:
+            self.manager.custom_words.add(word_lower)
+            self.populate_list()
+
+    def delete_word(self, word):
+        word_lower = word.lower()
+        self.manager.custom_words.discard(word_lower)
+        self.populate_list()
+
+    def done(self, r):
+        super().done(r)
+        self.manager._save_custom_dictionary()
+        self.manager.notify_config_changed()
+        for hl in list(self.manager.highlighters):
+            hl.clear_cache()
+            hl.rehighlight()

--- a/ballontranslator/ui/spellcheck.py
+++ b/ballontranslator/ui/spellcheck.py
@@ -8,7 +8,7 @@ from qtpy.QtCore import Qt, QTimer, QThread, Signal, QSize
 from qtpy.QtGui import QSyntaxHighlighter, QTextCharFormat, QColor
 from qtpy.QtWidgets import (
     QListWidget, QHBoxLayout, QVBoxLayout, QPushButton,
-    QLineEdit, QDialog, QLabel, QWidget, QListWidgetItem
+    QLineEdit, QDialog, QLabel, QWidget, QListWidgetItem, QTextEdit
 )
 
 from ballontranslator.utils import shared
@@ -421,7 +421,6 @@ class SpellCheckHighlighter(QSyntaxHighlighter):
 
         # Check if editor is a Source block editor and if spell checking on source is enabled
         editor = self.parent()
-        from qtpy.QtWidgets import QTextEdit
         if editor and not isinstance(editor, QTextEdit):
             # Fallback if document was passed
             doc_parent = editor.parent()

--- a/ballontranslator/ui/spellcheck.py
+++ b/ballontranslator/ui/spellcheck.py
@@ -17,7 +17,7 @@ from ballontranslator.utils.download_util import download_url_to_file
 from ballontranslator.utils.logger import logger as LOGGER
 
 # Predefined dictionary repository URLs mapping language names to LibreOffice raw URLs.
-dictionary_urls = {
+DICTIONARY_URLS = {
     "Arabic (ar)": "https://raw.githubusercontent.com/LibreOffice/dictionaries/master/ar/ar.dic",
     "Belarusian (be_BY)": "https://raw.githubusercontent.com/LibreOffice/dictionaries/master/be_BY/be-official.dic",
     "Bulgarian (bg_BG)": "https://raw.githubusercontent.com/LibreOffice/dictionaries/master/bg_BG/bg_BG.dic",

--- a/ballontranslator/ui/textedit_area.py
+++ b/ballontranslator/ui/textedit_area.py
@@ -131,6 +131,7 @@ class SourceTextEdit(QTextEdit):
     push_undo_stack = Signal(int)
     text_changed = Signal()
     focus_out = Signal(int)
+    suggestions_ready = Signal(object, str, list)
 
     def __init__(self, idx, parent, fold=False, *args, **kwargs):
         super().__init__(parent, *args, **kwargs)
@@ -160,6 +161,8 @@ class SourceTextEdit(QTextEdit):
         self.spell_highlighter = SpellCheckHighlighter(self.document())
         self.selectionChanged.connect(self.on_selection_changed)
         self.suggestion_popup = None
+        self.suggestions_ready.connect(self.show_suggestions_popup)
+        self.current_suggestion_word = None
 
     def setFold(self, fold: bool):
         if fold:
@@ -199,41 +202,64 @@ class SourceTextEdit(QTextEdit):
             if not cursor.hasSelection():
                 if hasattr(self, 'suggestion_popup') and self.suggestion_popup:
                     self.suggestion_popup.hide()
+                self.current_suggestion_word = None
                 return
 
             selected_text = cursor.selectedText().strip()
             # Only suggest for a single word
             if len(selected_text) > 1 and re.match(r'^[a-zA-Zа-яА-ЯёЁ]+$', selected_text):
                 if not manager.is_correct(selected_text):
-                    suggestions = manager.get_suggestions(selected_text)
-                    if not self.suggestion_popup:
-                        self.suggestion_popup = FloatingSuggestionLabel(self)
+                    self.current_suggestion_word = selected_text
                     
-                    self.suggestion_popup.set_suggestions(cursor, selected_text, suggestions)
-                    self.suggestion_popup.adjustSize()
-                        
-                    rect = self.cursorRect()
-                    
-                    # Position above the selection inside the editor viewport
-                    px = rect.left() + (rect.width() - self.suggestion_popup.width()) // 2
-                    py = rect.top() - self.suggestion_popup.height() - 4
-                    
-                    # Guard boundaries
-                    # If it goes off the top of the viewport, show it below the cursor
-                    if py < 0:
-                        py = rect.bottom() + 4
-                        
-                    px = max(5, min(px, self.viewport().width() - self.suggestion_popup.width() - 5))
-                    
-                    # Map viewport local coordinates to global screen coordinates
-                    global_pos = self.viewport().mapToGlobal(QPoint(px, py))
-                    
-                    self.suggestion_popup.move(global_pos)
-                    self.suggestion_popup.show()
+                    # Fetch suggestions in background thread to avoid freezing the UI thread
+                    def fetch_bg(c, w):
+                        try:
+                            sugs = manager.get_suggestions(w)
+                            self.suggestions_ready.emit(c, w, sugs)
+                        except Exception:
+                            pass
+                            
+                    import threading
+                    t = threading.Thread(target=fetch_bg, args=(cursor, selected_text), daemon=True)
+                    t.start()
                     return
 
             if hasattr(self, 'suggestion_popup') and self.suggestion_popup:
                 self.suggestion_popup.hide()
+            self.current_suggestion_word = None
+        except Exception as e:
+            import traceback
+            traceback.print_exc()
+
+    def show_suggestions_popup(self, cursor, word, suggestions):
+        try:
+            if getattr(self, 'current_suggestion_word', None) != word:
+                return
+                
+            if not self.suggestion_popup:
+                self.suggestion_popup = FloatingSuggestionLabel(self)
+            
+            self.suggestion_popup.set_suggestions(cursor, word, suggestions)
+            self.suggestion_popup.adjustSize()
+                
+            rect = self.cursorRect()
+            
+            # Position above the selection inside the editor viewport
+            px = rect.left() + (rect.width() - self.suggestion_popup.width()) // 2
+            py = rect.top() - self.suggestion_popup.height() - 4
+            
+            # Guard boundaries
+            # If it goes off the top of the viewport, show it below the cursor
+            if py < 0:
+                py = rect.bottom() + 4
+                
+            px = max(5, min(px, self.viewport().width() - self.suggestion_popup.width() - 5))
+            
+            # Map viewport local coordinates to global screen coordinates
+            global_pos = self.viewport().mapToGlobal(QPoint(px, py))
+            
+            self.suggestion_popup.move(global_pos)
+            self.suggestion_popup.show()
         except Exception as e:
             import traceback
             traceback.print_exc()

--- a/ballontranslator/ui/textedit_area.py
+++ b/ballontranslator/ui/textedit_area.py
@@ -207,7 +207,7 @@ class SourceTextEdit(QTextEdit):
 
             selected_text = cursor.selectedText().strip()
             # Only suggest for a single word
-            if len(selected_text) > 1 and re.match(r'^[a-zA-Zа-яА-ЯёЁ]+$', selected_text):
+            if len(selected_text) > 1 and re.match(r'^[^\W\d_]+$', selected_text):
                 if not manager.is_correct(selected_text):
                     self.current_suggestion_word = selected_text
                     

--- a/ballontranslator/ui/textedit_area.py
+++ b/ballontranslator/ui/textedit_area.py
@@ -73,6 +73,17 @@ class FloatingSuggestionLabel(QWidget):
         if win:
             self.setStyleSheet(win.styleSheet())
         
+        from ballontranslator.utils.config import pcfg
+        is_dark = pcfg.darkmode
+        
+        # Determine theme-specific colors
+        theme_normal_bg = "#21252b" if is_dark else "rgba(198, 201, 207, 50%)"
+        theme_hover_bg = "#535671" if is_dark else "#b3b6bf" # Lightens on dark, darkens on light
+        theme_fg = "#8e99b1" if is_dark else "#5d5d5f"
+        theme_hover_fg = "#ffffff" if is_dark else "#000000"
+        green_fg = "#4caf50" if is_dark else "#2e7d32"
+        border_color = "#535671" if is_dark else "#b3b6bf"
+        
         while self.buttons_layout.count() > 0:
             item = self.buttons_layout.takeAt(0)
             w = item.widget()
@@ -85,9 +96,29 @@ class FloatingSuggestionLabel(QWidget):
             self.buttons_layout.addWidget(btn)
             
             # Stylize borders and round corners so they form a single seamless block
-            border_right = "1px solid @borderColor"
+            border_right = f"1px solid {border_color}"
             left_radius = "4px" if i == 0 else "0px"
-            btn.setStyleSheet(f"QPushButton {{ border-right: {border_right}; border-top-left-radius: {left_radius}; border-bottom-left-radius: {left_radius}; border-top-right-radius: 0px; border-bottom-right-radius: 0px; }}")
+            btn.setStyleSheet(f"""
+                QPushButton {{
+                    background-color: {theme_normal_bg};
+                    color: {theme_fg};
+                    border: none;
+                    border-right: {border_right};
+                    border-top-left-radius: {left_radius};
+                    border-bottom-left-radius: {left_radius};
+                    border-top-right-radius: 0px;
+                    border-bottom-right-radius: 0px;
+                    padding: 0px 12px;
+                    height: 28px;
+                    font-family: 'Segoe UI', Arial, sans-serif;
+                    font-size: 11px;
+                    font-weight: normal;
+                }}
+                QPushButton:hover {{
+                    background-color: {theme_hover_bg};
+                    color: {theme_hover_fg};
+                }}
+            """)
 
         # Add "Add to Dict" button at the end
         add_dict_btn = QPushButton(f"+ {self.tr('Add')}", self.scroll_content)
@@ -96,7 +127,26 @@ class FloatingSuggestionLabel(QWidget):
         self.buttons_layout.addWidget(add_dict_btn)
 
         left_radius = "4px" if len(suggestions) == 0 else "0px"
-        add_dict_btn.setStyleSheet(f"QPushButton {{ border: none; border-top-left-radius: {left_radius}; border-bottom-left-radius: {left_radius}; border-top-right-radius: 4px; border-bottom-right-radius: 4px; }}")
+        add_dict_btn.setStyleSheet(f"""
+            QPushButton {{
+                background-color: {theme_normal_bg};
+                color: {green_fg};
+                border: none;
+                border-top-left-radius: {left_radius};
+                border-bottom-left-radius: {left_radius};
+                border-top-right-radius: 4px;
+                border-bottom-right-radius: 4px;
+                padding: 0px 12px;
+                height: 28px;
+                font-family: 'Segoe UI', Arial, sans-serif;
+                font-size: 11px;
+                font-weight: normal;
+            }}
+            QPushButton:hover {{
+                background-color: {green_fg};
+                color: #ffffff;
+            }}
+        """)
             
         self.scroll_content.adjustSize()
         total_width = self.scroll_content.width()

--- a/ballontranslator/ui/textedit_area.py
+++ b/ballontranslator/ui/textedit_area.py
@@ -75,14 +75,7 @@ class FloatingSuggestionLabel(QWidget):
         
         from ballontranslator.utils.config import pcfg
         is_dark = pcfg.darkmode
-        
-        # Determine theme-specific colors
-        theme_normal_bg = "#21252b" if is_dark else "rgba(198, 201, 207, 50%)"
-        theme_hover_bg = "#535671" if is_dark else "#b3b6bf" # Lightens on dark, darkens on light
-        theme_fg = "#8e99b1" if is_dark else "#5d5d5f"
-        theme_hover_fg = "#ffffff" if is_dark else "#000000"
-        green_fg = "#4caf50" if is_dark else "#2e7d32"
-        border_color = "#535671" if is_dark else "#b3b6bf"
+        border_color = "rgba(255, 255, 255, 12%)" if is_dark else "rgba(0, 0, 0, 12%)"
         
         while self.buttons_layout.count() > 0:
             item = self.buttons_layout.takeAt(0)
@@ -98,27 +91,7 @@ class FloatingSuggestionLabel(QWidget):
             # Stylize borders and round corners so they form a single seamless block
             border_right = f"1px solid {border_color}"
             left_radius = "4px" if i == 0 else "0px"
-            btn.setStyleSheet(f"""
-                QPushButton {{
-                    background-color: {theme_normal_bg};
-                    color: {theme_fg};
-                    border: none;
-                    border-right: {border_right};
-                    border-top-left-radius: {left_radius};
-                    border-bottom-left-radius: {left_radius};
-                    border-top-right-radius: 0px;
-                    border-bottom-right-radius: 0px;
-                    padding: 0px 12px;
-                    height: 28px;
-                    font-family: 'Segoe UI', Arial, sans-serif;
-                    font-size: 11px;
-                    font-weight: normal;
-                }}
-                QPushButton:hover {{
-                    background-color: {theme_hover_bg};
-                    color: {theme_hover_fg};
-                }}
-            """)
+            btn.setStyleSheet(f"border: none; border-right: {border_right}; border-top-left-radius: {left_radius}; border-bottom-left-radius: {left_radius}; border-top-right-radius: 0px; border-bottom-right-radius: 0px;")
 
         # Add "Add to Dict" button at the end
         add_dict_btn = QPushButton(f"+ {self.tr('Add')}", self.scroll_content)
@@ -127,26 +100,7 @@ class FloatingSuggestionLabel(QWidget):
         self.buttons_layout.addWidget(add_dict_btn)
 
         left_radius = "4px" if len(suggestions) == 0 else "0px"
-        add_dict_btn.setStyleSheet(f"""
-            QPushButton {{
-                background-color: {theme_normal_bg};
-                color: {green_fg};
-                border: none;
-                border-top-left-radius: {left_radius};
-                border-bottom-left-radius: {left_radius};
-                border-top-right-radius: 4px;
-                border-bottom-right-radius: 4px;
-                padding: 0px 12px;
-                height: 28px;
-                font-family: 'Segoe UI', Arial, sans-serif;
-                font-size: 11px;
-                font-weight: normal;
-            }}
-            QPushButton:hover {{
-                background-color: {green_fg};
-                color: #ffffff;
-            }}
-        """)
+        add_dict_btn.setStyleSheet(f"border: none; border-top-left-radius: {left_radius}; border-bottom-left-radius: {left_radius}; border-top-right-radius: 4px; border-bottom-right-radius: 4px;")
             
         self.scroll_content.adjustSize()
         total_width = self.scroll_content.width()

--- a/ballontranslator/ui/textedit_area.py
+++ b/ballontranslator/ui/textedit_area.py
@@ -20,19 +20,6 @@ class FloatingSuggestionLabel(QWidget):
         self.editor = editor
         self.setObjectName("suggestion_popup")
         
-        # Segmented tab style: dark background, border, zero margins/padding between buttons
-        self.setStyleSheet("""
-            QWidget#suggestion_popup {
-                background-color: #2b2b2d;
-                border: 1px solid #45474a;
-                border-radius: 4px;
-            }
-            QScrollArea {
-                border: none;
-                background: transparent;
-            }
-        """)
-        
         self.main_layout = QHBoxLayout(self)
         self.main_layout.setContentsMargins(0, 0, 0, 0)
         self.main_layout.setSpacing(0)
@@ -87,31 +74,18 @@ class FloatingSuggestionLabel(QWidget):
             self.buttons_layout.addWidget(btn)
             
             # Stylize borders and round corners so they form a single seamless block
-            border_right = "1px solid #45474a" if i < len(suggestions) - 1 else "none"
+            border_right = "1px solid @borderColor"
             left_radius = "4px" if i == 0 else "0px"
-            right_radius = "4px" if i == len(suggestions) - 1 else "0px"
-            
-            btn.setStyleSheet(f"""
-                QPushButton {{
-                    background-color: #3b3d40;
-                    color: #ffffff;
-                    border: none;
-                    border-right: {border_right};
-                    border-top-left-radius: {left_radius};
-                    border-bottom-left-radius: {left_radius};
-                    border-top-right-radius: {right_radius};
-                    border-bottom-right-radius: {right_radius};
-                    padding: 0px 12px;
-                    height: 28px;
-                    font-family: 'Segoe UI', Arial, sans-serif;
-                    font-size: 11px;
-                    font-weight: bold;
-                }}
-                QPushButton:hover {{
-                    background-color: #1e93e5;
-                    color: #ffffff;
-                }}
-            """)
+            btn.setStyleSheet(f"QPushButton {{ border-right: {border_right}; border-top-left-radius: {left_radius}; border-bottom-left-radius: {left_radius}; border-top-right-radius: 0px; border-bottom-right-radius: 0px; }}")
+
+        # Add "Add to Dict" button at the end
+        add_dict_btn = QPushButton(f"+ {self.tr('Add')}", self.scroll_content)
+        add_dict_btn.setObjectName("add_to_dict")
+        add_dict_btn.clicked.connect(self.add_to_dict)
+        self.buttons_layout.addWidget(add_dict_btn)
+
+        left_radius = "4px" if len(suggestions) == 0 else "0px"
+        add_dict_btn.setStyleSheet(f"QPushButton {{ border: none; border-top-left-radius: {left_radius}; border-bottom-left-radius: {left_radius}; border-top-right-radius: 4px; border-bottom-right-radius: 4px; }}")
             
         self.scroll_content.adjustSize()
         total_width = self.scroll_content.width()
@@ -123,6 +97,11 @@ class FloatingSuggestionLabel(QWidget):
         
     def apply_suggestion(self, replacement):
         self.editor._replace_word(self.cursor, replacement)
+        self.hide()
+
+    def add_to_dict(self):
+        from ballontranslator.utils.spellcheck import SpellCheckManager
+        SpellCheckManager.get_instance().add_to_dictionary(self.word)
         self.hide()
 
 
@@ -179,11 +158,15 @@ class SourceTextEdit(QTextEdit):
     def _replace_word(self, cursor, replacement):
         self.setFocus()
         tc = self.textCursor()
-        tc.beginEditBlock()
         tc.setPosition(cursor.selectionStart())
         tc.setPosition(cursor.selectionEnd(), QTextCursor.MoveMode.KeepAnchor)
+        self.setTextCursor(tc)
+        
+        tc.beginEditBlock()
         tc.insertText(replacement)
         tc.endEditBlock()
+        
+        self.handle_content_change()
 
     def on_selection_changed(self):
         try:
@@ -248,13 +231,11 @@ class SourceTextEdit(QTextEdit):
 
         try:
             # Spell suggestions integration
-            from ballontranslator.utils.spellcheck import SpellCheckManager
             import re
             from qtpy.QtWidgets import QAction
             from qtpy.QtGui import QDesktopServices
             from qtpy.QtCore import QUrl
 
-            manager = SpellCheckManager.get_instance()
             pos = event.pos()
             # Handle keyboard-triggered menu (where pos is negative)
             if pos.x() < 0 or pos.y() < 0:
@@ -276,43 +257,6 @@ class SourceTextEdit(QTextEdit):
                     menu.insertSeparator(first_act)
                 else:
                     menu.addAction(search_act)
-
-                # Check spelling suggestions
-                is_misspelled = False
-                if manager.is_available() and re.match(r'^[a-zA-Zа-яА-ЯёЁ]+$', selected_word):
-                    is_misspelled = not manager.is_correct(selected_word)
-
-                if is_misspelled:
-                    suggestions = manager.get_suggestions(selected_word)
-
-                    # Add suggestions
-                    if suggestions:
-                        for sug in suggestions:
-                            sug_act = QAction(sug, menu)
-                            sug_act.triggered.connect(lambda checked, s=sug, c=cursor: self._replace_word(c, s))
-                            font = sug_act.font()
-                            font.setBold(True)
-                            sug_act.setFont(font)
-                            if first_act:
-                                menu.insertAction(first_act, sug_act)
-                            else:
-                                menu.addAction(sug_act)
-                    else:
-                        no_sug_act = QAction(self.tr("No spelling suggestions"), menu)
-                        no_sug_act.setEnabled(False)
-                        if first_act:
-                            menu.insertAction(first_act, no_sug_act)
-                        else:
-                            menu.addAction(no_sug_act)
-
-                    # Add to Dictionary action
-                    add_dict_act = QAction(self.tr("Add to Dictionary"), menu)
-                    add_dict_act.triggered.connect(lambda checked, w=selected_word: manager.add_to_dictionary(w))
-                    if first_act:
-                        menu.insertAction(first_act, add_dict_act)
-                        menu.insertSeparator(first_act)
-                    else:
-                        menu.addAction(add_dict_act)
         except Exception as e:
             import traceback
             traceback.print_exc()

--- a/ballontranslator/ui/textedit_area.py
+++ b/ballontranslator/ui/textedit_area.py
@@ -191,32 +191,31 @@ class SourceTextEdit(QTextEdit):
             if len(selected_text) > 1 and re.match(r'^[a-zA-Zа-яА-ЯёЁ]+$', selected_text):
                 if not manager.is_correct(selected_text):
                     suggestions = manager.get_suggestions(selected_text)
-                    if suggestions:
-                        if not self.suggestion_popup:
-                            self.suggestion_popup = FloatingSuggestionLabel(self)
+                    if not self.suggestion_popup:
+                        self.suggestion_popup = FloatingSuggestionLabel(self)
+                    
+                    self.suggestion_popup.set_suggestions(cursor, selected_text, suggestions)
+                    self.suggestion_popup.adjustSize()
                         
-                        self.suggestion_popup.set_suggestions(cursor, selected_text, suggestions)
-                        self.suggestion_popup.adjustSize()
+                    rect = self.cursorRect()
+                    
+                    # Position above the selection inside the editor viewport
+                    px = rect.left() + (rect.width() - self.suggestion_popup.width()) // 2
+                    py = rect.top() - self.suggestion_popup.height() - 4
+                    
+                    # Guard boundaries
+                    # If it goes off the top of the viewport, show it below the cursor
+                    if py < 0:
+                        py = rect.bottom() + 4
                         
-                        rect = self.cursorRect()
-                        
-                        # Position above the selection inside the editor viewport
-                        px = rect.left() + (rect.width() - self.suggestion_popup.width()) // 2
-                        py = rect.top() - self.suggestion_popup.height() - 4
-                        
-                        # Guard boundaries
-                        # If it goes off the top of the viewport, show it below the cursor
-                        if py < 0:
-                            py = rect.bottom() + 4
-                            
-                        px = max(5, min(px, self.viewport().width() - self.suggestion_popup.width() - 5))
-                        
-                        # Map viewport local coordinates to global screen coordinates
-                        global_pos = self.viewport().mapToGlobal(QPoint(px, py))
-                        
-                        self.suggestion_popup.move(global_pos)
-                        self.suggestion_popup.show()
-                        return
+                    px = max(5, min(px, self.viewport().width() - self.suggestion_popup.width() - 5))
+                    
+                    # Map viewport local coordinates to global screen coordinates
+                    global_pos = self.viewport().mapToGlobal(QPoint(px, py))
+                    
+                    self.suggestion_popup.move(global_pos)
+                    self.suggestion_popup.show()
+                    return
 
             if hasattr(self, 'suggestion_popup') and self.suggestion_popup:
                 self.suggestion_popup.hide()

--- a/ballontranslator/ui/textedit_area.py
+++ b/ballontranslator/ui/textedit_area.py
@@ -1,3 +1,6 @@
+import re
+import threading
+import traceback
 from typing import List, Union
 
 from qtpy.QtWidgets import QStackedWidget, QSizePolicy, QTextEdit, QScrollArea, QGraphicsDropShadowEffect, QVBoxLayout, QApplication, QHBoxLayout, QLabel, QLineEdit, QWidget, QPushButton
@@ -7,6 +10,7 @@ import numpy as np
 
 from .custom_widget import ScrollBar, Widget, SeparatorWidget
 from .textitem import TextBlock
+from ballontranslator.utils.config import pcfg
 from ballontranslator.ui.spellcheck import SpellCheckManager, SpellCheckHighlighter
 
 
@@ -75,7 +79,6 @@ class FloatingSuggestionLabel(QWidget):
 
     def eventFilter(self, watched, event):
         try:
-            from qtpy.QtCore import QEvent
             if event.type() == QEvent.Type.ApplicationDeactivate:
                 self.hide()
         except RuntimeError:
@@ -117,7 +120,6 @@ class FloatingSuggestionLabel(QWidget):
         if win:
             self.setStyleSheet(win.styleSheet())
         
-        from ballontranslator.utils.config import pcfg
         is_dark = pcfg.darkmode
         border_color = "rgba(255, 255, 255, 12%)" if is_dark else "rgba(0, 0, 0, 12%)"
         hover_bg = "rgba(255, 255, 255, 16%)" if is_dark else "rgba(0, 0, 0, 10%)"
@@ -267,12 +269,9 @@ class SourceTextEdit(QTextEdit):
 
     def on_selection_changed(self):
         try:
-            import re
-
             manager = SpellCheckManager.get_instance()
             if not manager.is_available():
                 return
-            from ballontranslator.utils.config import pcfg
             if not getattr(pcfg, 'spellcheck_enabled', True):
                 return
 
@@ -298,7 +297,6 @@ class SourceTextEdit(QTextEdit):
                         except Exception:
                             pass
                             
-                    import threading
                     t = threading.Thread(target=fetch_bg, args=(cursor, selected_text), daemon=True)
                     t.start()
                     return
@@ -307,7 +305,6 @@ class SourceTextEdit(QTextEdit):
                 self.suggestion_popup.hide()
             self.current_suggestion_word = None
         except Exception as e:
-            import traceback
             traceback.print_exc()
 
     def show_suggestions_popup(self, cursor, word, suggestions):
@@ -340,7 +337,6 @@ class SourceTextEdit(QTextEdit):
             self.suggestion_popup.move(global_pos)
             self.suggestion_popup.show()
         except Exception as e:
-            import traceback
             traceback.print_exc()
 
     def contextMenuEvent(self, event):

--- a/ballontranslator/ui/textedit_area.py
+++ b/ballontranslator/ui/textedit_area.py
@@ -286,9 +286,8 @@ class SourceTextEdit(QTextEdit):
                 return
 
             selected_text = cursor.selectedText().strip()
-            # Only suggest for a single word (optionally excluding CJK)
-            skip_cjk = getattr(pcfg, 'spellcheck_skip_cjk', True)
-            pattern = r'^[^\W\d_\u3040-\u309f\u30a0-\u30ff\u4e00-\u9fff\uac00-\ud7a3\u3400-\u4dbf]+$' if skip_cjk else r'^[^\W\d_]+$'
+            # Only suggest for a single word
+            pattern = r'^[^\W\d_]+$'
             if len(selected_text) > 1 and re.match(pattern, selected_text):
                 if not manager.is_correct(selected_text):
                     self.current_suggestion_word = selected_text

--- a/ballontranslator/ui/textedit_area.py
+++ b/ballontranslator/ui/textedit_area.py
@@ -243,38 +243,6 @@ class SourceTextEdit(QTextEdit):
         menu.setAttribute(Qt.WidgetAttribute.WA_DeleteOnClose)
         acts = menu.actions()
 
-        try:
-            # Spell suggestions integration
-            import re
-            from qtpy.QtWidgets import QAction
-            from qtpy.QtGui import QDesktopServices
-            from qtpy.QtCore import QUrl
-
-            pos = event.pos()
-            # Handle keyboard-triggered menu (where pos is negative)
-            if pos.x() < 0 or pos.y() < 0:
-                cursor = self.textCursor()
-            else:
-                cursor = self.cursorForPosition(pos)
-                
-            cursor.select(QTextCursor.SelectionType.WordUnderCursor)
-            selected_word = cursor.selectedText().strip()
-
-            if selected_word and len(selected_word) > 1:
-                first_act = acts[0] if acts else None
-
-                # Add Search Online action
-                search_act = QAction(self.tr("Search Online"), menu)
-                search_act.triggered.connect(lambda checked, w=selected_word: QDesktopServices.openUrl(QUrl(f"https://translate.google.com/?sl=auto&tl=ru&text={w}")))
-                if first_act:
-                    menu.insertAction(first_act, search_act)
-                    menu.insertSeparator(first_act)
-                else:
-                    menu.addAction(search_act)
-        except Exception as e:
-            import traceback
-            traceback.print_exc()
-
         self.in_acts = True
         rst = menu.exec_(event.globalPos())
 

--- a/ballontranslator/ui/textedit_area.py
+++ b/ballontranslator/ui/textedit_area.py
@@ -19,6 +19,7 @@ class FloatingSuggestionLabel(QWidget):
         super().__init__(editor, Qt.WindowType.ToolTip | Qt.WindowType.FramelessWindowHint)
         self.editor = editor
         self.setObjectName("suggestion_popup")
+        self.setAttribute(Qt.WidgetAttribute.WA_StyledBackground, True)
         
         # Inherit stylesheet dynamically from the parent MainWindow to respect light/dark themes
         win = self.editor.window()

--- a/ballontranslator/ui/textedit_area.py
+++ b/ballontranslator/ui/textedit_area.py
@@ -206,8 +206,8 @@ class SourceTextEdit(QTextEdit):
                 return
 
             selected_text = cursor.selectedText().strip()
-            # Only suggest for a single word
-            if len(selected_text) > 1 and re.match(r'^[^\W\d_]+$', selected_text):
+            # Only suggest for a single word (excluding CJK)
+            if len(selected_text) > 1 and re.match(r'^[^\W\d_\u3040-\u309f\u30a0-\u30ff\u4e00-\u9fff\uac00-\ud7a3\u3400-\u4dbf]+$', selected_text):
                 if not manager.is_correct(selected_text):
                     self.current_suggestion_word = selected_text
                     

--- a/ballontranslator/ui/textedit_area.py
+++ b/ballontranslator/ui/textedit_area.py
@@ -30,10 +30,10 @@ class FloatingSuggestionLabel(QWidget):
         self.main_layout.setContentsMargins(0, 0, 0, 0)
         self.main_layout.setSpacing(0)
         
-        # Horizontal scroll area
+        # Horizontal scroll area for suggestions only
         self.scroll_area = QScrollArea(self)
         self.scroll_area.setWidgetResizable(True)
-        self.scroll_area.setHorizontalScrollBarPolicy(Qt.ScrollBarPolicy.ScrollBarAlwaysOff)
+        self.scroll_area.setHorizontalScrollBarPolicy(Qt.ScrollBarPolicy.ScrollBarAsNeeded)
         self.scroll_area.setVerticalScrollBarPolicy(Qt.ScrollBarPolicy.ScrollBarAlwaysOff)
         self.scroll_area.setFixedHeight(28)
         self.scroll_area.wheelEvent = self.scroll_area_wheel_event
@@ -49,6 +49,15 @@ class FloatingSuggestionLabel(QWidget):
         self.scroll_area.setWidget(self.scroll_content)
         self.main_layout.addWidget(self.scroll_area)
         
+        # Add static "Add to Dict" button outside scroll area
+        self.add_dict_btn = QPushButton(self)
+        self.add_dict_btn.setObjectName("add_to_dict")
+        self.add_dict_btn.clicked.connect(self.add_to_dict)
+        self.add_dict_btn.setFixedHeight(28)
+        self.add_dict_btn.setMouseTracking(True)
+        self.add_dict_btn.setAttribute(Qt.WidgetAttribute.WA_Hover, True)
+        self.main_layout.addWidget(self.add_dict_btn)
+        
         shadow = QGraphicsDropShadowEffect(self)
         shadow.setBlurRadius(6)
         shadow.setColor(QColor(0, 0, 0, 150))
@@ -56,6 +65,13 @@ class FloatingSuggestionLabel(QWidget):
         self.setGraphicsEffect(shadow)
         
         self.hide()
+
+    def wheelEvent(self, event):
+        scrollbar = self.scroll_area.horizontalScrollBar()
+        if scrollbar:
+            delta = event.angleDelta().y() or event.angleDelta().x()
+            scrollbar.setValue(scrollbar.value() - delta // 2)
+            event.accept()
 
     def scroll_area_wheel_event(self, event):
         scrollbar = self.scroll_area.horizontalScrollBar()
@@ -76,6 +92,7 @@ class FloatingSuggestionLabel(QWidget):
         from ballontranslator.utils.config import pcfg
         is_dark = pcfg.darkmode
         border_color = "rgba(255, 255, 255, 12%)" if is_dark else "rgba(0, 0, 0, 12%)"
+        hover_bg = "rgba(255, 255, 255, 16%)" if is_dark else "rgba(0, 0, 0, 10%)"
         
         while self.buttons_layout.count() > 0:
             item = self.buttons_layout.takeAt(0)
@@ -89,25 +106,61 @@ class FloatingSuggestionLabel(QWidget):
             self.buttons_layout.addWidget(btn)
             
             # Stylize borders and round corners so they form a single seamless block
-            border_right = f"1px solid {border_color}"
+            border_right = "none" if i == len(suggestions) - 1 else f"1px solid {border_color}"
             left_radius = "4px" if i == 0 else "0px"
-            btn.setStyleSheet(f"border: none; border-right: {border_right}; border-top-left-radius: {left_radius}; border-bottom-left-radius: {left_radius}; border-top-right-radius: 0px; border-bottom-right-radius: 0px;")
+            btn.setStyleSheet(f"""
+                QPushButton {{
+                    border: none;
+                    border-right: {border_right};
+                    border-top-left-radius: {left_radius};
+                    border-bottom-left-radius: {left_radius};
+                    border-top-right-radius: 0px;
+                    border-bottom-right-radius: 0px;
+                    background-color: transparent;
+                }}
+                QPushButton:hover {{
+                    background-color: {hover_bg};
+                }}
+            """)
 
-        # Add "Add to Dict" button at the end
-        add_dict_btn = QPushButton(f"+ {self.tr('Add')}", self.scroll_content)
-        add_dict_btn.setObjectName("add_to_dict")
-        add_dict_btn.clicked.connect(self.add_to_dict)
-        self.buttons_layout.addWidget(add_dict_btn)
-
+        # Update static Add button
+        self.add_dict_btn.setText(f"+ {self.tr('Add')}")
         left_radius = "4px" if len(suggestions) == 0 else "0px"
-        add_dict_btn.setStyleSheet(f"border: none; border-top-left-radius: {left_radius}; border-bottom-left-radius: {left_radius}; border-top-right-radius: 4px; border-bottom-right-radius: 4px;")
+        border_left = "none" if len(suggestions) == 0 else f"1px solid {border_color}"
+        self.add_dict_btn.setStyleSheet(f"""
+            QPushButton#add_to_dict {{
+                border: none;
+                border-left: {border_left};
+                border-top-left-radius: {left_radius};
+                border-bottom-left-radius: {left_radius};
+                border-top-right-radius: 4px;
+                border-bottom-right-radius: 4px;
+                background-color: transparent;
+                color: #4caf50;
+            }}
+            QPushButton#add_to_dict:hover {{
+                background-color: #4caf50;
+                color: #ffffff;
+            }}
+        """)
             
         self.scroll_content.adjustSize()
-        total_width = self.scroll_content.width()
+        suggestions_width = self.scroll_content.width()
         
-        # Max width is 250px, if more we scroll
-        popup_width = min(total_width, 250)
-        self.scroll_area.setFixedWidth(popup_width)
+        self.add_dict_btn.adjustSize()
+        add_btn_width = self.add_dict_btn.width()
+        self.add_dict_btn.setFixedWidth(add_btn_width)
+        
+        # Calculate horizontal sizes
+        scroll_area_width = min(suggestions_width, 180) if len(suggestions) > 0 else 0
+        self.scroll_area.setFixedWidth(scroll_area_width)
+        
+        if len(suggestions) == 0:
+            self.scroll_area.hide()
+        else:
+            self.scroll_area.show()
+            
+        popup_width = scroll_area_width + add_btn_width
         self.setFixedSize(popup_width, 28)
         
     def apply_suggestion(self, replacement):

--- a/ballontranslator/ui/textedit_area.py
+++ b/ballontranslator/ui/textedit_area.py
@@ -64,7 +64,34 @@ class FloatingSuggestionLabel(QWidget):
         shadow.setOffset(0, 2)
         self.setGraphicsEffect(shadow)
         
+        # Hide the suggestion popup automatically when application focus changes
+        app = QApplication.instance()
+        if app:
+            app.focusChanged.connect(self.on_focus_changed)
+            app.installEventFilter(self)
+            
         self.hide()
+
+    def eventFilter(self, watched, event):
+        try:
+            from qtpy.QtCore import QEvent
+            if event.type() == QEvent.Type.ApplicationDeactivate:
+                self.hide()
+        except RuntimeError:
+            pass
+        return super().eventFilter(watched, event)
+
+    def on_focus_changed(self, old_widget, new_widget):
+        try:
+            if not new_widget:
+                # Application lost focus (user switched to another application)
+                self.hide()
+            elif new_widget is not self.editor and not self.isAncestorOf(new_widget):
+                # User focused another widget within our application
+                self.hide()
+        except RuntimeError:
+            # Widget or editor might be partially deleted/garbage collected during teardown
+            pass
 
     def wheelEvent(self, event):
         scrollbar = self.scroll_area.horizontalScrollBar()
@@ -259,8 +286,10 @@ class SourceTextEdit(QTextEdit):
                 return
 
             selected_text = cursor.selectedText().strip()
-            # Only suggest for a single word (excluding CJK)
-            if len(selected_text) > 1 and re.match(r'^[^\W\d_\u3040-\u309f\u30a0-\u30ff\u4e00-\u9fff\uac00-\ud7a3\u3400-\u4dbf]+$', selected_text):
+            # Only suggest for a single word (optionally excluding CJK)
+            skip_cjk = getattr(pcfg, 'spellcheck_skip_cjk', True)
+            pattern = r'^[^\W\d_\u3040-\u309f\u30a0-\u30ff\u4e00-\u9fff\uac00-\ud7a3\u3400-\u4dbf]+$' if skip_cjk else r'^[^\W\d_]+$'
+            if len(selected_text) > 1 and re.match(pattern, selected_text):
                 if not manager.is_correct(selected_text):
                     self.current_suggestion_word = selected_text
                     

--- a/ballontranslator/ui/textedit_area.py
+++ b/ballontranslator/ui/textedit_area.py
@@ -20,6 +20,11 @@ class FloatingSuggestionLabel(QWidget):
         self.editor = editor
         self.setObjectName("suggestion_popup")
         
+        # Inherit stylesheet dynamically from the parent MainWindow to respect light/dark themes
+        win = self.editor.window()
+        if win:
+            self.setStyleSheet(win.styleSheet())
+        
         self.main_layout = QHBoxLayout(self)
         self.main_layout.setContentsMargins(0, 0, 0, 0)
         self.main_layout.setSpacing(0)
@@ -61,6 +66,11 @@ class FloatingSuggestionLabel(QWidget):
     def set_suggestions(self, cursor, word, suggestions):
         self.cursor = cursor
         self.word = word
+        
+        # Refresh stylesheet to match the current theme
+        win = self.editor.window()
+        if win:
+            self.setStyleSheet(win.styleSheet())
         
         while self.buttons_layout.count() > 0:
             item = self.buttons_layout.takeAt(0)

--- a/ballontranslator/ui/textedit_area.py
+++ b/ballontranslator/ui/textedit_area.py
@@ -195,7 +195,7 @@ class FloatingSuggestionLabel(QWidget):
         self.hide()
 
     def add_to_dict(self):
-        from ballontranslator.utils.spellcheck import SpellCheckManager
+        from ballontranslator.ui.spellcheck import SpellCheckManager
         SpellCheckManager.get_instance().add_to_dictionary(self.word)
         self.hide()
 
@@ -237,8 +237,8 @@ class SourceTextEdit(QTextEdit):
 
         self.min_height = 45
         self.setFold(fold)
-        from ballontranslator.utils.spellcheck import SpellCheckHighlighter
-        self.spell_highlighter = SpellCheckHighlighter(self.document())
+        from ballontranslator.ui.spellcheck import SpellCheckHighlighter
+        self.spell_highlighter = SpellCheckHighlighter(self)
         self.selectionChanged.connect(self.on_selection_changed)
         self.suggestion_popup = None
         self.suggestions_ready.connect(self.show_suggestions_popup)
@@ -268,7 +268,7 @@ class SourceTextEdit(QTextEdit):
 
     def on_selection_changed(self):
         try:
-            from ballontranslator.utils.spellcheck import SpellCheckManager
+            from ballontranslator.ui.spellcheck import SpellCheckManager
             import re
 
             manager = SpellCheckManager.get_instance()

--- a/ballontranslator/ui/textedit_area.py
+++ b/ballontranslator/ui/textedit_area.py
@@ -7,6 +7,7 @@ import numpy as np
 
 from .custom_widget import ScrollBar, Widget, SeparatorWidget
 from .textitem import TextBlock
+from ballontranslator.ui.spellcheck import SpellCheckManager, SpellCheckHighlighter
 
 
 STYLE_TRANSPAIR_CHECKED = "background-color: rgba(30, 147, 229, 20%);"
@@ -195,7 +196,6 @@ class FloatingSuggestionLabel(QWidget):
         self.hide()
 
     def add_to_dict(self):
-        from ballontranslator.ui.spellcheck import SpellCheckManager
         SpellCheckManager.get_instance().add_to_dictionary(self.word)
         self.hide()
 
@@ -237,7 +237,6 @@ class SourceTextEdit(QTextEdit):
 
         self.min_height = 45
         self.setFold(fold)
-        from ballontranslator.ui.spellcheck import SpellCheckHighlighter
         self.spell_highlighter = SpellCheckHighlighter(self)
         self.selectionChanged.connect(self.on_selection_changed)
         self.suggestion_popup = None
@@ -268,7 +267,6 @@ class SourceTextEdit(QTextEdit):
 
     def on_selection_changed(self):
         try:
-            from ballontranslator.ui.spellcheck import SpellCheckManager
             import re
 
             manager = SpellCheckManager.get_instance()

--- a/ballontranslator/ui/textedit_area.py
+++ b/ballontranslator/ui/textedit_area.py
@@ -1,6 +1,6 @@
 from typing import List, Union
 
-from qtpy.QtWidgets import QStackedWidget, QSizePolicy, QTextEdit, QScrollArea, QGraphicsDropShadowEffect, QVBoxLayout, QApplication, QHBoxLayout, QSizePolicy, QLabel, QLineEdit
+from qtpy.QtWidgets import QStackedWidget, QSizePolicy, QTextEdit, QScrollArea, QGraphicsDropShadowEffect, QVBoxLayout, QApplication, QHBoxLayout, QLabel, QLineEdit, QWidget, QPushButton
 from qtpy.QtCore import Signal, Qt, QMimeData, QEvent, QPoint, QSize
 from qtpy.QtGui import QIntValidator, QColor, QFocusEvent, QInputMethodEvent, QDragEnterEvent, QDropEvent, QKeyEvent, QTextCursor, QMouseEvent, QDrag, QPixmap
 import numpy as np
@@ -12,6 +12,118 @@ from .textitem import TextBlock
 STYLE_TRANSPAIR_CHECKED = "background-color: rgba(30, 147, 229, 20%);"
 STYLE_TRANSPAIR_BOTTOM = "border-width: 5px; border-bottom-style: solid; border-color: rgb(30, 147, 229);"
 STYLE_TRANSPAIR_TOP = "border-width: 5px; border-top-style: solid; border-color: rgb(30, 147, 229);"
+
+
+class FloatingSuggestionLabel(QWidget):
+    def __init__(self, editor):
+        super().__init__(editor.viewport())
+        self.editor = editor
+        self.setObjectName("suggestion_popup")
+        
+        # Segmented tab style: dark background, border, zero margins/padding between buttons
+        self.setStyleSheet("""
+            QWidget#suggestion_popup {
+                background-color: #2b2b2d;
+                border: 1px solid #45474a;
+                border-radius: 4px;
+            }
+            QScrollArea {
+                border: none;
+                background: transparent;
+            }
+        """)
+        
+        self.main_layout = QHBoxLayout(self)
+        self.main_layout.setContentsMargins(0, 0, 0, 0)
+        self.main_layout.setSpacing(0)
+        
+        # Horizontal scroll area
+        self.scroll_area = QScrollArea(self)
+        self.scroll_area.setWidgetResizable(True)
+        self.scroll_area.setHorizontalScrollBarPolicy(Qt.ScrollBarPolicy.ScrollBarAlwaysOff)
+        self.scroll_area.setVerticalScrollBarPolicy(Qt.ScrollBarPolicy.ScrollBarAlwaysOff)
+        self.scroll_area.setFixedHeight(28)
+        self.scroll_area.wheelEvent = self.scroll_area_wheel_event
+        
+        self.scroll_content = QWidget()
+        self.scroll_content.setObjectName("scroll_content")
+        self.scroll_content.setStyleSheet("background: transparent;")
+        
+        self.buttons_layout = QHBoxLayout(self.scroll_content)
+        self.buttons_layout.setContentsMargins(0, 0, 0, 0)
+        self.buttons_layout.setSpacing(0)
+        
+        self.scroll_area.setWidget(self.scroll_content)
+        self.main_layout.addWidget(self.scroll_area)
+        
+        shadow = QGraphicsDropShadowEffect(self)
+        shadow.setBlurRadius(6)
+        shadow.setColor(QColor(0, 0, 0, 150))
+        shadow.setOffset(0, 2)
+        self.setGraphicsEffect(shadow)
+        
+        self.hide()
+
+    def scroll_area_wheel_event(self, event):
+        scrollbar = self.scroll_area.horizontalScrollBar()
+        if scrollbar:
+            delta = event.angleDelta().y() or event.angleDelta().x()
+            scrollbar.setValue(scrollbar.value() - delta // 2)
+            event.accept()
+
+    def set_suggestions(self, cursor, word, suggestions):
+        self.cursor = cursor
+        self.word = word
+        
+        while self.buttons_layout.count() > 0:
+            item = self.buttons_layout.takeAt(0)
+            w = item.widget()
+            if w:
+                w.deleteLater()
+                
+        for i, sug in enumerate(suggestions):
+            btn = QPushButton(sug, self.scroll_content)
+            btn.clicked.connect(lambda checked=False, s=sug: self.apply_suggestion(s))
+            self.buttons_layout.addWidget(btn)
+            
+            # Stylize borders and round corners so they form a single seamless block
+            border_right = "1px solid #45474a" if i < len(suggestions) - 1 else "none"
+            left_radius = "4px" if i == 0 else "0px"
+            right_radius = "4px" if i == len(suggestions) - 1 else "0px"
+            
+            btn.setStyleSheet(f"""
+                QPushButton {{
+                    background-color: #3b3d40;
+                    color: #ffffff;
+                    border: none;
+                    border-right: {border_right};
+                    border-top-left-radius: {left_radius};
+                    border-bottom-left-radius: {left_radius};
+                    border-top-right-radius: {right_radius};
+                    border-bottom-right-radius: {right_radius};
+                    padding: 0px 12px;
+                    height: 28px;
+                    font-family: 'Segoe UI', Arial, sans-serif;
+                    font-size: 11px;
+                    font-weight: bold;
+                }}
+                QPushButton:hover {{
+                    background-color: #1e93e5;
+                    color: #ffffff;
+                }}
+            """)
+            
+        self.scroll_content.adjustSize()
+        total_width = self.scroll_content.width()
+        
+        # Max width is 250px, if more we scroll
+        popup_width = min(total_width, 250)
+        self.scroll_area.setFixedWidth(popup_width)
+        self.setFixedSize(popup_width, 28)
+        
+    def apply_suggestion(self, replacement):
+        self.editor._replace_word(self.cursor, replacement)
+        self.hide()
 
 
 class SourceTextEdit(QTextEdit):
@@ -50,6 +162,10 @@ class SourceTextEdit(QTextEdit):
 
         self.min_height = 45
         self.setFold(fold)
+        from ballontranslator.utils.spellcheck import SpellCheckHighlighter
+        self.spell_highlighter = SpellCheckHighlighter(self.document())
+        self.selectionChanged.connect(self.on_selection_changed)
+        self.suggestion_popup = None
 
     def setFold(self, fold: bool):
         if fold:
@@ -60,10 +176,144 @@ class SourceTextEdit(QTextEdit):
             self.setLineWrapMode(QTextEdit.LineWrapMode.WidgetWidth)
             
 
+    def _replace_word(self, cursor, replacement):
+        self.setFocus()
+        tc = self.textCursor()
+        tc.beginEditBlock()
+        tc.setPosition(cursor.selectionStart())
+        tc.setPosition(cursor.selectionEnd(), QTextCursor.MoveMode.KeepAnchor)
+        tc.insertText(replacement)
+        tc.endEditBlock()
+
+    def on_selection_changed(self):
+        try:
+            from ballontranslator.utils.spellcheck import SpellCheckManager
+            import re
+
+            manager = SpellCheckManager.get_instance()
+            if not manager.is_available():
+                return
+            from ballontranslator.utils.config import pcfg
+            if not getattr(pcfg, 'spellcheck_enabled', True):
+                return
+
+            cursor = self.textCursor()
+            if not cursor.hasSelection():
+                if hasattr(self, 'suggestion_popup') and self.suggestion_popup:
+                    self.suggestion_popup.hide()
+                return
+
+            selected_text = cursor.selectedText().strip()
+            # Only suggest for a single word
+            if len(selected_text) > 1 and re.match(r'^[a-zA-Zа-яА-ЯёЁ]+$', selected_text):
+                if not manager.is_correct(selected_text):
+                    suggestions = manager.get_suggestions(selected_text)
+                    if suggestions:
+                        if not self.suggestion_popup:
+                            self.suggestion_popup = FloatingSuggestionLabel(self)
+                        
+                        self.suggestion_popup.set_suggestions(cursor, selected_text, suggestions)
+                        self.suggestion_popup.adjustSize()
+                        
+                        rect = self.cursorRect()
+                        
+                        # Position above the selection inside the editor viewport
+                        px = rect.left() + (rect.width() - self.suggestion_popup.width()) // 2
+                        py = rect.top() - self.suggestion_popup.height() - 4
+                        
+                        # Guard boundaries
+                        # If it goes off the top of the viewport, show it below the cursor
+                        if py < 0:
+                            py = rect.bottom() + 4
+                            
+                        px = max(5, min(px, self.viewport().width() - self.suggestion_popup.width() - 5))
+                        
+                        self.suggestion_popup.move(px, py)
+                        self.suggestion_popup.show()
+                        return
+
+            if hasattr(self, 'suggestion_popup') and self.suggestion_popup:
+                self.suggestion_popup.hide()
+        except Exception as e:
+            import traceback
+            traceback.print_exc()
+
     def contextMenuEvent(self, event):
         menu = self.createStandardContextMenu()
         menu.setAttribute(Qt.WidgetAttribute.WA_DeleteOnClose)
         acts = menu.actions()
+
+        try:
+            # Spell suggestions integration
+            from ballontranslator.utils.spellcheck import SpellCheckManager
+            import re
+            from qtpy.QtWidgets import QAction
+            from qtpy.QtGui import QDesktopServices
+            from qtpy.QtCore import QUrl
+
+            manager = SpellCheckManager.get_instance()
+            pos = event.pos()
+            # Handle keyboard-triggered menu (where pos is negative)
+            if pos.x() < 0 or pos.y() < 0:
+                cursor = self.textCursor()
+            else:
+                cursor = self.cursorForPosition(pos)
+                
+            cursor.select(QTextCursor.SelectionType.WordUnderCursor)
+            selected_word = cursor.selectedText().strip()
+
+            if selected_word and len(selected_word) > 1:
+                first_act = acts[0] if acts else None
+
+                # Add Search Online action
+                search_act = QAction(self.tr("Search Online"), menu)
+                search_act.triggered.connect(lambda checked, w=selected_word: QDesktopServices.openUrl(QUrl(f"https://translate.google.com/?sl=auto&tl=ru&text={w}")))
+                if first_act:
+                    menu.insertAction(first_act, search_act)
+                    menu.insertSeparator(first_act)
+                else:
+                    menu.addAction(search_act)
+
+                # Check spelling suggestions
+                is_misspelled = False
+                if manager.is_available() and re.match(r'^[a-zA-Zа-яА-ЯёЁ]+$', selected_word):
+                    is_misspelled = not manager.is_correct(selected_word)
+
+                if is_misspelled:
+                    suggestions = manager.get_suggestions(selected_word)
+
+                    # Add suggestions
+                    if suggestions:
+                        for sug in suggestions:
+                            sug_act = QAction(sug, menu)
+                            sug_act.triggered.connect(lambda checked, s=sug, c=cursor: self._replace_word(c, s))
+                            font = sug_act.font()
+                            font.setBold(True)
+                            sug_act.setFont(font)
+                            if first_act:
+                                menu.insertAction(first_act, sug_act)
+                            else:
+                                menu.addAction(sug_act)
+                    else:
+                        no_sug_act = QAction(self.tr("No spelling suggestions"), menu)
+                        no_sug_act.setEnabled(False)
+                        if first_act:
+                            menu.insertAction(first_act, no_sug_act)
+                        else:
+                            menu.addAction(no_sug_act)
+
+                    # Add to Dictionary action
+                    add_dict_act = QAction(self.tr("Add to Dictionary"), menu)
+                    add_dict_act.triggered.connect(lambda checked, w=selected_word: manager.add_to_dictionary(w))
+                    if first_act:
+                        menu.insertAction(first_act, add_dict_act)
+                        menu.insertSeparator(first_act)
+                    else:
+                        menu.addAction(add_dict_act)
+        except Exception as e:
+            import traceback
+            traceback.print_exc()
+
         self.in_acts = True
         rst = menu.exec_(event.globalPos())
 
@@ -166,7 +416,14 @@ class SourceTextEdit(QTextEdit):
     def focusOutEvent(self, event: QFocusEvent) -> None:
         self.setHoverEffect(False)
         self.focus_out.emit(self.idx)
+        if hasattr(self, 'suggestion_popup') and self.suggestion_popup:
+            self.suggestion_popup.hide()
         return super().focusOutEvent(event)
+
+    def wheelEvent(self, event) -> None:
+        if hasattr(self, 'suggestion_popup') and self.suggestion_popup:
+            self.suggestion_popup.hide()
+        return super().wheelEvent(event)
 
     def inputMethodEvent(self, e: QInputMethodEvent) -> None:
         if self.pre_editing is False:

--- a/ballontranslator/ui/textedit_area.py
+++ b/ballontranslator/ui/textedit_area.py
@@ -16,7 +16,7 @@ STYLE_TRANSPAIR_TOP = "border-width: 5px; border-top-style: solid; border-color:
 
 class FloatingSuggestionLabel(QWidget):
     def __init__(self, editor):
-        super().__init__(editor.viewport())
+        super().__init__(editor, Qt.WindowType.ToolTip | Qt.WindowType.FramelessWindowHint)
         self.editor = editor
         self.setObjectName("suggestion_popup")
         
@@ -228,7 +228,10 @@ class SourceTextEdit(QTextEdit):
                             
                         px = max(5, min(px, self.viewport().width() - self.suggestion_popup.width() - 5))
                         
-                        self.suggestion_popup.move(px, py)
+                        # Map viewport local coordinates to global screen coordinates
+                        global_pos = self.viewport().mapToGlobal(QPoint(px, py))
+                        
+                        self.suggestion_popup.move(global_pos)
                         self.suggestion_popup.show()
                         return
 

--- a/ballontranslator/utils/config.py
+++ b/ballontranslator/utils/config.py
@@ -140,6 +140,9 @@ class ProgramConfig(Config):
     original_transparency: float = 0.
     open_recent_on_startup: bool = True 
     check_update_on_startup: bool = True
+    spellcheck_enabled: bool = True
+    spellcheck_external_dict_path: str = ""
+    spellcheck_repo_dicts: str = ""
 
     let_fntsize_flag: int = 0
     let_fntstroke_flag: int = 0

--- a/ballontranslator/utils/config.py
+++ b/ballontranslator/utils/config.py
@@ -144,7 +144,6 @@ class ProgramConfig(Config):
     spellcheck_external_dict_path: str = ""
     spellcheck_repo_dicts: str = ""
     spellcheck_distance: int = 1
-    spellcheck_skip_cjk: bool = True
 
     let_fntsize_flag: int = 0
     let_fntstroke_flag: int = 0

--- a/ballontranslator/utils/config.py
+++ b/ballontranslator/utils/config.py
@@ -144,6 +144,7 @@ class ProgramConfig(Config):
     spellcheck_external_dict_path: str = ""
     spellcheck_repo_dicts: str = ""
     spellcheck_distance: int = 1
+    spellcheck_on_source_enabled: bool = False
 
     let_fntsize_flag: int = 0
     let_fntstroke_flag: int = 0

--- a/ballontranslator/utils/config.py
+++ b/ballontranslator/utils/config.py
@@ -143,6 +143,7 @@ class ProgramConfig(Config):
     spellcheck_enabled: bool = True
     spellcheck_external_dict_path: str = ""
     spellcheck_repo_dicts: str = ""
+    spellcheck_distance: int = 1
 
     let_fntsize_flag: int = 0
     let_fntstroke_flag: int = 0

--- a/ballontranslator/utils/config.py
+++ b/ballontranslator/utils/config.py
@@ -144,6 +144,7 @@ class ProgramConfig(Config):
     spellcheck_external_dict_path: str = ""
     spellcheck_repo_dicts: str = ""
     spellcheck_distance: int = 1
+    spellcheck_skip_cjk: bool = True
 
     let_fntsize_flag: int = 0
     let_fntstroke_flag: int = 0

--- a/ballontranslator/utils/py_package_manager.py
+++ b/ballontranslator/utils/py_package_manager.py
@@ -36,6 +36,7 @@ DEFAULT_PACKAGE_IMPORT_NAMES = {
     'pyobjc-framework-coreml': ['CoreML'],
     'pyobjc-framework-quartz': ['Quartz'],
     'pyyaml': ['yaml'],
+    'pyspellchecker': ['spellchecker'],
     'spacy-pkuseg': ['spacy_pkuseg'],
 }
 

--- a/ballontranslator/utils/spellcheck.py
+++ b/ballontranslator/utils/spellcheck.py
@@ -130,24 +130,39 @@ class SpellCheckManager:
             hl.clear_cache()
 
     def load_spellchecker_async(self):
+        from ballontranslator.utils.config import pcfg
+        from ballontranslator.utils.logger import logger as LOGGER
+
+        if not getattr(pcfg, 'spellcheck_enabled', True):
+            if self.spell is not None or self.external_words:
+                self.spell = None
+                self.external_words = set()
+                LOGGER.info("Spell Checker is disabled. Unloaded dictionaries.")
+                for hl in list(self.highlighters):
+                    hl.clear_cache()
+                    hl.rehighlight()
+            return
+
         import threading
         if hasattr(self, '_loading_thread') and self._loading_thread and self._loading_thread.is_alive():
             return
 
         def bg_load():
+            if not getattr(pcfg, 'spellcheck_enabled', True):
+                self.spell = None
+                self.external_words = set()
+                return
+
             if self.spell is None:
                 try:
                     from spellchecker import SpellChecker
                     self.spell = SpellChecker(language=['en', 'ru'], distance=1)
-                    from ballontranslator.utils.logger import logger as LOGGER
                     LOGGER.info("SpellChecker initialized in background")
                 except Exception as e:
-                    from ballontranslator.utils.logger import logger as LOGGER
                     LOGGER.error(f"Failed to load SpellChecker in background: {e}")
 
             temp_words = set()
             try:
-                from ballontranslator.utils.config import pcfg
                 repo_dicts = getattr(pcfg, 'spellcheck_repo_dicts', '').split(',')
                 loaded_repos = 0
                 for dict_name in repo_dicts:
@@ -166,13 +181,17 @@ class SpellCheckManager:
                         self._parse_and_load_file_to_set(path, temp_words)
                         loaded_externals += 1
 
-                from ballontranslator.utils.logger import logger as LOGGER
+                if not getattr(pcfg, 'spellcheck_enabled', True):
+                    self.spell = None
+                    self.external_words = set()
+                    LOGGER.info("Spell Checker is disabled. Cancelled dictionary loading.")
+                    return
+
                 LOGGER.info(
                     f"SpellCheckManager: loaded {len(temp_words)} words in background "
                     f"(from {loaded_repos} repo dictionaries, {loaded_externals} external dictionaries)"
                 )
             except Exception as e:
-                from ballontranslator.utils.logger import logger as LOGGER
                 LOGGER.error(f"Error loading dictionaries in background: {e}")
 
             self.external_words = temp_words

--- a/ballontranslator/utils/spellcheck.py
+++ b/ballontranslator/utils/spellcheck.py
@@ -374,8 +374,8 @@ class SpellCheckHighlighter(QSyntaxHighlighter):
         if not self.manager.is_available():
             return
 
-        # Pattern matches words in English and Russian
-        for match in re.finditer(r'\b[a-zA-Zа-яА-ЯёЁ]+\b', text):
+        # Pattern matches words in any language using Unicode character classes
+        for match in re.finditer(r'\b[^\W\d_]+\b', text):
             word = match.group(0)
             if len(word) <= 1:
                 continue

--- a/ballontranslator/utils/spellcheck.py
+++ b/ballontranslator/utils/spellcheck.py
@@ -374,8 +374,8 @@ class SpellCheckHighlighter(QSyntaxHighlighter):
         if not self.manager.is_available():
             return
 
-        # Pattern matches words in any language using Unicode character classes
-        for match in re.finditer(r'\b[^\W\d_]+\b', text):
+        # Pattern matches words in any language using Unicode character classes (excluding CJK)
+        for match in re.finditer(r'\b[^\W\d_\u3040-\u309f\u30a0-\u30ff\u4e00-\u9fff\uac00-\ud7a3\u3400-\u4dbf]+\b', text):
             word = match.group(0)
             if len(word) <= 1:
                 continue

--- a/ballontranslator/utils/spellcheck.py
+++ b/ballontranslator/utils/spellcheck.py
@@ -345,8 +345,17 @@ class SpellCheckHighlighter(QSyntaxHighlighter):
 
     def clear_cache(self):
         self._cache.clear()
-        if self.document():
-            self.rehighlight()
+        try:
+            if self.document():
+                self.rehighlight()
+        except RuntimeError:
+            pass
+
+    def rehighlight(self):
+        try:
+            super().rehighlight()
+        except RuntimeError:
+            pass
 
     def highlightBlock(self, text):
         from ballontranslator.utils.config import pcfg

--- a/ballontranslator/utils/spellcheck.py
+++ b/ballontranslator/utils/spellcheck.py
@@ -1,0 +1,295 @@
+import os
+import re
+import weakref
+from typing import List, Set
+from qtpy.QtGui import QSyntaxHighlighter, QTextCharFormat, QColor
+from qtpy.QtCore import Qt
+
+from . import shared
+
+class SpellCheckManager:
+    """SpellCheckManager manages spell checking, custom dictionaries, and suggestion retrieval.
+
+    >>> manager = SpellCheckManager.get_instance()
+    >>> isinstance(manager, SpellCheckManager)
+    True
+    """
+    _instance = None
+
+    @classmethod
+    def get_instance(cls):
+        if cls._instance is None:
+            cls._instance = cls()
+        return cls._instance
+
+    def __init__(self):
+        self.spell = None
+        self.custom_words: Set[str] = set()
+        self.external_words: Set[str] = set()
+        self.highlighters = weakref.WeakSet()
+        self.dict_path = os.path.join(shared.PROGRAM_PATH, 'config', 'custom_dictionary.txt')
+        self._load_custom_dictionary()
+        self.load_external_dictionary()
+
+    def _load_custom_dictionary(self):
+        """Loads custom user-added words from local storage.
+
+        >>> manager = SpellCheckManager.get_instance()
+        >>> manager._load_custom_dictionary()
+        """
+        if os.path.exists(self.dict_path):
+            try:
+                with open(self.dict_path, 'r', encoding='utf-8') as f:
+                    for line in f:
+                        word = line.strip().lower()
+                        if word:
+                            self.custom_words.add(word)
+            except Exception as e:
+                print(f"Error loading custom dictionary: {e}")
+
+    def _save_custom_dictionary(self):
+        """Saves custom user-added words to local storage.
+
+        >>> manager = SpellCheckManager.get_instance()
+        >>> manager._save_custom_dictionary()
+        """
+        try:
+            os.makedirs(os.path.dirname(self.dict_path), exist_ok=True)
+            with open(self.dict_path, 'w', encoding='utf-8') as f:
+                for word in sorted(self.custom_words):
+                    f.write(word + '\n')
+        except Exception as e:
+            print(f"Error saving custom dictionary: {e}")
+
+    def _parse_and_load_file(self, path):
+        try:
+            try:
+                with open(path, 'r', encoding='utf-8') as f:
+                    lines = f.readlines()
+            except UnicodeDecodeError:
+                with open(path, 'r', encoding='cp1251', errors='ignore') as f:
+                    lines = f.readlines()
+
+            for line in lines:
+                line = line.strip()
+                if not line or line.startswith('#'):
+                    continue
+                if '/' in line:
+                    word = line.split('/', 1)[0].strip().lower()
+                else:
+                    word = line.lower()
+                if word.isdigit():
+                    continue
+                if word:
+                    self.external_words.add(word)
+        except Exception as e:
+            from ballontranslator.utils.logger import logger as LOGGER
+            LOGGER.error(f"Error reading dictionary file {path}: {e}")
+
+    def load_external_dictionary(self):
+        """Loads external and repository dictionary files specified in program config.
+
+        >>> manager = SpellCheckManager.get_instance()
+        >>> manager.load_external_dictionary()
+        """
+        self.external_words.clear()
+        try:
+            from ballontranslator.utils.config import pcfg
+            
+            # Load enabled repository dictionaries
+            repo_dicts = getattr(pcfg, 'spellcheck_repo_dicts', '').split(',')
+            loaded_repos = 0
+            for dict_name in repo_dicts:
+                dict_name = dict_name.strip()
+                if dict_name:
+                    dict_path = os.path.join(shared.PROGRAM_PATH, 'data', 'dictionaries', dict_name)
+                    if os.path.exists(dict_path):
+                        self._parse_and_load_file(dict_path)
+                        loaded_repos += 1
+            
+            # Load multiple external dictionaries
+            ext_paths = getattr(pcfg, 'spellcheck_external_dict_path', '').split(';')
+            loaded_externals = 0
+            for path in ext_paths:
+                path = path.strip()
+                if path and os.path.exists(path):
+                    self._parse_and_load_file(path)
+                    loaded_externals += 1
+                    
+            from ballontranslator.utils.logger import logger as LOGGER
+            LOGGER.info(
+                f"SpellCheckManager: loaded {len(self.external_words)} words "
+                f"(from {loaded_repos} repo dictionaries, {loaded_externals} external dictionaries)"
+            )
+        except Exception as e:
+            from ballontranslator.utils.logger import logger as LOGGER
+            LOGGER.error(f"Error loading dictionaries: {e}")
+            
+        for hl in list(self.highlighters):
+            hl.clear_cache()
+
+    def is_available(self) -> bool:
+        """Checks if the required pyspellchecker package is installed.
+
+        >>> manager = SpellCheckManager.get_instance()
+        >>> isinstance(manager.is_available(), bool)
+        True
+        """
+        try:
+            import spellchecker
+            return True
+        except ImportError:
+            return False
+
+    def load_spellchecker(self):
+        """Initializes the underlying SpellChecker instance with default dictionaries.
+
+        >>> manager = SpellCheckManager.get_instance()
+        >>> manager.load_spellchecker()
+        """
+        if self.spell is not None:
+            return
+        
+        try:
+            from spellchecker import SpellChecker
+            # Load English and Russian dictionaries with fast distance=1
+            self.spell = SpellChecker(language=['en', 'ru'], distance=1)
+            from ballontranslator.utils.logger import logger as LOGGER
+            LOGGER.info("SpellChecker initialized with languages: en, ru (distance=1)")
+        except Exception as e:
+            from ballontranslator.utils.logger import logger as LOGGER
+            LOGGER.error(f"Failed to load SpellChecker: {e}")
+            self.spell = None
+
+    def is_correct(self, word: str) -> bool:
+        """Checks if a given word is correctly spelled.
+
+        >>> manager = SpellCheckManager.get_instance()
+        >>> manager.is_correct("hello") in (True, False)
+        True
+        """
+        word_lower = word.lower()
+        if word_lower in self.custom_words or word_lower in self.external_words:
+            return True
+        
+        # If it contains digits or special chars, ignore it
+        if not word_lower.isalpha():
+            return True
+
+        if self.spell is None:
+            self.load_spellchecker()
+            if self.spell is None:
+                return True # If spellchecker cannot be loaded, assume correct
+
+        # pyspellchecker: known returns words that are in the dictionary
+        try:
+            return bool(self.spell.known([word_lower]))
+        except Exception:
+            return True
+
+    def get_suggestions(self, word: str) -> List[str]:
+        """Gets spelling suggestions for a misspelled word.
+
+        >>> manager = SpellCheckManager.get_instance()
+        >>> isinstance(manager.get_suggestions("helo"), list)
+        True
+        """
+        if len(word) > 15:
+            return []
+
+        if self.spell is None:
+            self.load_spellchecker()
+            if self.spell is None:
+                return []
+        
+        word_lower = word.lower()
+        try:
+            candidates = self.spell.candidates(word_lower)
+        except Exception:
+            return []
+        if not candidates:
+            return []
+        
+        # Sort or filter if needed, limit to 5
+        suggestions = list(candidates)[:5]
+        
+        # Match casing if possible (e.g. capitalized)
+        if word.istitle():
+            suggestions = [s.capitalize() for s in suggestions]
+        elif word.isupper():
+            suggestions = [s.upper() for s in suggestions]
+            
+        return suggestions
+
+    def add_to_dictionary(self, word: str):
+        """Adds a word to the custom dictionary, and triggers re-highlighting.
+
+        >>> manager = SpellCheckManager.get_instance()
+        >>> manager.add_to_dictionary("customword")
+        """
+        word_lower = word.lower()
+        if word_lower and word_lower not in self.custom_words:
+            self.custom_words.add(word_lower)
+            self._save_custom_dictionary()
+            # Clear cache of all highlighters and trigger rehighlight
+            for hl in list(self.highlighters):
+                hl.clear_cache()
+
+    def register_highlighter(self, highlighter):
+        """Registers a SpellCheckHighlighter to track active highlighters.
+
+        >>> manager = SpellCheckManager.get_instance()
+        >>> hl = SpellCheckHighlighter(None)
+        >>> manager.register_highlighter(hl)
+        """
+        self.highlighters.add(highlighter)
+
+    def notify_config_changed(self):
+        """Notifies all registered highlighters that config changed, clearing cache."""
+        self.load_external_dictionary()
+
+
+class SpellCheckHighlighter(QSyntaxHighlighter):
+    """SpellCheckHighlighter highlights misspelled words using a red wavy underline.
+
+    >>> hl = SpellCheckHighlighter(None)
+    >>> isinstance(hl, SpellCheckHighlighter)
+    True
+    """
+    def __init__(self, parent_document):
+        super().__init__(parent_document)
+        self.manager = SpellCheckManager.get_instance()
+        self.manager.register_highlighter(self)
+        self._cache = {}
+        
+        self.misspelled_format = QTextCharFormat()
+        self.misspelled_format.setUnderlineColor(QColor(235, 75, 75)) # Sleek red
+        self.misspelled_format.setUnderlineStyle(QTextCharFormat.UnderlineStyle.WaveUnderline)
+
+    def clear_cache(self):
+        self._cache.clear()
+        if self.document():
+            self.rehighlight()
+
+    def highlightBlock(self, text):
+        from ballontranslator.utils.config import pcfg
+        # Check if spellcheck is enabled in settings and if spellchecker package is installed
+        if not getattr(pcfg, 'spellcheck_enabled', True):
+            return
+        if not self.manager.is_available():
+            return
+
+        # Pattern matches words in English and Russian
+        for match in re.finditer(r'\b[a-zA-Zа-яА-ЯёЁ]+\b', text):
+            word = match.group(0)
+            if len(word) <= 1:
+                continue
+            
+            word_lower = word.lower()
+            if word_lower not in self._cache:
+                self._cache[word_lower] = self.manager.is_correct(word_lower)
+                
+            if not self._cache[word_lower]:
+                start = match.start()
+                length = match.end() - start
+                self.setFormat(start, length, self.misspelled_format)

--- a/ballontranslator/utils/spellcheck.py
+++ b/ballontranslator/utils/spellcheck.py
@@ -146,6 +146,10 @@ class SpellCheckManager:
         import threading
         if hasattr(self, '_loading_thread') and self._loading_thread and self._loading_thread.is_alive():
             return
+        
+        distance = getattr(pcfg, 'spellcheck_distance', 1)
+        if self.spell is not None and getattr(self.spell, '_distance', 1) != distance:
+            self.spell = None
 
         def bg_load():
             if not getattr(pcfg, 'spellcheck_enabled', True):
@@ -156,8 +160,8 @@ class SpellCheckManager:
             if self.spell is None:
                 try:
                     from spellchecker import SpellChecker
-                    self.spell = SpellChecker(language=['en', 'ru'], distance=1)
-                    LOGGER.info("SpellChecker initialized in background")
+                    self.spell = SpellChecker(language=['en', 'ru'], distance=distance)
+                    LOGGER.info(f"SpellChecker initialized in background (distance={distance})")
                 except Exception as e:
                     LOGGER.error(f"Failed to load SpellChecker in background: {e}")
 
@@ -225,15 +229,20 @@ class SpellCheckManager:
         >>> manager = SpellCheckManager.get_instance()
         >>> manager.load_spellchecker()
         """
+        from ballontranslator.utils.config import pcfg
+        distance = getattr(pcfg, 'spellcheck_distance', 1)
         if self.spell is not None:
-            return
+            if getattr(self.spell, '_distance', 1) == distance:
+                return
+            else:
+                self.spell = None
         
         try:
             from spellchecker import SpellChecker
-            # Load English and Russian dictionaries with fast distance=1
-            self.spell = SpellChecker(language=['en', 'ru'], distance=1)
+            # Load English and Russian dictionaries with configured distance
+            self.spell = SpellChecker(language=['en', 'ru'], distance=distance)
             from ballontranslator.utils.logger import logger as LOGGER
-            LOGGER.info("SpellChecker initialized with languages: en, ru (distance=1)")
+            LOGGER.info(f"SpellChecker initialized with languages: en, ru (distance={distance})")
         except Exception as e:
             from ballontranslator.utils.logger import logger as LOGGER
             LOGGER.error(f"Failed to load SpellChecker: {e}")

--- a/ballontranslator/utils/spellcheck.py
+++ b/ballontranslator/utils/spellcheck.py
@@ -28,6 +28,7 @@ class SpellCheckManager:
         self.external_words: Set[str] = set()
         self.highlighters = weakref.WeakSet()
         self.dict_path = os.path.join(shared.PROGRAM_PATH, 'config', 'custom_dictionary.txt')
+        self._reload_queued = False
         self._load_custom_dictionary()
         self.load_spellchecker_async()
 
@@ -145,67 +146,73 @@ class SpellCheckManager:
 
         import threading
         if hasattr(self, '_loading_thread') and self._loading_thread and self._loading_thread.is_alive():
+            self._reload_queued = True
             return
         
-        distance = getattr(pcfg, 'spellcheck_distance', 1)
-        if self.spell is not None and getattr(self.spell, '_distance', 1) != distance:
-            self.spell = None
+        self._reload_queued = False
 
         def bg_load():
-            if not getattr(pcfg, 'spellcheck_enabled', True):
-                self.spell = None
-                self.external_words = set()
-                return
-
-            if self.spell is None:
-                try:
-                    from spellchecker import SpellChecker
-                    self.spell = SpellChecker(language=['en', 'ru'], distance=distance)
-                    LOGGER.info(f"SpellChecker initialized in background (distance={distance})")
-                except Exception as e:
-                    LOGGER.error(f"Failed to load SpellChecker in background: {e}")
-
-            temp_words = set()
-            try:
-                repo_dicts = getattr(pcfg, 'spellcheck_repo_dicts', '').split(',')
-                loaded_repos = 0
-                for dict_name in repo_dicts:
-                    dict_name = dict_name.strip()
-                    if dict_name:
-                        dict_path = os.path.join(shared.PROGRAM_PATH, 'data', 'dictionaries', dict_name)
-                        if os.path.exists(dict_path):
-                            self._parse_and_load_file_to_set(dict_path, temp_words)
-                            loaded_repos += 1
-
-                ext_paths = getattr(pcfg, 'spellcheck_external_dict_path', '').split(';')
-                loaded_externals = 0
-                for path in ext_paths:
-                    path = path.strip()
-                    if path and os.path.exists(path):
-                        self._parse_and_load_file_to_set(path, temp_words)
-                        loaded_externals += 1
+            while True:
+                self._reload_queued = False
+                distance = getattr(pcfg, 'spellcheck_distance', 1)
 
                 if not getattr(pcfg, 'spellcheck_enabled', True):
                     self.spell = None
                     self.external_words = set()
-                    LOGGER.info("Spell Checker is disabled. Cancelled dictionary loading.")
                     return
 
-                LOGGER.info(
-                    f"SpellCheckManager: loaded {len(temp_words)} words in background "
-                    f"(from {loaded_repos} repo dictionaries, {loaded_externals} external dictionaries)"
-                )
-            except Exception as e:
-                LOGGER.error(f"Error loading dictionaries in background: {e}")
+                if self.spell is None or getattr(self.spell, '_distance', 1) != distance:
+                    try:
+                        from spellchecker import SpellChecker
+                        self.spell = SpellChecker(language=['en', 'ru'], distance=distance)
+                        LOGGER.info(f"SpellChecker initialized in background (distance={distance})")
+                    except Exception as e:
+                        LOGGER.error(f"Failed to load SpellChecker in background: {e}")
 
-            self.external_words = temp_words
+                temp_words = set()
+                try:
+                    repo_dicts = getattr(pcfg, 'spellcheck_repo_dicts', '').split(',')
+                    loaded_repos = 0
+                    for dict_name in repo_dicts:
+                        dict_name = dict_name.strip()
+                        if dict_name:
+                            dict_path = os.path.join(shared.PROGRAM_PATH, 'data', 'dictionaries', dict_name)
+                            if os.path.exists(dict_path):
+                                self._parse_and_load_file_to_set(dict_path, temp_words)
+                                loaded_repos += 1
 
-            from qtpy.QtCore import QTimer
-            def gui_notify():
-                for hl in list(self.highlighters):
-                    hl.clear_cache()
-                    hl.rehighlight()
-            QTimer.singleShot(0, gui_notify)
+                    ext_paths = getattr(pcfg, 'spellcheck_external_dict_path', '').split(';')
+                    loaded_externals = 0
+                    for path in ext_paths:
+                        path = path.strip()
+                        if path and os.path.exists(path):
+                            self._parse_and_load_file_to_set(path, temp_words)
+                            loaded_externals += 1
+
+                    if not getattr(pcfg, 'spellcheck_enabled', True):
+                        self.spell = None
+                        self.external_words = set()
+                        LOGGER.info("Spell Checker is disabled. Cancelled dictionary loading.")
+                        return
+
+                    LOGGER.info(
+                        f"SpellCheckManager: loaded {len(temp_words)} words in background "
+                        f"(from {loaded_repos} repo dictionaries, {loaded_externals} external dictionaries)"
+                    )
+                except Exception as e:
+                    LOGGER.error(f"Error loading dictionaries in background: {e}")
+
+                self.external_words = temp_words
+
+                from qtpy.QtCore import QTimer
+                def gui_notify():
+                    for hl in list(self.highlighters):
+                        hl.clear_cache()
+                        hl.rehighlight()
+                QTimer.singleShot(0, gui_notify)
+
+                if not self._reload_queued:
+                    break
 
         self._loading_thread = threading.Thread(target=bg_load, daemon=True)
         self._loading_thread.start()
@@ -374,8 +381,10 @@ class SpellCheckHighlighter(QSyntaxHighlighter):
         if not self.manager.is_available():
             return
 
-        # Pattern matches words in any language using Unicode character classes (excluding CJK)
-        for match in re.finditer(r'\b[^\W\d_\u3040-\u309f\u30a0-\u30ff\u4e00-\u9fff\uac00-\ud7a3\u3400-\u4dbf]+\b', text):
+        # Pattern matches words in any language using Unicode character classes (optionally excluding CJK)
+        skip_cjk = getattr(pcfg, 'spellcheck_skip_cjk', True)
+        pattern = r'\b[^\W\d_\u3040-\u309f\u30a0-\u30ff\u4e00-\u9fff\uac00-\ud7a3\u3400-\u4dbf]+\b' if skip_cjk else r'\b[^\W\d_]+\b'
+        for match in re.finditer(pattern, text):
             word = match.group(0)
             if len(word) <= 1:
                 continue

--- a/ballontranslator/utils/spellcheck.py
+++ b/ballontranslator/utils/spellcheck.py
@@ -29,7 +29,7 @@ class SpellCheckManager:
         self.highlighters = weakref.WeakSet()
         self.dict_path = os.path.join(shared.PROGRAM_PATH, 'config', 'custom_dictionary.txt')
         self._load_custom_dictionary()
-        self.load_external_dictionary()
+        self.load_spellchecker_async()
 
     def _load_custom_dictionary(self):
         """Loads custom user-added words from local storage.
@@ -61,7 +61,7 @@ class SpellCheckManager:
         except Exception as e:
             print(f"Error saving custom dictionary: {e}")
 
-    def _parse_and_load_file(self, path):
+    def _parse_and_load_file_to_set(self, path, target_set):
         try:
             try:
                 with open(path, 'r', encoding='utf-8') as f:
@@ -81,7 +81,7 @@ class SpellCheckManager:
                 if word.isdigit():
                     continue
                 if word:
-                    self.external_words.add(word)
+                    target_set.add(word)
         except Exception as e:
             from ballontranslator.utils.logger import logger as LOGGER
             LOGGER.error(f"Error reading dictionary file {path}: {e}")
@@ -92,7 +92,7 @@ class SpellCheckManager:
         >>> manager = SpellCheckManager.get_instance()
         >>> manager.load_external_dictionary()
         """
-        self.external_words.clear()
+        temp_words = set()
         try:
             from ballontranslator.utils.config import pcfg
             
@@ -104,7 +104,7 @@ class SpellCheckManager:
                 if dict_name:
                     dict_path = os.path.join(shared.PROGRAM_PATH, 'data', 'dictionaries', dict_name)
                     if os.path.exists(dict_path):
-                        self._parse_and_load_file(dict_path)
+                        self._parse_and_load_file_to_set(dict_path, temp_words)
                         loaded_repos += 1
             
             # Load multiple external dictionaries
@@ -113,20 +113,79 @@ class SpellCheckManager:
             for path in ext_paths:
                 path = path.strip()
                 if path and os.path.exists(path):
-                    self._parse_and_load_file(path)
+                    self._parse_and_load_file_to_set(path, temp_words)
                     loaded_externals += 1
                     
             from ballontranslator.utils.logger import logger as LOGGER
             LOGGER.info(
-                f"SpellCheckManager: loaded {len(self.external_words)} words "
+                f"SpellCheckManager: loaded {len(temp_words)} words "
                 f"(from {loaded_repos} repo dictionaries, {loaded_externals} external dictionaries)"
             )
         except Exception as e:
             from ballontranslator.utils.logger import logger as LOGGER
             LOGGER.error(f"Error loading dictionaries: {e}")
             
+        self.external_words = temp_words
         for hl in list(self.highlighters):
             hl.clear_cache()
+
+    def load_spellchecker_async(self):
+        import threading
+        if hasattr(self, '_loading_thread') and self._loading_thread and self._loading_thread.is_alive():
+            return
+
+        def bg_load():
+            if self.spell is None:
+                try:
+                    from spellchecker import SpellChecker
+                    self.spell = SpellChecker(language=['en', 'ru'], distance=1)
+                    from ballontranslator.utils.logger import logger as LOGGER
+                    LOGGER.info("SpellChecker initialized in background")
+                except Exception as e:
+                    from ballontranslator.utils.logger import logger as LOGGER
+                    LOGGER.error(f"Failed to load SpellChecker in background: {e}")
+
+            temp_words = set()
+            try:
+                from ballontranslator.utils.config import pcfg
+                repo_dicts = getattr(pcfg, 'spellcheck_repo_dicts', '').split(',')
+                loaded_repos = 0
+                for dict_name in repo_dicts:
+                    dict_name = dict_name.strip()
+                    if dict_name:
+                        dict_path = os.path.join(shared.PROGRAM_PATH, 'data', 'dictionaries', dict_name)
+                        if os.path.exists(dict_path):
+                            self._parse_and_load_file_to_set(dict_path, temp_words)
+                            loaded_repos += 1
+
+                ext_paths = getattr(pcfg, 'spellcheck_external_dict_path', '').split(';')
+                loaded_externals = 0
+                for path in ext_paths:
+                    path = path.strip()
+                    if path and os.path.exists(path):
+                        self._parse_and_load_file_to_set(path, temp_words)
+                        loaded_externals += 1
+
+                from ballontranslator.utils.logger import logger as LOGGER
+                LOGGER.info(
+                    f"SpellCheckManager: loaded {len(temp_words)} words in background "
+                    f"(from {loaded_repos} repo dictionaries, {loaded_externals} external dictionaries)"
+                )
+            except Exception as e:
+                from ballontranslator.utils.logger import logger as LOGGER
+                LOGGER.error(f"Error loading dictionaries in background: {e}")
+
+            self.external_words = temp_words
+
+            from qtpy.QtCore import QTimer
+            def gui_notify():
+                for hl in list(self.highlighters):
+                    hl.clear_cache()
+                    hl.rehighlight()
+            QTimer.singleShot(0, gui_notify)
+
+        self._loading_thread = threading.Thread(target=bg_load, daemon=True)
+        self._loading_thread.start()
 
     def is_available(self) -> bool:
         """Checks if the required pyspellchecker package is installed.
@@ -177,9 +236,8 @@ class SpellCheckManager:
             return True
 
         if self.spell is None:
-            self.load_spellchecker()
-            if self.spell is None:
-                return True # If spellchecker cannot be loaded, assume correct
+            self.load_spellchecker_async()
+            return True # If spellchecker cannot be loaded or is loading, assume correct
 
         # pyspellchecker: known returns words that are in the dictionary
         try:
@@ -198,9 +256,8 @@ class SpellCheckManager:
             return []
 
         if self.spell is None:
-            self.load_spellchecker()
-            if self.spell is None:
-                return []
+            self.load_spellchecker_async()
+            return []
         
         word_lower = word.lower()
         try:
@@ -234,6 +291,7 @@ class SpellCheckManager:
             # Clear cache of all highlighters and trigger rehighlight
             for hl in list(self.highlighters):
                 hl.clear_cache()
+                hl.rehighlight()
 
     def register_highlighter(self, highlighter):
         """Registers a SpellCheckHighlighter to track active highlighters.
@@ -246,7 +304,7 @@ class SpellCheckManager:
 
     def notify_config_changed(self):
         """Notifies all registered highlighters that config changed, clearing cache."""
-        self.load_external_dictionary()
+        self.load_spellchecker_async()
 
 
 class SpellCheckHighlighter(QSyntaxHighlighter):

--- a/ballontranslator/utils/spellcheck.py
+++ b/ballontranslator/utils/spellcheck.py
@@ -381,9 +381,8 @@ class SpellCheckHighlighter(QSyntaxHighlighter):
         if not self.manager.is_available():
             return
 
-        # Pattern matches words in any language using Unicode character classes (optionally excluding CJK)
-        skip_cjk = getattr(pcfg, 'spellcheck_skip_cjk', True)
-        pattern = r'\b[^\W\d_\u3040-\u309f\u30a0-\u30ff\u4e00-\u9fff\uac00-\ud7a3\u3400-\u4dbf]+\b' if skip_cjk else r'\b[^\W\d_]+\b'
+        # Pattern matches words in any language using Unicode character classes
+        pattern = r'\b[^\W\d_]+\b'
         for match in re.finditer(pattern, text):
             word = match.group(0)
             if len(word) <= 1:

--- a/requirements.txt
+++ b/requirements.txt
@@ -30,3 +30,5 @@ pyobjc-core; sys_platform == 'darwin'
 pyobjc-framework-cocoa; sys_platform == 'darwin'
 pyobjc-framework-coreml; sys_platform == 'darwin'
 pyobjc-framework-quartz; sys_platform == 'darwin'
+pyspellchecker
+

--- a/resources/stylesheet.css
+++ b/resources/stylesheet.css
@@ -1092,15 +1092,15 @@ QWidget#suggestion_popup QPushButton {
 }
 
 QWidget#suggestion_popup QPushButton:hover {
-    background-color: #1e93e5;
-    color: #ffffff;
+    background-color: @borderColor;
+    color: @qwidgetForegroundColor;
 }
 
 QWidget#suggestion_popup QPushButton#add_to_dict {
-    color: #5cb85c;
+    color: #4caf50;
 }
 
 QWidget#suggestion_popup QPushButton#add_to_dict:hover {
-    background-color: #5cb85c;
+    background-color: #4caf50;
     color: #ffffff;
 }

--- a/resources/stylesheet.css
+++ b/resources/stylesheet.css
@@ -1104,3 +1104,27 @@ QWidget#suggestion_popup QPushButton#add_to_dict:hover {
     background-color: #4caf50;
     color: #ffffff;
 }
+
+QWidget#suggestion_popup QScrollBar:horizontal {
+    background: transparent;
+    height: 3px;
+    margin: 0px;
+}
+
+QWidget#suggestion_popup QScrollBar::handle:horizontal {
+    background: @scrollBarColor;
+    border-radius: 1px;
+    min-width: 20px;
+}
+
+QWidget#suggestion_popup QScrollBar::handle:horizontal:hover {
+    background: @scrollBarHoverColor;
+}
+
+QWidget#suggestion_popup QScrollBar::add-line:horizontal,
+QWidget#suggestion_popup QScrollBar::sub-line:horizontal,
+QWidget#suggestion_popup QScrollBar::add-page:horizontal,
+QWidget#suggestion_popup QScrollBar::sub-page:horizontal {
+    width: 0px;
+    background: transparent;
+}

--- a/resources/stylesheet.css
+++ b/resources/stylesheet.css
@@ -1088,7 +1088,7 @@ QWidget#suggestion_popup QPushButton {
     height: 28px;
     font-family: 'Segoe UI', Arial, sans-serif;
     font-size: 11px;
-    font-weight: bold;
+    font-weight: normal;
 }
 
 QWidget#suggestion_popup QPushButton:hover {

--- a/resources/stylesheet.css
+++ b/resources/stylesheet.css
@@ -1067,3 +1067,40 @@ DeleteStyleButton {
 DeleteStyleButton::hover {
     background-color: #FF605C;
 }
+
+/* Suggestion Popup (Spell Checker) */
+QWidget#suggestion_popup {
+    background-color: @emptyContentBackgroundColor;
+    border: 1px solid @borderColor;
+    border-radius: 4px;
+}
+
+QWidget#suggestion_popup QScrollArea {
+    border: none;
+    background: transparent;
+}
+
+QWidget#suggestion_popup QPushButton {
+    background-color: @pushBtnBackgroundColor;
+    color: @qwidgetForegroundColor;
+    border: none;
+    padding: 0px 12px;
+    height: 28px;
+    font-family: 'Segoe UI', Arial, sans-serif;
+    font-size: 11px;
+    font-weight: bold;
+}
+
+QWidget#suggestion_popup QPushButton:hover {
+    background-color: #1e93e5;
+    color: #ffffff;
+}
+
+QWidget#suggestion_popup QPushButton#add_to_dict {
+    color: #5cb85c;
+}
+
+QWidget#suggestion_popup QPushButton#add_to_dict:hover {
+    background-color: #5cb85c;
+    color: #ffffff;
+}


### PR DESCRIPTION
### Spell Checker Feature Integration

Introduced a comprehensive, non-blocking Spell Checker feature powered by `pyspellchecker`:

* **Word Highlighting:** Misspelled words in translation text boxes are now highlighted in real-time with a sleek red wavy underline.
* **Multi-Language Support:** Integrated support for 35 repository languages. Dictionaries are automatically downloaded to `data/dictionaries/` on-demand with progress tracking.
* **Large Dictionary Compatibility:** Resilient to large custom wordlists (e.g., flat text files with millions of inflected forms, such as `danakt/russian-words`) with support for fallback encodings (`UTF-8`, `CP1251`).
* **Custom Dictionary Manager:** Added a settings dialog allowing users to manage their own allowed wordlist (add inline with Enter key, hover to delete via `×`, fully integrated with the global UI theme).
* **Asynchronous & Non-Blocking:** All dictionary loading and SpellChecker initializations are handled in background threads to guarantee a smooth, lag-free GUI experience. Dictionaries are automatically unloaded from memory when the feature is disabled.
