### PR TITLE
Feat/add litellm provider

### DIFF
--- a/ballontranslator/modules/translators/trans_litellm.py
+++ b/ballontranslator/modules/translators/trans_litellm.py
@@ -1,0 +1,279 @@
+import re
+import time
+import json
+import traceback
+from typing import List, Dict, Optional
+
+from pydantic import BaseModel, Field, ValidationError
+
+from .base import BaseTranslator, register_translator
+
+
+class TranslationElement(BaseModel):
+    id: int = Field(..., description="The original numeric ID of the text snippet.")
+    translation: str = Field(
+        ..., description="The translated text corresponding to the id."
+    )
+
+
+class TranslationResponse(BaseModel):
+    translations: List[TranslationElement] = Field(
+        ..., description="A list of all translated elements."
+    )
+
+
+@register_translator("LiteLLM")
+class LiteLLMTranslator(BaseTranslator):
+    dependencies = ['litellm']
+
+    concate_text = False
+    cht_require_convert = True
+    params: Dict = {
+        "model": {
+            "value": "openai/gpt-4o",
+            "description": "LiteLLM model string (e.g. openai/gpt-4o, anthropic/claude-sonnet-4-20250514, gemini/gemini-2.5-flash). See https://docs.litellm.ai/docs/providers",
+        },
+        "api_key": {
+            "value": "",
+            "description": "API key for the provider. Leave empty to use provider env vars (OPENAI_API_KEY, ANTHROPIC_API_KEY, etc.).",
+        },
+        "api_base": {
+            "value": "",
+            "description": "Custom API base URL (e.g. http://localhost:4000 for LiteLLM proxy). Leave empty for provider defaults.",
+        },
+        "system_prompt": {
+            "type": "editor",
+            "value": 'You are an expert translator. Your task is to accurately translate the given text snippets. You MUST provide the output strictly in the specified JSON format, without any additional explanations or markdown formatting. The JSON object must have a single key \'translations\', which is a list of objects, each with an \'id\' (integer) and a \'translation\' (string).\n\nExample Output Schema:\n{"translations": [{"id": 1, "translation": "Translated text here."}]}',
+            "description": "System message to instruct the LLM on its role and required output format.",
+        },
+        "temperature": {
+            "value": 0.1,
+            "description": "Sampling temperature. Lower values are recommended for structured output.",
+        },
+        "max_tokens": {
+            "value": 4096,
+            "description": "Maximum tokens for the response.",
+        },
+        "retry_attempts": {
+            "value": 3,
+            "description": "Number of retry attempts on API failures.",
+        },
+        "retry_timeout": {
+            "value": 15,
+            "description": "Timeout between retry attempts (seconds).",
+        },
+        "invalid_repeat_count": {
+            "value": 2,
+            "description": "Number of retries if the count of translations mismatches the source count.",
+        },
+        "delay": {
+            "value": 0.3,
+            "description": "Delay in seconds between requests.",
+        },
+    }
+
+    def _setup_translator(self):
+        self.lang_map = {
+            "简体中文": "Simplified Chinese",
+            "繁體中文": "Traditional Chinese",
+            "日本語": "Japanese",
+            "English": "English",
+            "한국어": "Korean",
+            "Tiếng Việt": "Vietnamese",
+            "čeština": "Czech",
+            "Français": "French",
+            "Deutsch": "German",
+            "magyar nyelv": "Hungarian",
+            "Italiano": "Italian",
+            "Polski": "Polish",
+            "Português": "Portuguese",
+            "limba română": "Romanian",
+            "русский язык": "Russian",
+            "Español": "Spanish",
+            "Türk dili": "Turkish",
+            "украї́нська мо́ва": "Ukrainian",
+            "Thai": "Thai",
+            "Arabic": "Arabic",
+            "Malayalam": "Malayalam",
+            "Tamil": "Tamil",
+            "Hindi": "Hindi",
+        }
+        self.token_count = 0
+        self.token_count_last = 0
+        self.last_request_time = 0
+
+    def _assemble_prompt(self, queries: List[str], to_lang: str) -> str:
+        from_lang = self.lang_map.get(self.lang_source, self.lang_source)
+        input_elements = [
+            {"id": i + 1, "source": query} for i, query in enumerate(queries)
+        ]
+        input_json_str = json.dumps(input_elements, ensure_ascii=False, indent=2)
+        return (
+            f"Please translate the following text snippets from {from_lang} to {to_lang}. "
+            f"The input is provided as a JSON array. Respond with a JSON object in the specified format.\n\n"
+            f"INPUT:\n{input_json_str}"
+        )
+
+    def _respect_delay(self):
+        delay = float(self.get_param_value("delay"))
+        elapsed = time.time() - self.last_request_time
+        if elapsed < delay:
+            time.sleep(delay - elapsed)
+        self.last_request_time = time.time()
+
+    def _request_translation(self, prompt: str) -> Optional[TranslationResponse]:
+        import litellm
+
+        model = self.get_param_value("model")
+        api_key = self.get_param_value("api_key") or None
+        api_base = self.get_param_value("api_base") or None
+        temperature = float(self.get_param_value("temperature"))
+        max_tokens = int(self.get_param_value("max_tokens"))
+        system_prompt = self.get_param_value("system_prompt")
+
+        messages = [
+            {"role": "system", "content": system_prompt},
+            {"role": "user", "content": prompt},
+        ]
+
+        kwargs = {
+            "model": model,
+            "messages": messages,
+            "temperature": temperature,
+            "max_tokens": max_tokens,
+            "drop_params": True,
+        }
+        if api_key:
+            kwargs["api_key"] = api_key
+        if api_base:
+            kwargs["api_base"] = api_base
+
+        try:
+            kwargs["response_format"] = {"type": "json_object"}
+        except Exception:
+            pass
+
+        self._respect_delay()
+
+        try:
+            completion = litellm.completion(**kwargs)
+        except Exception as e:
+            self.logger.error(f"LiteLLM API request failed: {e}")
+            raise
+
+        if (
+            completion.choices
+            and completion.choices[0].message
+            and completion.choices[0].message.content
+        ):
+            raw_content = completion.choices[0].message.content
+            json_to_parse = raw_content.strip()
+
+            match = re.search(
+                r"```(?:json)?\s*(\{.*?\})\s*```", json_to_parse, re.DOTALL
+            )
+            if match:
+                json_to_parse = match.group(1)
+            else:
+                start = json_to_parse.find("{")
+                end = json_to_parse.rfind("}")
+                if start != -1 and end != -1 and end > start:
+                    json_to_parse = json_to_parse[start : end + 1]
+
+            try:
+                data = json.loads(json_to_parse)
+                validated = TranslationResponse.model_validate(data)
+            except (ValidationError, json.JSONDecodeError):
+                try:
+                    simple_data = json.loads(json_to_parse)
+                    fixed = []
+                    if isinstance(simple_data, dict) and all(
+                        k.isdigit() for k in simple_data.keys()
+                    ):
+                        fixed = [
+                            {"id": int(k), "translation": v}
+                            for k, v in simple_data.items()
+                        ]
+                    elif isinstance(simple_data, list):
+                        fixed = simple_data
+                    if fixed:
+                        validated = TranslationResponse.model_validate(
+                            {"translations": fixed}
+                        )
+                    else:
+                        raise
+                except (ValidationError, json.JSONDecodeError, Exception):
+                    self.logger.error(
+                        f"Failed to parse LLM response. Raw: {raw_content[:200]}"
+                    )
+                    raise
+        else:
+            self.logger.warning("No valid message content in API response.")
+            return None
+
+        if hasattr(completion, "usage") and completion.usage:
+            self.token_count += completion.usage.total_tokens
+            self.token_count_last = completion.usage.total_tokens
+        else:
+            self.token_count_last = 0
+
+        return validated
+
+    def _translate(self, src_list: List[str]) -> List[str]:
+        if not src_list:
+            return []
+
+        retry_attempts = int(self.get_param_value("retry_attempts"))
+        retry_timeout = int(self.get_param_value("retry_timeout"))
+        invalid_repeat_count = int(self.get_param_value("invalid_repeat_count"))
+
+        to_lang = self.lang_map.get(self.lang_target, self.lang_target)
+        prompt = self._assemble_prompt(src_list, to_lang)
+
+        api_retry = 0
+        mismatch_retry = 0
+
+        while True:
+            try:
+                parsed = self._request_translation(prompt)
+                if parsed is None:
+                    raise ValueError("Empty response from API.")
+
+                result_map = {
+                    elem.id: elem.translation for elem in parsed.translations
+                }
+                translations = []
+                for i in range(1, len(src_list) + 1):
+                    if i in result_map:
+                        translations.append(result_map[i])
+                    else:
+                        self.logger.warning(
+                            f"Missing translation for id {i}. Using source text."
+                        )
+                        translations.append(src_list[i - 1])
+
+                if len(parsed.translations) != len(src_list):
+                    mismatch_retry += 1
+                    if mismatch_retry <= invalid_repeat_count:
+                        self.logger.warning(
+                            f"Translation count mismatch ({len(parsed.translations)} vs {len(src_list)}). "
+                            f"Retry {mismatch_retry}/{invalid_repeat_count}."
+                        )
+                        continue
+
+                return translations
+
+            except Exception as e:
+                api_retry += 1
+                if api_retry > retry_attempts:
+                    self.logger.error(
+                        f"All {retry_attempts} retries exhausted. Error: {e}"
+                    )
+                    self.logger.debug(traceback.format_exc())
+                    return src_list
+
+                self.logger.warning(
+                    f"Attempt {api_retry}/{retry_attempts} failed: {e}. "
+                    f"Retrying in {retry_timeout}s."
+                )
+                time.sleep(retry_timeout)

