### PR TITLE
CTBD 检测器新增文本类型筛选（框内框外过滤）

### DIFF
--- a/ballontranslator/modules/textdetector/detector_ctbd.py
+++ b/ballontranslator/modules/textdetector/detector_ctbd.py
@@ -505,6 +505,15 @@ class RTDetrV2TextDetector(TextDetectorBase):
             'description': 'Detect text blocks.',
             'display_name': 'Detect Text'
         },
+        # options UI shows raw values; no option i18n yet:
+        # all=全部, text_bubble=框內字, text_free=框外字
+        'text_region_filter': {
+            'value': 'all',
+            'type': 'selector',
+            'options': ['all', 'text_bubble', 'text_free'],
+            'description': 'Keep all text, only text inside speech bubbles, or only text outside speech bubbles.',
+            'display_name': 'Text Region Filter'
+        },
         'merge_duplicates': {
             'value': True,
             'type': 'checkbox',
@@ -557,6 +566,11 @@ class RTDetrV2TextDetector(TextDetectorBase):
     @property
     def detect_text(self) -> bool:
         return bool(self.get_param_value('detect_text'))
+
+    @property
+    def text_region_filter(self) -> str:
+        value = self.get_param_value('text_region_filter')
+        return value if value in {'all', 'text_bubble', 'text_free'} else 'all'
 
     @property
     def merge_duplicates(self) -> bool:
@@ -653,7 +667,10 @@ class RTDetrV2TextDetector(TextDetectorBase):
                 # ONNX output format is [x_min, y_min, x_max, y_max]
                 x1, y1, x2, y2 = map(int, box)
                 coords = [x1, y1, x2, y2]
-                if label == 0 and self.detect_bubbles:
+                needs_bubble_boxes = (
+                    self.detect_bubbles or self.text_region_filter != 'all'
+                )
+                if label == 0 and needs_bubble_boxes:
                     b_boxes.append(coords)
                 elif label in [1, 2] and self.detect_text:
                     t_boxes.append(coords)
@@ -678,9 +695,24 @@ class RTDetrV2TextDetector(TextDetectorBase):
         bub_list = bub_boxes.tolist() if bub_boxes.size > 0 else []
 
         for tb_rect in txt_boxes:
-            local_block_mask = np.zeros(img.shape[:2], dtype=np.uint8)
+            x1, y1, x2, y2 = tb_rect
+            current_tb_rect_list = tb_rect.tolist()
+            best_bubble = None
+            for bb in bub_list:
+                if does_rectangle_fit(bb, current_tb_rect_list):
+                    best_bubble = bb
+                    break
+                elif do_rectangles_overlap(bb, current_tb_rect_list):
+                    if best_bubble is None:
+                        best_bubble = bb
 
-            inpaint_regions = get_inpaint_bboxes(tb_rect.tolist(), img, self.logger)
+            text_class = "text_bubble" if best_bubble else "text_free"
+            if self.text_region_filter not in {'all', text_class}:
+                continue
+
+            # Build the mask only after filtering so excluded text is not erased.
+            local_block_mask = np.zeros(img.shape[:2], dtype=np.uint8)
+            inpaint_regions = get_inpaint_bboxes(current_tb_rect_list, img, self.logger)
             for r_x1, r_y1, r_x2, r_y2 in inpaint_regions:
                 cv2.rectangle(local_block_mask, (r_x1, r_y1), (r_x2, r_y2), 255, -1)
 
@@ -697,25 +729,14 @@ class RTDetrV2TextDetector(TextDetectorBase):
 
             final_inpaint_mask = cv2.bitwise_or(final_inpaint_mask, local_block_mask)
 
-            x1, y1, x2, y2 = tb_rect
-            current_tb_rect_list = tb_rect.tolist()
-            best_bubble = None
-            for bb in bub_list:
-                if does_rectangle_fit(bb, current_tb_rect_list):
-                    best_bubble = bb
-                    break
-                elif do_rectangles_overlap(bb, current_tb_rect_list):
-                    if best_bubble is None:
-                        best_bubble = bb
-
             block_to_add = TextBlock(
                 xyxy=current_tb_rect_list,
                 lines=[[[x1, y1], [x2, y1], [x2, y2], [x1, y2]]],
                 det_model=self.name,
-                label="text_bubble" if best_bubble else "text_free",
+                label=text_class,
             )
             setattr(block_to_add, 'bubble_xyxy', best_bubble)
-            setattr(block_to_add, 'text_class', "text_bubble" if best_bubble else "text_free")
+            setattr(block_to_add, 'text_class', text_class)
             blocks.append(block_to_add)
 
         self.logger.debug(
@@ -778,6 +799,7 @@ class RTDetrV2TextDetector(TextDetectorBase):
             "mask_unification_method",
             "detect_bubbles",
             "detect_text",
+            "text_region_filter",
             "merge_duplicates",
             "merge_duplicates_iou",
             "remove_contained_text",

--- a/ballontranslator/ui/_generated/module_param_i18n_catalog.py
+++ b/ballontranslator/ui/_generated/module_param_i18n_catalog.py
@@ -409,6 +409,12 @@ MODULE_PARAM_CATALOG = {
     ('textdetector', 'ctbd', 'slice_threshold_ratio', 'display_name'): {
         "source": 'Slice Threshold Ratio', "translate": lambda: QCoreApplication.translate('ModuleParamTranslator', 'Slice Threshold Ratio'),
     },
+    ('textdetector', 'ctbd', 'text_region_filter', 'description'): {
+        "source": 'Keep all text, only text inside speech bubbles, or only text outside speech bubbles.', "translate": lambda: QCoreApplication.translate('ModuleParamTranslator', 'Keep all text, only text inside speech bubbles, or only text outside speech bubbles.'),
+    },
+    ('textdetector', 'ctbd', 'text_region_filter', 'display_name'): {
+        "source": 'Text Region Filter', "translate": lambda: QCoreApplication.translate('ModuleParamTranslator', 'Text Region Filter'),
+    },
     ('textdetector', 'ctd', '', 'description'): {
         "source": 'ComicTextDetector', "translate": lambda: QCoreApplication.translate('ModuleParamTranslator', 'ComicTextDetector'),
     },

--- a/resources/translate/zh_CN.ts
+++ b/resources/translate/zh_CN.ts
@@ -2243,6 +2243,14 @@ All existing translation results will be cleared!</source>
         <translation>检测文本</translation>
     </message>
     <message>
+        <source>Keep all text, only text inside speech bubbles, or only text outside speech bubbles.</source>
+        <translation>保留全部文本、仅保留对话气泡内文本，或仅保留对话气泡外文本。</translation>
+    </message>
+    <message>
+        <source>Text Region Filter</source>
+        <translation>文本区域筛选</translation>
+    </message>
+    <message>
         <location filename="../../ballontranslator/ui/_generated/module_param_i18n_catalog.py" line="335"/>
         <source>Dilation kernel size (px) for the inpaint mask. Merges text fragments.</source>
         <translation>用于修复掩膜的膨胀核大小，用于合并文本碎块</translation>

--- a/resources/translate/zh_TW.ts
+++ b/resources/translate/zh_TW.ts
@@ -2249,6 +2249,14 @@ All existing translation results will be cleared!</source>
         <translation>檢測文本</translation>
     </message>
     <message>
+        <source>Keep all text, only text inside speech bubbles, or only text outside speech bubbles.</source>
+        <translation>保留全部文本、僅保留對話氣泡內文本，或僅保留對話氣泡外文本。</translation>
+    </message>
+    <message>
+        <source>Text Region Filter</source>
+        <translation>文本區域篩選</translation>
+    </message>
+    <message>
         <location filename="../../ballontranslator/ui/_generated/module_param_i18n_catalog.py" line="335"/>
         <source>Dilation kernel size (px) for the inpaint mask. Merges text fragments.</source>
         <translation>用於修復掩膜的膨脹核大小，用於合併文本碎塊</translation>


### PR DESCRIPTION
## Summary
- 为 CTBD 检测器新增 `Text Region Filter`（文本类型筛选），可选择保留全部文字、仅气泡内文字（`text_bubble`）、或仅气泡外文字（`text_free`）。
## Test plan
- [ ] CTBD 默认 `all`：结果与改动前一致
- [ ] 选 `text_bubble`：只保留气泡内文字块，气泡外原文不被修复
- [ ] 选 `text_free`：只保留气泡外文字块，气泡内原文不被修复