### PR TITLE
fix: respect Chinese UI language on startup

### DIFF
--- a/ballontranslator/launch.py
+++ b/ballontranslator/launch.py
@@ -207,6 +207,32 @@ def core_requirements_env(config_path: str) -> dict:
     return installer_env_with_pypi_mirror(os.environ.copy(), read_saved_pypi_mirror(config_path))
 
 
+def default_display_language(system_locale) -> str:
+    """Return the UI locale, preserving the user's Chinese script choice.
+
+    >>> locale = type('Locale', (), {
+    ...     'name': lambda self: 'zh_TW',
+    ...     'uiLanguages': lambda self: ['zh-Hans-CN'],
+    ... })()
+    >>> default_display_language(locale)
+    'zh_CN'
+    """
+
+    locale_name = system_locale.name().replace('en_CN', 'zh_CN')
+    try:
+        ui_languages = system_locale.uiLanguages()
+    except (AttributeError, TypeError):
+        return locale_name
+
+    for language in ui_languages:
+        normalized = language.replace('-', '_').lower()
+        if normalized.startswith('zh_hans') or normalized.startswith(('zh_cn', 'zh_sg')):
+            return 'zh_CN'
+        if normalized.startswith('zh_hant') or normalized.startswith(('zh_tw', 'zh_hk', 'zh_mo')):
+            return 'zh_TW'
+    return locale_name
+
+
 def main():
 
     if args.debug:
@@ -244,7 +270,7 @@ def main():
 
     from qtpy.QtCore import QTranslator, QLocale, Qt, QTimer
     shared.args = args
-    shared.DEFAULT_DISPLAY_LANG = QLocale.system().name().replace('en_CN', 'zh_CN')
+    shared.DEFAULT_DISPLAY_LANG = default_display_language(QLocale.system())
     shared.HEADLESS = args.headless
     shared.load_cache()
     program_config.load_config(args.config_path)

--- a/tests/test_launch_restart.py
+++ b/tests/test_launch_restart.py
@@ -11,6 +11,27 @@ from ballontranslator import launch
 
 class LaunchRestartTests(unittest.TestCase):
 
+    def test_default_display_language_uses_simplified_chinese_ui_language(self):
+        system_locale = mock.Mock()
+        system_locale.name.return_value = 'zh_TW'
+        system_locale.uiLanguages.return_value = ['zh-Hans-CN', 'en-US']
+
+        self.assertEqual(launch.default_display_language(system_locale), 'zh_CN')
+
+    def test_default_display_language_uses_traditional_chinese_ui_language(self):
+        system_locale = mock.Mock()
+        system_locale.name.return_value = 'zh_CN'
+        system_locale.uiLanguages.return_value = ['zh-Hant-TW', 'en-US']
+
+        self.assertEqual(launch.default_display_language(system_locale), 'zh_TW')
+
+    def test_default_display_language_keeps_non_chinese_locale(self):
+        system_locale = mock.Mock()
+        system_locale.name.return_value = 'fr_FR'
+        system_locale.uiLanguages.return_value = ['fr-FR']
+
+        self.assertEqual(launch.default_display_language(system_locale), 'fr_FR')
+
     def test_restart_preserves_module_launch(self):
         main_path = str(Path(launch.__file__).resolve().parent / '__main__.py')
         with mock.patch.object(sys, 'argv', [main_path, '--debug']), \


### PR DESCRIPTION
On systems whose regional formatting locale differs from their UI language, startup could select the wrong Chinese translation. Use Qt's ordered UI-language preference to distinguish simplified and traditional Chinese while preserving existing behavior for other locales.

Closes #1145

Test: `python -m unittest tests.test_launch_restart`