--- a/ballontranslator/modules/translators/trans_litellm.py
+++ b/ballontranslator/modules/translators/trans_litellm.py
@@ -8,6 +8,21 @@ from pydantic import BaseModel, Field, ValidationError
 
 from .base import BaseTranslator, register_translator
 
+_TRANSIENT_ERROR_QUALNAMES = {
+    "litellm.exceptions.RateLimitError",
+    "litellm.exceptions.APIConnectionError",
+    "litellm.exceptions.Timeout",
+    "litellm.exceptions.InternalServerError",
+    "litellm.exceptions.ServiceUnavailableError",
+}
+
+
+def _is_transient_error(exc: BaseException) -> bool:
+    if isinstance(exc, (ValueError, json.JSONDecodeError)):
+        return True
+    qualname = f"{type(exc).__module__}.{type(exc).__name__}"
+    return qualname in _TRANSIENT_ERROR_QUALNAMES
+
 
 class TranslationElement(BaseModel):
     id: int = Field(..., description="The original numeric ID of the text snippet.")
@@ -148,18 +163,11 @@ class LiteLLMTranslator(BaseTranslator):
         if api_base:
             kwargs["api_base"] = api_base
 
-        try:
-            kwargs["response_format"] = {"type": "json_object"}
-        except Exception:
-            pass
+        kwargs["response_format"] = {"type": "json_object"}
 
         self._respect_delay()
 
