### PR TITLE
Fix: persist font selection across restarts and prevent invalid font_list entries

### DIFF
--- a/ballontranslator/ui/text_panel.py
+++ b/ballontranslator/ui/text_panel.py
@@ -4,7 +4,7 @@ from typing import List
 
 from qtpy.QtWidgets import QLineEdit, QSizePolicy, QHBoxLayout, QVBoxLayout, QFrame, QFontComboBox, QApplication, QPushButton, QLabel, QGroupBox, QCheckBox, QSlider
 from qtpy.QtCore import Signal, Qt
-from qtpy.QtGui import QFocusEvent, QMouseEvent, QTextCursor, QKeyEvent
+from qtpy.QtGui import QFocusEvent, QMouseEvent, QTextCursor, QKeyEvent, QFont
 
 from ballontranslator.utils import shared
 from ballontranslator.utils import config as C
@@ -228,7 +228,15 @@ class FontFamilyComboBox(QFontComboBox):
         current_font = self.currentFont().family()
         self.clear()
         self.addItems(font_list)
-        self.addItems([current_font])
+
+        # If the current font is not in the list, use the first available font
+        if current_font not in font_list:
+            if font_list:  # If the list is not empty, use the first one.
+                current_font = list(font_list)[0]
+            else:  # Don't add anything if the list is empty.
+                self.currentFontChanged.connect(self.on_fontfamily_changed)
+                return
+    
         self.setCurrentText(current_font)
         self.currentFontChanged.connect(self.on_fontfamily_changed)
 
@@ -507,6 +515,7 @@ class FontFormatPanel(Widget):
             font_size += "+"
         self.fontsizebox.fcombobox.setCurrentText(font_size)
         self.familybox.setCurrentText(font_format.font_family)
+        self.familybox.setCurrentFont(QFont(font_format.font_family))
         self.colorPicker.setPickerColor(font_format.foreground_color())
         self.strokeColorPicker.setPickerColor(font_format.stroke_color())
         self.strokeWidthBox.setValue(font_format.stroke_width)


### PR DESCRIPTION
## Summary

Two related fixes to ensure font selection is correctly saved and restored:

1. **`set_active_format()`**: now also calls `setCurrentFont()`
   - Previously only `setCurrentText()` was called, which updates the displayed
     text but not the underlying `QFont` object.
   - This caused `update_font_list()` to read incorrect font info, so the
     `global_fontformat` value stored in `config.json` was never correctly
     applied.

2. **`update_font_list()`**: prevent system fonts from appearing when only
   custom fonts should be shown
   - Check whether `current_font` exists in the provided `font_list`.
   - If not found, fall back to the first available custom font.
   - If the custom font list is empty, skip setting the display.

## Why

Without these fixes:
- Font selection was not correctly restored after restarting the app.
- The "show custom fonts only" filter could still let system fonts leak
  into the display.

## Changes

- `set_active_format()`: add `setCurrentFont()` call
- `update_font_list()`: add fallback/guard logic for font list validation

## Testing

- [ ] Set a custom font, restart the app, confirm the font selection persists
- [ ] Enable "custom fonts only" mode, confirm no system fonts appear in the list
- [ ] Confirm `global_fontformat` in `config.json` is correctly applied on load

## Notes

No breaking changes; behavior-only fix for font persistence and filtering.