### PR TITLE
fix global text transforms for pipeline output and new text blocks

### DIFF
--- a/ballontranslator/ui/mainwindow.py
+++ b/ballontranslator/ui/mainwindow.py
@@ -1688,6 +1688,9 @@ class MainWindow(mainwindow_cls):
                     if sw > 0 and enable_ocr and enable_detect and not override_fnt_size:
                         blk.font_size = blk.font_size / (1 + sw)
 
+                    # Apply the complete global text-transform stack.
+                    blk.fontformat.text_transform = gf.text_transform
+
             self.st_manager.auto_textlayout_flag = pcfg.let_autolayout_flag and \
                 (enable_detect or enable_translate)
         

--- a/ballontranslator/ui/text_engine/item.py
+++ b/ballontranslator/ui/text_engine/item.py
@@ -842,8 +842,10 @@ class TextBlkItem(QGraphicsTextItem):
         self.fontformat.gradient_angle = ffmat.gradient_angle
         self.fontformat.gradient_size = ffmat.gradient_size
         
+        # Apply while the canonical model still contains the previous
+        # transform; merging first would skip live geometry recompilation.
+        self.set_text_transform(ffmat.text_transform)
         self.fontformat.merge(ffmat)
-        self.set_text_transform(self.fontformat.text_transform)
 
         self.repainting = False
         if self.fontformat.gradient_enabled:


### PR DESCRIPTION
## Summary

Global text transforms, such as vertical scaling, were not applied in two cases:

- After running the translation pipeline
- When creating a new text block by right-click dragging on the canvas

The pipeline applied the global font and typesetting properties to the resulting blocks, but did not copy the global `TextTransformStack`.

For newly created text blocks, `set_fontformat()` merged the target format into the block model before applying the live text transform. This made the transform appear unchanged and caused geometry recompilation to be skipped.

This change:

- Copies the complete global text-transform stack to pipeline output blocks
- Applies the live text transform before merging the target `FontFormat` into the block model
- Preserves existing per-block transforms when rendering without text-style updates

Because the complete `TextTransformStack` is applied, the fix also covers projective scaling, slant, 3D rotation, nonlinear transforms such as Bend, Sine, and Grid, and Glyph Slant.

## Before

https://github.com/user-attachments/assets/035ffbdd-2119-434d-a0c2-c34ef932c1a3

## After

https://github.com/user-attachments/assets/f77a71ec-6570-419c-8573-24552165ee73