-        try:
-            completion = litellm.completion(**kwargs)
-        except Exception as e:
-            self.logger.error(f"LiteLLM API request failed: {e}")
-            raise
+        completion = litellm.completion(**kwargs)
 
         if (
             completion.choices
@@ -264,16 +272,21 @@ class LiteLLMTranslator(BaseTranslator):
                 return translations
 
             except Exception as e:
-                api_retry += 1
-                if api_retry > retry_attempts:
-                    self.logger.error(
-                        f"All {retry_attempts} retries exhausted. Error: {e}"
-                    )
-                    self.logger.debug(traceback.format_exc())
-                    return src_list
+                if _is_transient_error(e):
+                    api_retry += 1
+                    if api_retry > retry_attempts:
+                        self.logger.error(
+                            f"All {retry_attempts} retries exhausted. Error: {e}"
+                        )
+                        self.logger.debug(traceback.format_exc())
+                        return src_list
 
-                self.logger.warning(
-                    f"Attempt {api_retry}/{retry_attempts} failed: {e}. "
-                    f"Retrying in {retry_timeout}s."
-                )
-                time.sleep(retry_timeout)
+                    self.logger.warning(
+                        f"Attempt {api_retry}/{retry_attempts} failed (transient): {e}. "
+                        f"Retrying in {retry_timeout}s."
+                    )
+                    time.sleep(retry_timeout)
+                else:
+                    self.logger.error(f"Non-retryable error: {e}")
+                    self.logger.debug(traceback.format_exc())
+                    raise

--- a/tests/test_litellm_translator.py
+++ b/tests/test_litellm_translator.py
@@ -1,0 +1,342 @@
+import json
+import importlib
+import os
+import sys
+import types
+import unittest
+from unittest import mock
+from types import SimpleNamespace
+
+
+def _make_litellm_stub():
+    """Install a fake litellm module so tests run without the real package."""
+    fake = types.ModuleType("litellm")
+    fake.completion = mock.MagicMock(name="litellm.completion")
+
+    exc_mod = types.ModuleType("litellm.exceptions")
+    exc_mod.RateLimitError = type("RateLimitError", (Exception,), {"__module__": "litellm.exceptions"})
+    exc_mod.APIConnectionError = type("APIConnectionError", (Exception,), {"__module__": "litellm.exceptions"})
+    exc_mod.Timeout = type("Timeout", (Exception,), {"__module__": "litellm.exceptions"})
+    exc_mod.InternalServerError = type("InternalServerError", (Exception,), {"__module__": "litellm.exceptions"})
+    exc_mod.ServiceUnavailableError = type("ServiceUnavailableError", (Exception,), {"__module__": "litellm.exceptions"})
+    exc_mod.AuthenticationError = type("AuthenticationError", (Exception,), {"__module__": "litellm.exceptions"})
+    exc_mod.NotFoundError = type("NotFoundError", (Exception,), {"__module__": "litellm.exceptions"})
+
+    fake.exceptions = exc_mod
+    sys.modules["litellm"] = fake
+    sys.modules["litellm.exceptions"] = exc_mod
+    return fake
+
+
+_litellm_stub = _make_litellm_stub()
+
+
+def _load_trans_litellm():
+    """Load trans_litellm.py directly, bypassing the heavy ballontranslator package imports."""
+    base_mod = types.ModuleType("ballontranslator.modules.translators.base")
+    base_mod.BaseTranslator = type("BaseTranslator", (), {
+        "get_param_value": lambda self, k: "",
+        "logger": mock.MagicMock(),
+    })
+    base_mod.register_translator = lambda name: lambda cls: cls
+
+    parent = types.ModuleType("ballontranslator.modules.translators")
+    parent.base = base_mod
+    sys.modules.setdefault("ballontranslator", types.ModuleType("ballontranslator"))
+    sys.modules.setdefault("ballontranslator.modules", types.ModuleType("ballontranslator.modules"))
+    sys.modules["ballontranslator.modules.translators"] = parent
+    sys.modules["ballontranslator.modules.translators.base"] = base_mod
+
+    file_path = os.path.join(
+        os.path.dirname(__file__),
+        "..", "ballontranslator", "modules", "translators", "trans_litellm.py",
+    )
+    spec = importlib.util.spec_from_file_location(
+        "ballontranslator.modules.translators.trans_litellm",
+        file_path,
+        submodule_search_locations=[],
+    )
+    mod = importlib.util.module_from_spec(spec)
+    mod.__package__ = "ballontranslator.modules.translators"
+    spec.loader.exec_module(mod)
+    return mod
+
+
+_mod = _load_trans_litellm()
+LiteLLMTranslator = _mod.LiteLLMTranslator
+_is_transient_error = _mod._is_transient_error
+
+
+def _make_completion_response(translations_json):
+    """Build a fake litellm.completion() response."""
+    return SimpleNamespace(
+        choices=[
+            SimpleNamespace(
+                message=SimpleNamespace(content=json.dumps(translations_json))
+            )
+        ],
+        usage=SimpleNamespace(total_tokens=42),
+    )
+
+
+def _make_translator(**overrides):
+    """Instantiate LiteLLMTranslator with sensible test defaults."""
+    t = LiteLLMTranslator.__new__(LiteLLMTranslator)
+    t.logger = mock.MagicMock()
+    t.lang_source = "English"
+    t.lang_target = "Japanese"
+    t.token_count = 0
+    t.token_count_last = 0
+    t.last_request_time = 0
+
+    defaults = {
+        "model": "openai/gpt-4o-mini",
+        "api_key": "sk-test-key",
+        "api_base": "",
+        "system_prompt": "You are a translator.",
+        "temperature": 0.1,
+        "max_tokens": 4096,
+        "retry_attempts": 2,
+        "retry_timeout": 0,
+        "invalid_repeat_count": 1,
+        "delay": 0,
+    }
+    defaults.update(overrides)
+    t.get_param_value = mock.MagicMock(side_effect=lambda k: defaults.get(k, ""))
+    t.lang_map = {
+        "English": "English",
+        "Japanese": "Japanese",
+    }
+
+    return t
+
+
+class TestLiteLLMTranslator(unittest.TestCase):
+
+    def test_successful_translation(self):
+        """Happy path: correct JSON response with matching IDs."""
+        t = _make_translator()
+        response = _make_completion_response({
+            "translations": [
+                {"id": 1, "translation": "hello in Japanese"},
+                {"id": 2, "translation": "world in Japanese"},
+            ]
+        })
+        _litellm_stub.completion.return_value = response
+
+        result = t._translate(["hello", "world"])
+
+        self.assertEqual(result, ["hello in Japanese", "world in Japanese"])
+        _litellm_stub.completion.assert_called_once()
+        call_kwargs = _litellm_stub.completion.call_args[1]
+        self.assertTrue(call_kwargs["drop_params"])
+        self.assertEqual(call_kwargs["model"], "openai/gpt-4o-mini")
+        self.assertEqual(call_kwargs["api_key"], "sk-test-key")
+
+    def test_drop_params_always_set(self):
+        """drop_params=True must always be in the completion call."""
+        t = _make_translator()
+        response = _make_completion_response({
+            "translations": [{"id": 1, "translation": "ok"}]
+        })
+        _litellm_stub.completion.return_value = response
+
+        t._translate(["test"])
+
+        call_kwargs = _litellm_stub.completion.call_args[1]
+        self.assertIn("drop_params", call_kwargs)
+        self.assertTrue(call_kwargs["drop_params"])
+
+    def test_api_key_omitted_when_empty(self):
+        """When api_key is empty, it should NOT be passed to litellm (fallback to env vars)."""
+        t = _make_translator(api_key="")
+        response = _make_completion_response({
+            "translations": [{"id": 1, "translation": "ok"}]
+        })
+        _litellm_stub.completion.return_value = response
+
+        t._translate(["test"])
+
+        call_kwargs = _litellm_stub.completion.call_args[1]
+        self.assertNotIn("api_key", call_kwargs)
+
+    def test_api_base_omitted_when_empty(self):
+        """When api_base is empty, it should NOT be passed to litellm."""
+        t = _make_translator(api_base="")
+        response = _make_completion_response({
+            "translations": [{"id": 1, "translation": "ok"}]
+        })
+        _litellm_stub.completion.return_value = response
+
+        t._translate(["test"])
+
+        call_kwargs = _litellm_stub.completion.call_args[1]
+        self.assertNotIn("api_base", call_kwargs)
+
+    def test_api_base_forwarded_when_set(self):
+        """When api_base is set, it must be forwarded to litellm."""
+        t = _make_translator(api_base="http://localhost:4000/v1")
+        response = _make_completion_response({
+            "translations": [{"id": 1, "translation": "ok"}]
+        })
+        _litellm_stub.completion.return_value = response
+
+        t._translate(["test"])
+
+        call_kwargs = _litellm_stub.completion.call_args[1]
+        self.assertEqual(call_kwargs["api_base"], "http://localhost:4000/v1")
+
+    def test_empty_input_returns_empty(self):
+        """Empty source list should return empty list without calling API."""
+        t = _make_translator()
+        _litellm_stub.completion.reset_mock()
+
+        result = t._translate([])
+
+        self.assertEqual(result, [])
+        _litellm_stub.completion.assert_not_called()
+
+    def test_missing_ids_fallback_to_source(self):
+        """If response has fewer translations than sources, missing ones use source text."""
+        t = _make_translator(invalid_repeat_count=0)
+        response = _make_completion_response({
+            "translations": [
+                {"id": 1, "translation": "first translated"},
+            ]
+        })
+        _litellm_stub.completion.return_value = response
+
+        result = t._translate(["first", "second"])
+
+        self.assertEqual(result[0], "first translated")
+        self.assertEqual(result[1], "second")
+
+    def test_null_response_triggers_retry(self):
+        """None response should trigger retry, then return source on exhaustion."""
+        t = _make_translator(retry_attempts=1, retry_timeout=0)
+        empty_response = SimpleNamespace(
+            choices=[SimpleNamespace(message=SimpleNamespace(content=None))],
+            usage=None,
+        )
+        _litellm_stub.completion.return_value = empty_response
+
+        result = t._translate(["hello"])
+
+        self.assertEqual(result, ["hello"])
+        self.assertEqual(_litellm_stub.completion.call_count, 2)
+
+    def test_malformed_json_triggers_retry(self):
+        """Malformed JSON response should trigger retry."""
+        t = _make_translator(retry_attempts=1, retry_timeout=0)
+        bad_response = SimpleNamespace(
+            choices=[SimpleNamespace(message=SimpleNamespace(content="not json at all"))],
+            usage=None,
+        )
+        _litellm_stub.completion.return_value = bad_response
+
+        result = t._translate(["hello"])
+
+        self.assertEqual(result, ["hello"])
+
+    def test_transient_error_retries(self):
+        """RateLimitError (transient) should trigger retry."""
+        t = _make_translator(retry_attempts=2, retry_timeout=0)
+        rate_limit_err = _litellm_stub.exceptions.RateLimitError("rate limited")
+        good_response = _make_completion_response({
+            "translations": [{"id": 1, "translation": "ok"}]
+        })
+        _litellm_stub.completion.side_effect = [rate_limit_err, good_response]
+
+        result = t._translate(["hello"])
+
+        self.assertEqual(result, ["ok"])
+        self.assertEqual(_litellm_stub.completion.call_count, 2)
+
+    def test_auth_error_does_not_retry(self):
+        """AuthenticationError (non-transient) should raise immediately, not retry."""
+        t = _make_translator(retry_attempts=3, retry_timeout=0)
+        auth_err = _litellm_stub.exceptions.AuthenticationError("bad key")
+        _litellm_stub.completion.side_effect = auth_err
+
+        with self.assertRaises(type(auth_err)):
+            t._translate(["hello"])
+
+        self.assertEqual(_litellm_stub.completion.call_count, 1)
+
+    def test_markdown_code_block_extraction(self):
+        """Response wrapped in ```json ... ``` should be extracted correctly."""
+        t = _make_translator()
+        wrapped = '```json\n{"translations": [{"id": 1, "translation": "extracted"}]}\n```'
+        response = SimpleNamespace(
+            choices=[SimpleNamespace(message=SimpleNamespace(content=wrapped))],
+            usage=SimpleNamespace(total_tokens=10),
+        )
+        _litellm_stub.completion.return_value = response
+
+        result = t._translate(["test"])
+
+        self.assertEqual(result, ["extracted"])
+
+    def test_simple_dict_format_fallback(self):
+        """Response as {"1": "text"} should be parsed via fallback."""
+        t = _make_translator()
+        simple = json.dumps({"1": "fallback parsed"})
+        response = SimpleNamespace(
+            choices=[SimpleNamespace(message=SimpleNamespace(content=simple))],
+            usage=SimpleNamespace(total_tokens=10),
+        )
+        _litellm_stub.completion.return_value = response
+
+        result = t._translate(["test"])
+
+        self.assertEqual(result, ["fallback parsed"])
+
+    def test_token_counting(self):
+        """Token count should accumulate from usage."""
+        t = _make_translator()
+        response = _make_completion_response({
+            "translations": [{"id": 1, "translation": "ok"}]
+        })
+        _litellm_stub.completion.return_value = response
+
+        t._translate(["hello"])
+
+        self.assertEqual(t.token_count, 42)
+        self.assertEqual(t.token_count_last, 42)
+
+    def setUp(self):
+        _litellm_stub.completion.reset_mock()
+        _litellm_stub.completion.side_effect = None
+
+
+class TestIsTransientError(unittest.TestCase):
+
+    def test_rate_limit_is_transient(self):
+        err = _litellm_stub.exceptions.RateLimitError("429")
+        self.assertTrue(_is_transient_error(err))
+
+    def test_timeout_is_transient(self):
+        err = _litellm_stub.exceptions.Timeout("timed out")
+        self.assertTrue(_is_transient_error(err))
+
+    def test_connection_error_is_transient(self):
+        err = _litellm_stub.exceptions.APIConnectionError("connection refused")
+        self.assertTrue(_is_transient_error(err))
+
+    def test_auth_error_is_not_transient(self):
+        err = _litellm_stub.exceptions.AuthenticationError("bad key")
+        self.assertFalse(_is_transient_error(err))
+
+    def test_not_found_is_not_transient(self):
+        err = _litellm_stub.exceptions.NotFoundError("model not found")
+        self.assertFalse(_is_transient_error(err))
+
+    def test_value_error_is_transient(self):
+        self.assertTrue(_is_transient_error(ValueError("empty response")))
+
+    def test_json_decode_error_is_transient(self):
+        self.assertTrue(_is_transient_error(json.JSONDecodeError("bad", "", 0)))
+
+
+if __name__ == "__main__":
+    unittest.main()


### PR DESCRIPTION
## Summary

- Adds [LiteLLM](https://github.com/BerriAI/litellm) as a new translator backend, giving users access to 100+ LLM providers (OpenAI, Anthropic, Google, Azure, AWS Bedrock, DeepSeek, and more) through a single unified interface.
- Single file, auto-discovered by the lazy registry - no changes to existing code.


LiteLLM handles provider-specific routing, auth, and parameter translation, so users just set a model string (e.g., `anthropic/claude-sonnet-4-20250514`, `gemini/gemini-2.5-flash`, `bedrock/anthropic.claude-3`) and a single API key.

## Changes

- **`ballontranslator/modules/translators/trans_litellm.py`** (new) - LiteLLM translator implementing `BaseTranslator` via `@register_translator("LiteLLM")`
  - Uses `litellm.completion()` with `drop_params=True` for cross-provider compatibility
  - JSON structured output with Pydantic validation (same response parsing as LLM_API_Translator)
  - Lazy import of `litellm` - only loaded when the translator is selected
  - `dependencies = ['litellm']` for on-demand installation via the in-app package manager
  - Configurable: model, api_key, api_base (for proxy), temperature, max_tokens, retries

## Tests

**1. AST scanner compatibility verified:**
```
$ python3 -c "import ast; tree = ast.parse(open('ballontranslator/modules/translators/trans_litellm.py').read()); print('OK')"
OK
```

**2. Code follows existing patterns:**
- Same `TranslationResponse` Pydantic model and JSON parsing logic as `trans_llm_api.py`
- Same `lang_map`, retry pattern, delay handling
- Same response extraction with markdown code block stripping and fallback parsing

## Risk / Compatibility

- **Additive only.** Single new file, no existing code touched.
- `litellm` installed on demand via the `dependencies` class attribute - base install unaffected.
- Follows the exact same translation prompt format and JSON response parsing as the existing LLM_API_Translator.

## Example usage

Select "LiteLLM" from the translator dropdown, then configure:
- **model**: `anthropic/claude-sonnet-4-20250514` (or any [supported model](https://docs.litellm.ai/docs/providers))
- **api_key**: Your provider API key (or leave empty if set via env var like `ANTHROPIC_API_KEY`)
- **api_base**: `http://localhost:4000` (if using LiteLLM proxy, otherwise leave empty)

```python
# Under the hood, the translator calls:
import litellm
response = litellm.completion(
    model="anthropic/claude-sonnet-4-20250514",
    messages=[...],
    temperature=0.1,
    max_tokens=4096,
    drop_params=True,  # silently drops unsupported params per provider
)
```
