### PR TITLE
PR3-路径重排

### DIFF
--- a/ballontranslator/ui/canvas.py
+++ b/ballontranslator/ui/canvas.py
@@ -2,9 +2,9 @@ import numpy as np
 from typing import Callable, List, Optional, Union
 import os
 
-from qtpy.QtWidgets import QApplication, QSlider, QMenu, QGraphicsScene, QGraphicsSceneDragDropEvent , QGraphicsView, QGraphicsSceneDragDropEvent, QGraphicsRectItem, QGraphicsItem, QScrollBar, QGraphicsPixmapItem, QGraphicsSceneMouseEvent, QGraphicsSceneContextMenuEvent, QRubberBand
+from qtpy.QtWidgets import QApplication, QSlider, QMenu, QGraphicsScene, QGraphicsSceneDragDropEvent , QGraphicsView, QGraphicsSceneDragDropEvent, QGraphicsRectItem, QGraphicsItem, QScrollBar, QGraphicsPixmapItem, QGraphicsSceneMouseEvent, QGraphicsSceneContextMenuEvent, QRubberBand, QGraphicsPathItem
 from qtpy.QtCore import Qt, QDateTime, QRectF, QPointF, QPoint, Signal, QSize, QSizeF, QEvent, QTimer
-from qtpy.QtGui import QKeySequence, QPixmap, QImage, QHideEvent, QKeyEvent, QWheelEvent, QResizeEvent, QPainter, QPen, QPainterPath, QCursor, QNativeGestureEvent
+from qtpy.QtGui import QKeySequence, QPixmap, QImage, QHideEvent, QKeyEvent, QWheelEvent, QResizeEvent, QPainter, QPen, QPainterPath, QPainterPathStroker, QColor, QCursor, QNativeGestureEvent
 
 try:
     from qtpy.QtWidgets import QUndoStack, QUndoCommand
@@ -162,6 +162,9 @@ class Canvas(QGraphicsScene):
     incanvas_selection_changed = Signal()
     switch_text_item = Signal(int, QKeyEvent)
 
+    # Path-reorder mode
+    reorder_path_finished = Signal(list)  # touched_ids in contact order
+
     def __init__(self, parent=None):
         super().__init__(parent)
         self.scale_factor = 1.
@@ -170,6 +173,14 @@ class Canvas(QGraphicsScene):
         self.creating_textblock = False
         self.create_block_origin: QPointF = None
         self.editing_textblkitem: TextBlkItem = None
+
+        # Path-reorder mode (replaces grid-based Smart Reorder)
+        self._reorder_mode = False
+        self._reorder_drawing = False       # left button currently held
+        self._reorder_path = QPainterPath()
+        self._reorder_path_item: QGraphicsPathItem = None
+        self._reorder_touched_blocks: List[TextBlock] = []
+        self._reorder_brush_radius = 20.0   # effective brush half-width (scene coords)
 
         self.gv = CustomGV(self)
         self.gv.scale_down_signal.connect(self.scaleDown)
@@ -705,7 +716,116 @@ class Canvas(QGraphicsScene):
                 textblk_created = True
         return textblk_created
 
+    # ── Path-reorder mode ───────────────────────────────────────
+
+    def enterReorderMode(self):
+        """Enter path-drawing reorder mode.
+
+        The user draws one or more strokes across text blocks on the canvas.
+        Blocks are reordered in the sequence they are first touched.
+        """
+        self._reorder_mode = True
+        self._reorder_drawing = False
+        self._reorder_path = QPainterPath()
+        self._reorder_touched_blocks.clear()
+        self.gv.setCursor(Qt.CursorShape.CrossCursor)
+        self.gv.setDragMode(QGraphicsView.DragMode.NoDrag)
+
+        # Create visual path item
+        pen = QPen(QColor(52, 152, 219, 150), 4)
+        pen.setStyle(Qt.PenStyle.DashLine)
+        self._reorder_path_item = QGraphicsPathItem()
+        self._reorder_path_item.setPen(pen)
+        self._reorder_path_item.setZValue(150)  # above textLayer children
+        self._reorder_path_item.setParentItem(self.textLayer)
+        self._reorder_path_item.hide()
+        self.addItem(self._reorder_path_item)
+
+    def exitReorderMode(self):
+        """Exit path-drawing reorder mode and clean up."""
+        self._reorder_mode = False
+        self._reorder_drawing = False
+        self._reorder_path = QPainterPath()
+        self._reorder_touched_blocks.clear()
+        self.gv.unsetCursor()
+        self.gv.setDragMode(QGraphicsView.DragMode.ScrollHandDrag)
+
+        # Remove visual path item
+        if self._reorder_path_item is not None:
+            self.removeItem(self._reorder_path_item)
+            self._reorder_path_item = None
+
+        # Reset reorder badge state on all text blocks
+        for item in self.textLayer.childItems():
+            if isinstance(item, TextBlkItem):
+                if item._reorder_seq >= 0:
+                    item._reorder_seq = -1
+                    item.setSelected(False)
+                    item.update()
+
+    def _reorder_start_stroke(self, scene_pos: QPointF):
+        """Begin a new reorder path stroke at *scene_pos*."""
+        self._reorder_drawing = True
+        self._reorder_path = QPainterPath()
+        # Map from scene coords to textLayer local coords so the path
+        # and absBoundingRect() are in the same coordinate space.
+        self._reorder_path.moveTo(self.textLayer.mapFromScene(scene_pos))
+
+    def _reorder_extend_stroke(self, scene_pos: QPointF):
+        """Extend the current reorder stroke and check intersections."""
+        # Map to textLayer local coords to match absBoundingRect() space
+        local_pos = self.textLayer.mapFromScene(scene_pos)
+        self._reorder_path.lineTo(local_pos)
+
+        # Build a stroked (wide) version for collision detection.
+        # Scale brush radius inversely with zoom so the visual hit
+        # area stays consistent regardless of zoom level.
+        stroker = QPainterPathStroker()
+        stroker.setWidth(self._reorder_brush_radius * 2 / self.scale_factor)
+        stroked = stroker.createStroke(self._reorder_path)
+
+        # Check un-touched blocks
+        for item in self.textLayer.childItems():
+            if not isinstance(item, TextBlkItem):
+                continue
+            if any(item.blk is blk for blk in self._reorder_touched_blocks):
+                continue
+            br = item.absBoundingRect(qrect=True)
+            if stroked.intersects(br):
+                self._reorder_touched_blocks.append(item.blk)
+                item.setSelected(True)
+                item._reorder_seq = len(self._reorder_touched_blocks) - 1
+                item.update()
+
+        # Update visual path
+        if self._reorder_path_item is not None:
+            self._reorder_path_item.setPath(self._reorder_path)
+            if not self._reorder_path_item.isVisible():
+                self._reorder_path_item.show()
+
+    def _reorder_end_stroke(self):
+        """Finalize current stroke and emit results."""
+        self._reorder_drawing = False
+        # Build index from ALL canvas text items (includes unsaved
+        # new blocks that aren't yet in imgtrans_proj.pages)
+        canvas_blocks = [
+            item.blk
+            for item in self.textLayer.childItems()
+            if isinstance(item, TextBlkItem)
+        ]
+        idx_map = {id(blk): i for i, blk in enumerate(canvas_blocks)}
+        touched_ids = [
+            idx_map[id(blk)]
+            for blk in self._reorder_touched_blocks
+            if id(blk) in idx_map
+        ]
+        self.reorder_path_finished.emit(touched_ids)
+
     def mouseMoveEvent(self, event: QGraphicsSceneMouseEvent) -> None:
+        # Path-reorder mode — extend stroke and check intersections
+        if self._reorder_drawing:
+            self._reorder_extend_stroke(event.scenePos())
+            return
         control = self.active_text_transform_control()
         if control is not None and control.handle_modal_mouse_move(event):
             return
@@ -780,6 +900,10 @@ class Canvas(QGraphicsScene):
         if control is not None and control.handle_modal_mouse_press(event):
             return
         btn = event.button()
+        # Path-reorder mode — start drawing a stroke
+        if self._reorder_mode and btn == Qt.MouseButton.LeftButton:
+            self._reorder_start_stroke(event.scenePos())
+            return
         if (
             btn in (
                 Qt.MouseButton.LeftButton,
@@ -846,6 +970,10 @@ class Canvas(QGraphicsScene):
         if control is not None and control.handle_modal_mouse_release(event):
             return
         btn = event.button()
+        # Path-reorder mode — finish stroke and emit results
+        if self._reorder_drawing and btn == Qt.MouseButton.LeftButton:
+            self._reorder_end_stroke()
+            return
         rubber_target = self._rubber_band_target
         if self._finish_rubber_band(event.scenePos(), btn) and (
             rubber_target == 'grid'

--- a/ballontranslator/ui/configpanel.py
+++ b/ballontranslator/ui/configpanel.py
@@ -13,6 +13,7 @@ from qtpy.QtCore import Qt, Signal, QSize, QItemSelection, QTimer
 from qtpy.QtGui import QStandardItem, QStandardItemModel, QMouseEvent, QFont, QIntValidator, QValidator, QFocusEvent
 
 from .custom_widget import ConfigComboBox, NoBorderPushBtn, ScrollBar, Widget
+from .shortcut_editor import ShortcutEditor
 from ballontranslator.utils import shared
 from ballontranslator.utils.config import pcfg
 from ballontranslator.utils.version import APP_VERSION
@@ -676,6 +677,7 @@ class ConfigPanel(OutsideClickFramelessMixin, FramelessWindow):
     show_pre_MT_keyword_window = Signal()
     show_MT_keyword_window = Signal()
     show_OCR_keyword_window = Signal()
+    shortcuts_changed = Signal()
 
     dictionary_urls = DICTIONARY_URLS
 
@@ -711,12 +713,14 @@ class ConfigPanel(OutsideClickFramelessMixin, FramelessWindow):
         label_application = self.tr('Application')
         label_typesetting = self.tr('Typesetting')
         label_spellcheck = self.tr('Spell Checker')
+        label_shortcuts = self.tr('Shortcuts')
 
         pipelineConfigPanel = self.addConfigBlock(label_pipeline, moduleTableItem, 'pipeline')
         llmProfileConfigPanel = self.addConfigBlock(label_llm_profile, moduleTableItem, 'llm_profile')
         applicationConfigPanel = self.addConfigBlock(label_application, generalTableItem, 'application')
         typesettingConfigPanel = self.addConfigBlock(label_typesetting, generalTableItem, 'typesetting')
         spellcheckConfigPanel = self.addConfigBlock(label_spellcheck, generalTableItem, 'spellcheck')
+        shortcutsConfigPanel = self.addConfigBlock(label_shortcuts, generalTableItem, 'shortcuts')
         
         pipeline_options = QWidget()
         pipeline_options.setObjectName('PipelineModuleOptions')
@@ -894,6 +898,10 @@ class ConfigPanel(OutsideClickFramelessMixin, FramelessWindow):
         ext_layout.addLayout(ext_btns_layout)
 
         self.spellcheck_subblock = spellcheckConfigPanel.addBlockWidget(ext_layout)
+
+        self.shortcut_editor = ShortcutEditor()
+        self.shortcut_editor.shortcut_changed.connect(self._on_shortcuts_changed)
+        shortcutsConfigPanel.vlayout.addWidget(self.shortcut_editor)
 
         update_status_widget = QWidget()
         update_status_widget.setObjectName('ConfigInlineRow')
@@ -1101,6 +1109,10 @@ class ConfigPanel(OutsideClickFramelessMixin, FramelessWindow):
         self.show()
         self.raise_()
         self.activateWindow()
+
+    def _on_shortcuts_changed(self):
+        self.save_config.emit()
+        self.shortcuts_changed.emit()
 
     def showSection(self, section_key: str):
         section_key = SECTION_ALIASES.get(section_key, section_key)

--- a/ballontranslator/ui/configpanel.py
+++ b/ballontranslator/ui/configpanel.py
@@ -678,6 +678,7 @@ class ConfigPanel(OutsideClickFramelessMixin, FramelessWindow):
     show_MT_keyword_window = Signal()
     show_OCR_keyword_window = Signal()
     shortcuts_changed = Signal()
+    show_seq_badge_changed = Signal()
 
     dictionary_urls = DICTIONARY_URLS
 
@@ -1005,6 +1006,9 @@ class ConfigPanel(OutsideClickFramelessMixin, FramelessWindow):
         self.let_show_only_custom_fonts, sublock = typesettingConfigPanel.addCheckBox(self.tr("Show only custom fonts"))
         self.let_show_only_custom_fonts.stateChanged.connect(self.on_show_only_custom_fonts)
 
+        self.show_seq_badge_checker, _ = typesettingConfigPanel.addCheckBox(self.tr('Sequence Badge'))
+        self.show_seq_badge_checker.stateChanged.connect(self.on_show_seq_badge_changed)
+
         self.exclude_fonts_btn = QPushButton(self.tr('Hide Unused Fonts'), parent=self)
         self.exclude_fonts_btn.clicked.connect(self.show_font_exclusion_dialog)
         typesettingConfigPanel.addBlockWidget(
@@ -1307,6 +1311,11 @@ class ConfigPanel(OutsideClickFramelessMixin, FramelessWindow):
     def on_uppercase_changed(self):
         pcfg.let_uppercase_flag = self.let_uppercase_checker.isChecked()
 
+    def on_show_seq_badge_changed(self):
+        pcfg.show_seq_badge = self.show_seq_badge_checker.isChecked()
+        self.show_seq_badge_changed.emit()
+        self.save_config.emit()
+
     def on_textstyle_indep_changed(self):
         pcfg.let_textstyle_indep_flag = self.let_textstyle_indep_checker.isChecked()
         self.reload_textstyle.emit(pcfg.let_textstyle_indep_flag)
@@ -1495,6 +1504,7 @@ class ConfigPanel(OutsideClickFramelessMixin, FramelessWindow):
         self.let_autolayout_checker.setChecked(pcfg.let_autolayout_flag)
         self.let_uppercase_checker.setChecked(pcfg.let_uppercase_flag)
         self.let_textstyle_indep_checker.setChecked(pcfg.let_textstyle_indep_flag)
+        self.show_seq_badge_checker.setChecked(pcfg.show_seq_badge)
         self.rst_imgformat_combobox.setCurrentText(pcfg.imgsave_ext.replace('.', '').upper())
         self.intermediate_imgformat_combobox.setCurrentText(pcfg.intermediate_imgsave_ext.replace('.', '').upper())
         self.rst_imgquality_edit.setText(str(pcfg.imgsave_quality))

--- a/ballontranslator/ui/mainwindow.py
+++ b/ballontranslator/ui/mainwindow.py
@@ -30,6 +30,7 @@ from ballontranslator.utils.config import (
 )
 from ballontranslator.utils.proj_imgtrans import ProjImgTrans
 from .canvas import Canvas
+from .text_engine.item import TextBlkItem
 from .configpanel import ConfigPanel
 from .shortcut_editor import resolve_shortcut_keys
 from .module_manager import ModuleManager
@@ -853,6 +854,7 @@ class MainWindow(mainwindow_cls):
         self.titleBar.font_exclusion_trigger.connect(
             self.configPanel.show_font_exclusion_dialog
         )
+        self.titleBar.path_reorder_trigger.connect(self.on_path_reorder)
 
         self.configPanel.shortcuts_changed.connect(self.refreshShortcuts)
         self._install_shortcuts()
@@ -898,6 +900,7 @@ class MainWindow(mainwindow_cls):
         self.shortcut_registry["escape"] = self._make_shortcuts("escape", self.shortcutEscape)
         self.shortcut_registry["space_inpaint"] = self._make_shortcuts("space_inpaint", self.shortcutSpace)
         self.shortcut_registry["merge_tool"] = self._make_shortcuts("merge_tool", self.on_open_merge_tool)
+        self.shortcut_registry["path_reorder"] = self._make_shortcuts("path_reorder", self.on_path_reorder)
 
         drawpanel_info = {
             "hand": "hand_tool",
@@ -1090,6 +1093,100 @@ class MainWindow(mainwindow_cls):
             self.merge_dialog.activateWindow()
         else:
             self.merge_dialog.show()
+
+    # ── Path Reorder ─────────────────────────────────────────
+
+    def on_path_reorder(self):
+        """Path Reorder: user draws a path across text blocks to set reading order."""
+        if self.canvas._reorder_mode:
+            # Already in path-reorder mode — ignore repeat trigger
+            return
+
+        if self.imgtrans_proj.is_empty:
+            QMessageBox.warning(
+                self, self.tr("Warning"), self.tr("Please open a project first")
+            )
+            return
+
+        current_img = self.imgtrans_proj.current_img
+        if not current_img:
+            QMessageBox.warning(
+                self, self.tr("Warning"), self.tr("No current file")
+            )
+            return
+
+        if not self.imgtrans_proj.current_block_list():
+            QMessageBox.warning(
+                self, self.tr("Notice"), self.tr("No text blocks on current page")
+            )
+            return
+
+        self.canvas.reorder_path_finished.connect(self._on_reorder_path_done)
+        self.canvas.enterReorderMode()
+
+    def _on_reorder_path_done(self, touched_ids):
+        """Callback when a reorder path stroke is completed."""
+        self.canvas.reorder_path_finished.disconnect(self._on_reorder_path_done)
+
+        if len(touched_ids) < 2:
+            mb = QMessageBox(self)
+            mb.setWindowTitle(self.tr("Path Reorder"))
+            mb.setText(
+                self.tr(
+                    "Not enough text blocks touched by the path (need at least 2)."
+                )
+            )
+            cont_btn = mb.addButton(
+                self.tr("Continue Drawing"), QMessageBox.ButtonRole.ActionRole
+            )
+            mb.addButton(
+                self.tr("Cancel"), QMessageBox.ButtonRole.RejectRole
+            )
+            mb.setDefaultButton(cont_btn)
+            mb.exec_()
+            if mb.clickedButton() == cont_btn:
+                self.canvas.reorder_path_finished.connect(self._on_reorder_path_done)
+            else:
+                self.canvas.exitReorderMode()
+            return
+
+        mb = QMessageBox(self)
+        mb.setWindowTitle(self.tr("Path Reorder"))
+        mb.setText(self.tr("Apply reorder?"))
+        apply_btn = mb.addButton(
+            self.tr("Apply"), QMessageBox.ButtonRole.AcceptRole
+        )
+        cont_btn = mb.addButton(
+            self.tr("Continue Drawing"), QMessageBox.ButtonRole.ActionRole
+        )
+        mb.addButton(
+            self.tr("Cancel"), QMessageBox.ButtonRole.RejectRole
+        )
+        mb.setDefaultButton(apply_btn)
+        mb.exec_()
+
+        clicked = mb.clickedButton()
+        if clicked == apply_btn:
+            current_img = self.imgtrans_proj.current_img
+            # Build block list from canvas items (includes unsaved new blocks)
+            blk_list = [
+                item.blk
+                for item in self.canvas.textLayer.childItems()
+                if isinstance(item, TextBlkItem)
+            ]
+            reordered = [blk_list[i] for i in touched_ids]
+            untouched = [
+                b for i, b in enumerate(blk_list) if i not in touched_ids
+            ]
+            reordered.extend(untouched)
+            self.imgtrans_proj.pages[current_img] = reordered
+            self.canvas.updateCanvas()
+            self.st_manager.updateSceneTextitems()
+            self.canvas.exitReorderMode()
+        elif clicked == cont_btn:
+            self.canvas.reorder_path_finished.connect(self._on_reorder_path_done)
+        else:
+            self.canvas.exitReorderMode()
 
     def run_merge_task(self, on_current=False):
         """执行区域合并任务"""

--- a/ballontranslator/ui/mainwindow.py
+++ b/ballontranslator/ui/mainwindow.py
@@ -1,6 +1,6 @@
 import os.path as osp
 import os, re, traceback, sys
-from typing import List, Optional, Union
+from typing import List, Optional, Union, Dict
 from pathlib import Path
 import subprocess
 from functools import partial
@@ -31,6 +31,7 @@ from ballontranslator.utils.config import (
 from ballontranslator.utils.proj_imgtrans import ProjImgTrans
 from .canvas import Canvas
 from .configpanel import ConfigPanel
+from .shortcut_editor import resolve_shortcut_keys
 from .module_manager import ModuleManager
 from .text_engine.editing.widgets import SourceTextEdit, TransTextEdit
 from .drawingpanel import DrawingPanel
@@ -123,6 +124,7 @@ class MainWindow(mainwindow_cls):
         self.setupUi()
         self.validateModuleSelections()
         self.setupConfig()
+        self.shortcut_registry: Dict[str, list] = {}
         self.setupShortcuts()
         self.setupRegisterWidget()
         if not shared.ON_WINDOWS:
@@ -851,52 +853,72 @@ class MainWindow(mainwindow_cls):
             self.configPanel.show_font_exclusion_dialog
         )
 
-        shortcutA = QShortcut(QKeySequence("A"), self)
-        shortcutA.activated.connect(self.shortcutBefore)
-        shortcutPageUp = QShortcut(QKeySequence(QKeySequence.StandardKey.MoveToPreviousPage), self)
-        shortcutPageUp.activated.connect(self.shortcutBefore)
+        self.configPanel.shortcuts_changed.connect(self.refreshShortcuts)
+        self._install_shortcuts()
 
-        shortcutD = QShortcut(QKeySequence("D"), self)
-        shortcutD.activated.connect(self.shortcutNext)
-        shortcutPageDown = QShortcut(QKeySequence(QKeySequence.StandardKey.MoveToNextPage), self)
-        shortcutPageDown.activated.connect(self.shortcutNext)
+    def _make_shortcuts(self, action_id: str, slot) -> list:
+        """Create QShortcut objects for *action_id* from current config."""
+        lst = []
+        for k in resolve_shortcut_keys(action_id):
+            sc = QShortcut(QKeySequence(k), self)
+            sc.activated.connect(slot)
+            lst.append(sc)
+        return lst
 
-        shortcutTextblock = QShortcut(QKeySequence("W"), self)
-        shortcutTextblock.activated.connect(self.shortcutTextblock)
-        shortcutZoomIn = QShortcut(QKeySequence.StandardKey.ZoomIn, self)
-        shortcutZoomIn.activated.connect(self.canvas.gv.scale_up_signal)
-        shortcutZoomOut = QShortcut(QKeySequence.StandardKey.ZoomOut, self)
-        shortcutZoomOut.activated.connect(self.canvas.gv.scale_down_signal)
-        shortcutCtrlD = QShortcut(QKeySequence("Ctrl+D"), self)
-        shortcutCtrlD.activated.connect(self.shortcutCtrlD)
-        shortcutSpace = QShortcut(QKeySequence("Space"), self)
-        shortcutSpace.activated.connect(self.shortcutSpace)
-        shortcutSelectAll = QShortcut(QKeySequence.StandardKey.SelectAll, self)
-        shortcutSelectAll.activated.connect(self.shortcutSelectAll)
+    def refreshShortcuts(self):
+        """Rebuild all QShortcut objects from current pcfg.shortcuts (live update)."""
+        for lst in self.shortcut_registry.values():
+            for sc in lst:
+                sc.deleteLater()
+        self.shortcut_registry.clear()
+        self._install_shortcuts()
 
-        shortcutEscape = QShortcut(QKeySequence("Escape"), self)
-        shortcutEscape.activated.connect(self.shortcutEscape)
+    def _install_shortcuts(self):
+        """Create all QShortcut objects from current config (init + refresh)."""
+        self.shortcut_registry["prev_page"] = self._make_shortcuts("prev_page", self.shortcutBefore)
+        self.shortcut_registry["prev_page_alt"] = self._make_shortcuts("prev_page_alt", self.shortcutBefore)
+        self.shortcut_registry["next_page"] = self._make_shortcuts("next_page", self.shortcutNext)
+        self.shortcut_registry["next_page_alt"] = self._make_shortcuts("next_page_alt", self.shortcutNext)
+        self.shortcut_registry["textedit_mode"] = self._make_shortcuts("textedit_mode", self.shortcutTextedit)
+        self.shortcut_registry["textblock_mode"] = self._make_shortcuts("textblock_mode", self.shortcutTextblock)
+        self.shortcut_registry["drawboard_mode"] = self._make_shortcuts("drawboard_mode", self.shortcutDrawboard)
+        self.shortcut_registry["zoom_in"] = self._make_shortcuts("zoom_in", self.canvas.gv.scale_up_signal)
+        self.shortcut_registry["zoom_out"] = self._make_shortcuts("zoom_out", self.canvas.gv.scale_down_signal)
+        self.shortcut_registry["delete_blks"] = self._make_shortcuts("delete_blks", self.shortcutDelete)
+        self.shortcut_registry["delete_blks_alt"] = self._make_shortcuts("delete_blks_alt", self.shortcutCtrlD)
+        self.shortcut_registry["select_all"] = self._make_shortcuts("select_all", self.shortcutSelectAll)
+        self.shortcut_registry["bold"] = self._make_shortcuts("bold", self.shortcutBold)
+        self.shortcut_registry["italic"] = self._make_shortcuts("italic", self.shortcutItalic)
+        self.shortcut_registry["underline"] = self._make_shortcuts("underline", self.shortcutUnderline)
+        self.shortcut_registry["undo"] = self._make_shortcuts("undo", self.on_undo)
+        self.shortcut_registry["redo"] = self._make_shortcuts("redo", self.on_redo)
+        self.shortcut_registry["page_search"] = self._make_shortcuts("page_search", self.on_page_search)
+        self.shortcut_registry["global_search"] = self._make_shortcuts("global_search", self.on_global_search)
+        self.shortcut_registry["escape"] = self._make_shortcuts("escape", self.shortcutEscape)
+        self.shortcut_registry["space_inpaint"] = self._make_shortcuts("space_inpaint", self.shortcutSpace)
+        self.shortcut_registry["merge_tool"] = self._make_shortcuts("merge_tool", self.on_open_merge_tool)
 
-        shortcutBold = QShortcut(QKeySequence.StandardKey.Bold, self)
-        shortcutBold.activated.connect(self.shortcutBold)
-        shortcutItalic = QShortcut(QKeySequence.StandardKey.Italic, self)
-        shortcutItalic.activated.connect(self.shortcutItalic)
-        shortcutUnderline = QShortcut(QKeySequence.StandardKey.Underline, self)
-        shortcutUnderline.activated.connect(self.shortcutUnderline)
-
-        shortcutDelete = QShortcut(QKeySequence.StandardKey.Delete, self)
-        shortcutDelete.activated.connect(self.shortcutDelete)
-
-        drawpanel_shortcuts = {'hand': 'H', 'rect': 'R', 'inpaint': 'J', 'pen': 'B'}
-        for tool_name, shortcut_key in drawpanel_shortcuts.items():
-            shortcut = QShortcut(QKeySequence(shortcut_key), self)
-            key = getattr(QKEY, f'Key_{shortcut_key}')
-            shortcut.activated.connect(partial(
-                self.drawingPanel.shortcutSetCurrentToolByName,
-                tool_name,
-                key,
-            ))
-            self.drawingPanel.setShortcutTip(tool_name, shortcut_key)
+        drawpanel_info = {
+            "hand": "hand_tool",
+            "rect": "rect_tool",
+            "inpaint": "inpaint_tool",
+            "pen": "pen_tool",
+        }
+        for tool_name, action_id in drawpanel_info.items():
+            keys = resolve_shortcut_keys(action_id)
+            lst = []
+            for k in keys:
+                sc = QShortcut(QKeySequence(k), self)
+                key = getattr(QKEY, f'Key_{k}', None) if len(k) == 1 else None
+                sc.activated.connect(partial(
+                    self.drawingPanel.shortcutSetCurrentToolByName,
+                    tool_name,
+                    key,
+                ))
+                lst.append(sc)
+            if keys:
+                self.drawingPanel.setShortcutTip(tool_name, keys[0])
+            self.shortcut_registry[action_id] = lst
 
     def shortcutNext(self):
         sender: QShortcut = self.sender()

--- a/ballontranslator/ui/mainwindow.py
+++ b/ballontranslator/ui/mainwindow.py
@@ -483,6 +483,7 @@ class MainWindow(mainwindow_cls):
         self.configPanel.check_update.connect(self.check_for_updates)
         self.configPanel.reload_textstyle.connect(self.load_textstyle_from_proj_dir)
         self.configPanel.font_list_changed.connect(self.on_show_only_custom_font)
+        self.configPanel.show_seq_badge_changed.connect(self.canvas.update)
         if pcfg.let_show_only_custom_fonts_flag or pcfg.excluded_fonts:
             self.on_show_only_custom_font(pcfg.let_show_only_custom_fonts_flag)
 

--- a/ballontranslator/ui/mainwindowbars.py
+++ b/ballontranslator/ui/mainwindowbars.py
@@ -415,11 +415,16 @@ class TitleBar(Widget):
         mergeToolAction = QAction('区域合并工具', self)
         self.merge_tool_trigger = mergeToolAction.triggered
 
+        # 路径重排（画路径定义阅读顺序）
+        pathReorderAction = QAction(self.tr('Path Reorder'), self)
+        self.path_reorder_trigger = pathReorderAction.triggered
+
         fontExclusionAction = QAction(self.tr('Font Exclusion'), self)
         self.font_exclusion_trigger = fontExclusionAction.triggered
         
         toolsMenu = QMenu(self.toolsToolBtn)
         toolsMenu.addAction(mergeToolAction)
+        toolsMenu.addAction(pathReorderAction)
         toolsMenu.addSeparator()
         toolsMenu.addAction(fontExclusionAction)
         self.toolsToolBtn.setMenu(toolsMenu)

--- a/ballontranslator/ui/mainwindowbars.py
+++ b/ballontranslator/ui/mainwindowbars.py
@@ -318,16 +318,12 @@ class TitleBar(Widget):
 
         undoAction = QAction(self.tr('Undo'), self)
         self.undo_trigger = undoAction.triggered
-        undoAction.setShortcut(QKeySequence.StandardKey.Undo)
         redoAction = QAction(self.tr('Redo'), self)
         self.redo_trigger = redoAction.triggered
-        redoAction.setShortcut(QKeySequence.StandardKey.Redo)
         pageSearchAction = QAction(self.tr('Search'), self)
         self.page_search_trigger = pageSearchAction.triggered
-        pageSearchAction.setShortcut(QKeySequence('Ctrl+F'))
         globalSearchAction = QAction(self.tr('Global Search'), self)
         self.global_search_trigger = globalSearchAction.triggered
-        globalSearchAction.setShortcut(QKeySequence('Ctrl+G'))
 
         replacePreMTkeyword = QAction(self.tr("Keyword substitution for machine translation source text"), self)
         self.replacePreMTkeyword_trigger = replacePreMTkeyword.triggered
@@ -363,9 +359,7 @@ class TitleBar(Widget):
         self.displayLanguageMenu.addActions(lang_actions)
 
         drawBoardAction = QAction(self.tr('Drawing Board'), self)
-        drawBoardAction.setShortcut(QKeySequence('P'))
         texteditAction = QAction(self.tr('Text Editor'), self)
-        texteditAction.setShortcut(QKeySequence('T'))
         importTextStyles = QAction(self.tr('Import Text Styles'), self)
         exportTextStyles = QAction(self.tr('Export Text Styles'), self)
         self.darkModeAction = darkModeAction = QAction(self.tr('Dark Mode'), self)
@@ -405,9 +399,7 @@ class TitleBar(Widget):
         self.goToolBtn = TitleBarToolBtn(self)
         self.goToolBtn.setText(self.tr('Go'))
         prevPageAction = QAction(self.tr('Previous Page'), self)
-        # prevPageAction.setShortcuts([QKeySequence.StandardKey.MoveToPreviousPage, QKeySequence('A')])
         nextPageAction = QAction(self.tr('Next Page'), self)
-        # nextPageAction.setShortcuts([QKeySequence.StandardKey.MoveToNextPage, QKeySequence('D')])
         goMenu = QMenu(self.goToolBtn)
         goMenu.addActions([prevPageAction, nextPageAction])
         self.goToolBtn.setMenu(goMenu)
@@ -421,7 +413,6 @@ class TitleBar(Widget):
         
         # 区域合并工具
         mergeToolAction = QAction('区域合并工具', self)
-        mergeToolAction.setShortcut(QKeySequence('Ctrl+Shift+M'))
         self.merge_tool_trigger = mergeToolAction.triggered
 
         fontExclusionAction = QAction(self.tr('Font Exclusion'), self)

--- a/ballontranslator/ui/shortcut_editor.py
+++ b/ballontranslator/ui/shortcut_editor.py
@@ -1,0 +1,302 @@
+"""User-configurable keyboard shortcut editor (settings panel section).
+
+The defaults mirror the previously hard-coded shortcuts; each action keeps
+its effective binding unless the user overrides it in ``pcfg.shortcuts``.
+"""
+
+from typing import Dict, List
+
+from qtpy.QtCore import Qt, Signal
+from qtpy.QtGui import QKeySequence
+from qtpy.QtWidgets import (
+    QFrame,
+    QHBoxLayout,
+    QKeySequenceEdit,
+    QLabel,
+    QPushButton,
+    QVBoxLayout,
+    QWidget,
+)
+
+from ballontranslator.utils.config import pcfg
+from ballontranslator.utils.shortcut_conflicts import find_conflict_keys
+
+from .custom_widget import PanelGroupBox
+
+DEFAULT_SHORTCUTS: Dict[str, List[str]] = {
+    "prev_page": ["A"],
+    "prev_page_alt": ["PgUp"],
+    "next_page": ["D"],
+    "next_page_alt": ["PgDown"],
+    "textedit_mode": ["T"],
+    "textblock_mode": ["W"],
+    "drawboard_mode": ["P"],
+    "zoom_in": ["Ctrl++"],
+    "zoom_out": ["Ctrl+-"],
+    "delete_blks": ["Del"],
+    "delete_blks_alt": ["Ctrl+D"],
+    "select_all": ["Ctrl+A"],
+    "bold": ["Ctrl+B"],
+    "italic": ["Ctrl+I"],
+    "underline": ["Ctrl+U"],
+    "undo": ["Ctrl+Z"],
+    "redo": ["Ctrl+Y"],
+    "page_search": ["Ctrl+F"],
+    "global_search": ["Ctrl+G"],
+    "escape": ["Escape"],
+    "space_inpaint": ["Space"],
+    "hand_tool": ["H"],
+    "rect_tool": ["R"],
+    "inpaint_tool": ["J"],
+    "pen_tool": ["B"],
+    "merge_tool": ["Ctrl+Shift+M"],
+}
+
+_ACTION_NAMES: Dict[str, str] = {
+    "prev_page": "Page Up",
+    "next_page": "Page Down",
+    "prev_page_alt": "Page Up (alt)",
+    "next_page_alt": "Page Down (alt)",
+    "textedit_mode": "Text Editor",
+    "textblock_mode": "Text Block",
+    "drawboard_mode": "Draw Board",
+    "zoom_in": "Zoom In",
+    "zoom_out": "Zoom Out",
+    "delete_blks": "Delete",
+    "delete_blks_alt": "Delete (alt)",
+    "select_all": "Select All",
+    "bold": "Bold",
+    "italic": "Italic",
+    "underline": "Underline",
+    "undo": "Undo",
+    "redo": "Redo",
+    "page_search": "Page Search",
+    "global_search": "Global Search",
+    "escape": "Escape",
+    "space_inpaint": "Inpaint",
+    "hand_tool": "Hand Tool",
+    "rect_tool": "Rect Tool",
+    "inpaint_tool": "Inpaint Tool",
+    "pen_tool": "Pen Tool",
+    "merge_tool": "Merge Tool",
+}
+
+_SHORTCUT_GROUPS: List[tuple] = [
+    ("Navigation", ["prev_page", "next_page", "prev_page_alt", "next_page_alt"]),
+    ("View", ["zoom_in", "zoom_out"]),
+    (
+        "Edit",
+        [
+            "textedit_mode",
+            "textblock_mode",
+            "drawboard_mode",
+            "delete_blks",
+            "delete_blks_alt",
+            "select_all",
+            "bold",
+            "italic",
+            "underline",
+            "undo",
+            "redo",
+        ],
+    ),
+    (
+        "Tools",
+        [
+            "hand_tool",
+            "rect_tool",
+            "inpaint_tool",
+            "pen_tool",
+            "merge_tool",
+            "space_inpaint",
+        ],
+    ),
+    ("Search", ["page_search", "global_search"]),
+    ("General", ["escape"]),
+]
+
+
+def resolve_shortcut_keys(action_id: str) -> List[str]:
+    """Effective key sequences for *action_id* — user override, else default."""
+    if action_id in pcfg.shortcuts:
+        keys = pcfg.shortcuts[action_id]
+        if not isinstance(keys, list):
+            keys = [keys] if keys else []
+        return list(keys)
+    return list(DEFAULT_SHORTCUTS.get(action_id, []))
+
+
+class _ShortcutRow(QWidget):
+    """A row for editing the shortcuts of a single action."""
+
+    shortcut_changed = Signal()
+
+    def __init__(self, action_id: str, parent=None):
+        super().__init__(parent)
+        self.action_id = action_id
+        self._conflict_keys: set = set()
+
+        h = QHBoxLayout(self)
+        h.setContentsMargins(2, 6, 2, 6)
+        h.setSpacing(6)
+
+        name = QLabel(self.tr(_ACTION_NAMES.get(action_id, action_id)))
+        name.setObjectName("ShortcutActionName")
+        name.setFixedWidth(150)
+        h.addWidget(name)
+
+        self.shortcuts_widget = QWidget()
+        self.shortcuts_layout = QHBoxLayout(self.shortcuts_widget)
+        self.shortcuts_layout.setContentsMargins(0, 0, 0, 0)
+        self.shortcuts_layout.setSpacing(4)
+        self.shortcuts_layout.setAlignment(Qt.AlignmentFlag.AlignLeft)
+        h.addWidget(self.shortcuts_widget, 1)
+
+        add_btn = QPushButton("+")
+        add_btn.setObjectName("ShortcutAddBtn")
+        add_btn.setFixedSize(24, 24)
+        add_btn.setToolTip(self.tr("Add shortcut"))
+        add_btn.clicked.connect(self._add_shortcut)
+        h.addWidget(add_btn)
+
+        clear_btn = QPushButton(self.tr("Del"))
+        clear_btn.setObjectName("ShortcutDelBtn")
+        clear_btn.setFixedSize(32, 24)
+        clear_btn.setToolTip(self.tr("Remove all shortcuts"))
+        clear_btn.clicked.connect(self._clear)
+        h.addWidget(clear_btn)
+
+        reset_btn = QPushButton(self.tr("Rst"))
+        reset_btn.setObjectName("ShortcutRstBtn")
+        reset_btn.setFixedSize(32, 24)
+        reset_btn.setToolTip(self.tr("Reset to default"))
+        reset_btn.clicked.connect(self._reset)
+        h.addWidget(reset_btn)
+
+        self._rebuild_pills()
+
+    def effective_keys(self) -> List[str]:
+        return resolve_shortcut_keys(self.action_id)
+
+    def _rebuild_pills(self):
+        while self.shortcuts_layout.count():
+            item = self.shortcuts_layout.takeAt(0)
+            if item.widget():
+                item.widget().deleteLater()
+
+        keys = self.effective_keys()
+        if keys:
+            for k in keys:
+                pill = QFrame()
+                pill.setObjectName("ShortcutPill")
+                is_conflict = k in self._conflict_keys
+                pill.setProperty("conflict", is_conflict)
+                pill_layout = QHBoxLayout(pill)
+                pill_layout.setContentsMargins(8, 1, 4, 1)
+                pill_layout.setSpacing(2)
+                lbl = QLabel(k)
+                lbl.setObjectName("ShortcutPillLabel")
+                lbl.setProperty("conflict", is_conflict)
+                pill_layout.addWidget(lbl)
+                close_btn = QPushButton("x")
+                close_btn.setObjectName("ShortcutPillCloseBtn")
+                close_btn.setFixedSize(20, 20)
+                close_btn.clicked.connect(
+                    lambda checked, ks=k: self._remove_shortcut(ks)
+                )
+                pill_layout.addWidget(close_btn)
+                self.shortcuts_layout.addWidget(pill)
+        else:
+            placeholder = QLabel(self.tr("— None —"))
+            placeholder.setObjectName("ShortcutNoneLabel")
+            self.shortcuts_layout.addWidget(placeholder)
+
+    def _add_shortcut(self):
+        edit = QKeySequenceEdit()
+        edit.setFixedWidth(120)
+        edit.setFixedHeight(24)
+        self.shortcuts_layout.addWidget(edit)
+        edit.setFocus()
+
+        def on_finished():
+            seq = edit.keySequence().toString()
+            edit.deleteLater()
+            if seq:
+                keys = self.effective_keys()
+                if seq not in keys:
+                    keys.append(seq)
+                    pcfg.shortcuts[self.action_id] = keys
+                self._rebuild_pills()
+                self.shortcut_changed.emit()
+            else:
+                self._rebuild_pills()
+
+        edit.editingFinished.connect(on_finished)
+
+    def _remove_shortcut(self, key_seq: str):
+        keys = self.effective_keys()
+        if key_seq in keys:
+            keys.remove(key_seq)
+            pcfg.shortcuts[self.action_id] = keys
+        self._rebuild_pills()
+        self.shortcut_changed.emit()
+
+    def _clear(self):
+        pcfg.shortcuts[self.action_id] = []
+        self._rebuild_pills()
+        self.shortcut_changed.emit()
+
+    def _reset(self):
+        defaults = list(DEFAULT_SHORTCUTS.get(self.action_id, []))
+        if defaults:
+            pcfg.shortcuts[self.action_id] = defaults
+        elif self.action_id in pcfg.shortcuts:
+            del pcfg.shortcuts[self.action_id]
+        self._rebuild_pills()
+        self.shortcut_changed.emit()
+
+    def refresh(self, conflict_keys=None):
+        self._conflict_keys = conflict_keys or set()
+        self._rebuild_pills()
+
+
+class ShortcutEditor(QWidget):
+    """Grouped shortcut rows; each row records new keys via QKeySequenceEdit."""
+
+    shortcut_changed = Signal()
+
+    def __init__(self, parent=None):
+        super().__init__(parent)
+        self._rows: Dict[str, _ShortcutRow] = {}
+
+        layout = QVBoxLayout(self)
+        layout.setContentsMargins(0, 0, 0, 0)
+        layout.setSpacing(6)
+
+        for group_name, action_ids in _SHORTCUT_GROUPS:
+            group_box = PanelGroupBox(self.tr(group_name))
+            group_layout = QVBoxLayout(group_box)
+            group_layout.setSpacing(0)
+            for action_id in action_ids:
+                row = _ShortcutRow(action_id)
+                row.shortcut_changed.connect(self._on_row_changed)
+                self._rows[action_id] = row
+                group_layout.addWidget(row)
+            layout.addWidget(group_box)
+
+        layout.addStretch()
+        self.refresh()
+
+    def _on_row_changed(self):
+        self.refresh()
+        self.shortcut_changed.emit()
+
+    def _compute_conflicts(self) -> set:
+        return find_conflict_keys(
+            {aid: row.effective_keys() for aid, row in self._rows.items()}
+        )
+
+    def refresh(self):
+        conflicts = self._compute_conflicts()
+        for row in self._rows.values():
+            row.refresh(conflicts)

--- a/ballontranslator/ui/shortcut_editor.py
+++ b/ballontranslator/ui/shortcut_editor.py
@@ -50,6 +50,7 @@ DEFAULT_SHORTCUTS: Dict[str, List[str]] = {
     "inpaint_tool": ["J"],
     "pen_tool": ["B"],
     "merge_tool": ["Ctrl+Shift+M"],
+    "path_reorder": [],
 }
 
 _ACTION_NAMES: Dict[str, str] = {
@@ -79,6 +80,7 @@ _ACTION_NAMES: Dict[str, str] = {
     "inpaint_tool": "Inpaint Tool",
     "pen_tool": "Pen Tool",
     "merge_tool": "Merge Tool",
+    "path_reorder": "Path Reorder",
 }
 
 _SHORTCUT_GROUPS: List[tuple] = [
@@ -108,6 +110,7 @@ _SHORTCUT_GROUPS: List[tuple] = [
             "inpaint_tool",
             "pen_tool",
             "merge_tool",
+            "path_reorder",
             "space_inpaint",
         ],
     ),

--- a/ballontranslator/ui/text_engine/item.py
+++ b/ballontranslator/ui/text_engine/item.py
@@ -56,6 +56,7 @@ class TextBlkItem(QGraphicsTextItem):
         self.old_ffmt_values = None
         
         self.idx = idx
+        self._reorder_seq = -1   # reading-order badge override during path reorder
         
         self.stroke_qcolor = QColor(0, 0, 0)
         self._old_pos = QPointF()
@@ -594,7 +595,10 @@ class TextBlkItem(QGraphicsTextItem):
         font = QFont()
         font.setBold(True)
         font.setPixelSize(font_size)
-        seq_text = str(self.idx + 1)
+        if self._reorder_seq >= 0:
+            seq_text = str(self._reorder_seq + 1)
+        else:
+            seq_text = str(self.idx + 1)
         fm = QFontMetrics(font)
         text_w = fm.horizontalAdvance(seq_text) + 8
         text_h = fm.height() + 4

--- a/ballontranslator/ui/text_engine/item.py
+++ b/ballontranslator/ui/text_engine/item.py
@@ -5,8 +5,9 @@ from qtpy.QtWidgets import QGraphicsItem, QWidget, QGraphicsSceneHoverEvent, QGr
 from qtpy.QtCore import Qt, QRect, QRectF, QPoint, QPointF, Signal
 from qtpy.QtGui import (QKeyEvent, QFont, QTextCursor,
                        QInputMethodEvent, QPainter, QColor, QTextCharFormat,
-                       QBrush, QPen)
+                       QBrush, QPen, QFontMetrics)
 
+from ballontranslator.utils.config import pcfg
 from ballontranslator.utils.textblock import TextBlock
 from ballontranslator.utils.imgproc_utils import xywh2xyxypoly
 from ballontranslator.utils.fontformat import (
@@ -576,6 +577,48 @@ class TextBlkItem(QGraphicsTextItem):
             super().paint,
         )
         self._paint_ui_guide(painter)
+        self._paint_seq_badge(painter)
+
+    def _paint_seq_badge(self, painter: QPainter) -> None:
+        """Draw the reading-order number badge at the content top-left corner."""
+        if self._ui_guide_suppressed or not pcfg.show_seq_badge:
+            return
+        outline = self.geometry_controller.visual_outline_in_item()
+        content_rect = (
+            outline.boundingRect() if not outline.isEmpty() else self.boundingRect()
+        )
+        top_level = self.topLevelItem()
+        scale = top_level.scale() if top_level is not None else 1.0
+        scale = scale if scale > 0 else 1.0
+        font_size = max(6, int(11 / scale))
+        font = QFont()
+        font.setBold(True)
+        font.setPixelSize(font_size)
+        seq_text = str(self.idx + 1)
+        fm = QFontMetrics(font)
+        text_w = fm.horizontalAdvance(seq_text) + 8
+        text_h = fm.height() + 4
+        badge_rect = QRectF(
+            content_rect.x(),
+            content_rect.y(),
+            text_w,
+            text_h,
+        )
+        painter.save()
+        if self.isSelected():
+            from ballontranslator.ui.custom_widget.helper import themeColor
+
+            bg = QColor(themeColor())
+            bg.setAlpha(200)
+        else:
+            bg = QColor(0, 0, 0, 170)
+        painter.setBrush(bg)
+        painter.setPen(Qt.PenStyle.NoPen)
+        painter.drawRoundedRect(badge_rect, 3, 3)
+        painter.setPen(Qt.GlobalColor.white)
+        painter.setFont(font)
+        painter.drawText(badge_rect, Qt.AlignmentFlag.AlignCenter, seq_text)
+        painter.restore()
 
     def _paint_ui_guide(self, painter: QPainter) -> None:
         """Paint selection/block guides outside cached effect surfaces."""

--- a/ballontranslator/utils/config.py
+++ b/ballontranslator/utils/config.py
@@ -309,6 +309,7 @@ class ProgramConfig(Config):
     text_transform_panel: bool = True
     expand_ttransform_panel: bool = True
     excluded_fonts: List[str] = field(default_factory=list)
+    shortcuts: Dict[str, List[str]] = field(default_factory=dict)
 
     @staticmethod
     def load(cfg_path: str):

--- a/ballontranslator/utils/config.py
+++ b/ballontranslator/utils/config.py
@@ -308,6 +308,7 @@ class ProgramConfig(Config):
     expand_tadvanced_panel: bool = True
     text_transform_panel: bool = True
     expand_ttransform_panel: bool = True
+    show_seq_badge: bool = True
     excluded_fonts: List[str] = field(default_factory=list)
     shortcuts: Dict[str, List[str]] = field(default_factory=dict)
 

--- a/ballontranslator/utils/shortcut_conflicts.py
+++ b/ballontranslator/utils/shortcut_conflicts.py
@@ -1,0 +1,22 @@
+"""Shared shortcut-conflict detection.
+
+Used by the shortcut editor (``ShortcutEditor``) — every user-assignable
+key sequence must not be bound to more than one action.
+"""
+
+from typing import Dict, Iterable, List, Set
+
+
+def find_conflict_keys(mapping: Dict[str, Iterable[str]]) -> Set[str]:
+    """Return the set of key sequences bound to more than one action.
+
+    *mapping* maps an action id to its list of effective key sequences;
+    empty / ``None`` entries are skipped.  The returned set contains the
+    duplicated key strings.
+    """
+    seen: Dict[str, List[str]] = {}
+    for owner, keys in mapping.items():
+        for k in keys or []:
+            if k:
+                seen.setdefault(k, []).append(owner)
+    return {k for k, owners in seen.items() if len(owners) > 1}

--- a/resources/stylesheet.css
+++ b/resources/stylesheet.css
@@ -2452,3 +2452,76 @@ QWidget#suggestion_popup QScrollBar::sub-page:horizontal {
     width: 0px;
     background: transparent;
 }
+
+/* Shortcut editor (settings -> Shortcuts) */
+QLabel#ShortcutActionName {
+    color: @qwidgetForegroundColor;
+    background: transparent;
+    border: none;
+}
+
+QFrame#ShortcutPill {
+    background: rgba(120, 140, 170, 0.25);
+    border-radius: 4px;
+}
+
+QFrame#ShortcutPill[conflict="true"] {
+    background: rgba(255, 90, 90, 0.30);
+}
+
+QLabel#ShortcutPillLabel {
+    color: @qwidgetForegroundColor;
+    background: transparent;
+    border: none;
+}
+
+QLabel#ShortcutPillLabel[conflict="true"] {
+    color: #ff8080;
+}
+
+QPushButton#ShortcutPillCloseBtn {
+    color: @qwidgetForegroundColor;
+    background: transparent;
+    border: none;
+    border-radius: 2px;
+    padding: 0px;
+}
+
+QPushButton#ShortcutPillCloseBtn:hover {
+    color: #ff8080;
+    background: rgba(255, 90, 90, 0.25);
+}
+
+QPushButton#ShortcutAddBtn {
+    color: @qwidgetForegroundColor;
+    background: transparent;
+    border: 1px solid @borderColor;
+    border-radius: 3px;
+    padding: 0px;
+}
+
+QPushButton#ShortcutAddBtn:hover {
+    color: #7fb4ff;
+    border-color: #7fb4ff;
+}
+
+QPushButton#ShortcutDelBtn,
+QPushButton#ShortcutRstBtn {
+    color: @qwidgetForegroundColor;
+    background: transparent;
+    border: none;
+    border-radius: 3px;
+    padding: 0px;
+}
+
+QPushButton#ShortcutDelBtn:hover,
+QPushButton#ShortcutRstBtn:hover {
+    color: #ff8080;
+}
+
+QLabel#ShortcutNoneLabel {
+    color: @qwidgetForegroundColor;
+    background: transparent;
+    font-style: italic;
+}
+

--- a/resources/translate/en_US.ts
+++ b/resources/translate/en_US.ts
@@ -363,6 +363,10 @@
         <source>Shortcuts</source>
         <translation type="unfinished"></translation>
     </message>
+    <message>
+        <source>Sequence Badge</source>
+        <translation type="unfinished"></translation>
+    </message>
 </context>
 <context>
     <name>FontExcludeDialog</name>

--- a/resources/translate/en_US.ts
+++ b/resources/translate/en_US.ts
@@ -1037,6 +1037,47 @@
         <source>Export to </source>
         <translation type="unfinished"></translation>
     </message>
+    <message>
+        <source>Warning</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Please open a project first</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>No current file</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Notice</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>No text blocks on current page</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Path Reorder</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Not enough text blocks touched by the path (need at least 2).</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Continue Drawing</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Apply</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Apply reorder?</source>
+        <translation type="unfinished"></translation>
+    </message>
+
 </context>
 <context>
     <name>ModuleManager</name>
@@ -1664,6 +1705,11 @@
         <source>Translate page</source>
         <translation type="unfinished"></translation>
     </message>
+    <message>
+        <source>Path Reorder</source>
+        <translation type="unfinished"></translation>
+    </message>
+
 </context>
 <context>
     <name>TranslateThread</name>
@@ -1866,6 +1912,11 @@
         <source>Reset to default</source>
         <translation type="unfinished"></translation>
     </message>
+    <message>
+        <source>Path Reorder</source>
+        <translation type="unfinished"></translation>
+    </message>
+
 </context>
 <context>
     <name>ShortcutEditor</name>

--- a/resources/translate/en_US.ts
+++ b/resources/translate/en_US.ts
@@ -359,6 +359,10 @@
         <source>Intermediate image format</source>
         <translation type="unfinished"></translation>
     </message>
+    <message>
+        <source>Shortcuts</source>
+        <translation type="unfinished"></translation>
+    </message>
 </context>
 <context>
     <name>FontExcludeDialog</name>
@@ -1733,6 +1737,156 @@
     <message>
         <location filename="../../ballontranslator/ui/mainwindowbars.py" line="601"/>
         <source>Target</source>
+        <translation type="unfinished"></translation>
+    </message>
+</context>
+<context>
+    <name>_ShortcutRow</name>
+    <message>
+        <source>Page Up</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Page Down</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Page Up (alt)</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Page Down (alt)</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Text Editor</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Text Block</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Draw Board</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Zoom In</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Zoom Out</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Delete</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Delete (alt)</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Select All</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Bold</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Italic</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Underline</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Undo</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Redo</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Page Search</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Global Search</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Escape</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Inpaint</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Hand Tool</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Rect Tool</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Inpaint Tool</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Pen Tool</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Merge Tool</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>— None —</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Add shortcut</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Remove all shortcuts</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Reset to default</source>
+        <translation type="unfinished"></translation>
+    </message>
+</context>
+<context>
+    <name>ShortcutEditor</name>
+    <message>
+        <source>Navigation</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>View</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Edit</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Tools</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Search</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>General</source>
         <translation type="unfinished"></translation>
     </message>
 </context>

--- a/resources/translate/es_MX.ts
+++ b/resources/translate/es_MX.ts
@@ -815,6 +815,47 @@ All existing translation results will be cleared!</source>
         <source>Export to </source>
         <translation>Exportar a </translation>
     </message>
+    <message>
+        <source>Warning</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Please open a project first</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>No current file</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Notice</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>No text blocks on current page</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Path Reorder</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Not enough text blocks touched by the path (need at least 2).</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Continue Drawing</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Apply</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Apply reorder?</source>
+        <translation type="unfinished"></translation>
+    </message>
+
 </context>
 <context>
     <name>ModuleManager</name>
@@ -1314,6 +1355,11 @@ All existing translation results will be cleared!</source>
         <source>Translate page</source>
         <translation>Traducir página</translation>
     </message>
+    <message>
+        <source>Path Reorder</source>
+        <translation type="unfinished"></translation>
+    </message>
+
 </context>
 <context>
     <name>TranslateThread</name>
@@ -1501,6 +1547,11 @@ All existing translation results will be cleared!</source>
         <source>Reset to default</source>
         <translation type="unfinished"></translation>
     </message>
+    <message>
+        <source>Path Reorder</source>
+        <translation type="unfinished"></translation>
+    </message>
+
 </context>
 <context>
     <name>ShortcutEditor</name>

--- a/resources/translate/es_MX.ts
+++ b/resources/translate/es_MX.ts
@@ -298,6 +298,10 @@
         <source>Shortcuts</source>
         <translation type="unfinished"></translation>
     </message>
+    <message>
+        <source>Sequence Badge</source>
+        <translation type="unfinished"></translation>
+    </message>
 </context>
 <context>
     <name>DrawingPanel</name>

--- a/resources/translate/es_MX.ts
+++ b/resources/translate/es_MX.ts
@@ -294,6 +294,10 @@
         <source>Shortcut</source>
         <translation>Acceso directo</translation>
     </message>
+    <message>
+        <source>Shortcuts</source>
+        <translation type="unfinished"></translation>
+    </message>
 </context>
 <context>
     <name>DrawingPanel</name>
@@ -1369,6 +1373,156 @@ All existing translation results will be cleared!</source>
         <location filename="../ui/mainwindowbars.py" line="571"/>
         <source>Target</source>
         <translation>Objetivo</translation>
+    </message>
+</context>
+<context>
+    <name>_ShortcutRow</name>
+    <message>
+        <source>Page Up</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Page Down</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Page Up (alt)</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Page Down (alt)</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Text Editor</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Text Block</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Draw Board</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Zoom In</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Zoom Out</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Delete</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Delete (alt)</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Select All</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Bold</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Italic</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Underline</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Undo</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Redo</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Page Search</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Global Search</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Escape</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Inpaint</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Hand Tool</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Rect Tool</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Inpaint Tool</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Pen Tool</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Merge Tool</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>— None —</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Add shortcut</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Remove all shortcuts</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Reset to default</source>
+        <translation type="unfinished"></translation>
+    </message>
+</context>
+<context>
+    <name>ShortcutEditor</name>
+    <message>
+        <source>Navigation</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>View</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Edit</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Tools</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Search</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>General</source>
+        <translation type="unfinished"></translation>
     </message>
 </context>
 </TS>

--- a/resources/translate/fr_FR.ts
+++ b/resources/translate/fr_FR.ts
@@ -812,6 +812,47 @@ Tous les résultats de traduction existants seront effacés !</translation>
         <source>Export to </source>
         <translation>Exporter vers</translation>
     </message>
+    <message>
+        <source>Warning</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Please open a project first</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>No current file</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Notice</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>No text blocks on current page</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Path Reorder</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Not enough text blocks touched by the path (need at least 2).</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Continue Drawing</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Apply</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Apply reorder?</source>
+        <translation type="unfinished"></translation>
+    </message>
+
 </context>
 <context>
     <name>ModuleManager</name>
@@ -1311,6 +1352,11 @@ Tous les résultats de traduction existants seront effacés !</translation>
         <source>Translate page</source>
         <translation>Traduire la page</translation>
     </message>
+    <message>
+        <source>Path Reorder</source>
+        <translation type="unfinished"></translation>
+    </message>
+
 </context>
 <context>
     <name>TranslateThread</name>
@@ -1498,6 +1544,11 @@ Tous les résultats de traduction existants seront effacés !</translation>
         <source>Reset to default</source>
         <translation type="unfinished"></translation>
     </message>
+    <message>
+        <source>Path Reorder</source>
+        <translation type="unfinished"></translation>
+    </message>
+
 </context>
 <context>
     <name>ShortcutEditor</name>

--- a/resources/translate/fr_FR.ts
+++ b/resources/translate/fr_FR.ts
@@ -297,6 +297,10 @@
         <source>Shortcuts</source>
         <translation type="unfinished"></translation>
     </message>
+    <message>
+        <source>Sequence Badge</source>
+        <translation type="unfinished"></translation>
+    </message>
 </context>
 <context>
     <name>DrawingPanel</name>

--- a/resources/translate/fr_FR.ts
+++ b/resources/translate/fr_FR.ts
@@ -293,6 +293,10 @@
         <source>Shortcut</source>
         <translation>Raccourci</translation>
     </message>
+    <message>
+        <source>Shortcuts</source>
+        <translation type="unfinished"></translation>
+    </message>
 </context>
 <context>
     <name>DrawingPanel</name>
@@ -1366,6 +1370,156 @@ Tous les résultats de traduction existants seront effacés !</translation>
         <location filename="../ui/mainwindowbars.py" line="571" />
         <source>Target</source>
         <translation>Cible</translation>
+    </message>
+</context>
+<context>
+    <name>_ShortcutRow</name>
+    <message>
+        <source>Page Up</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Page Down</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Page Up (alt)</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Page Down (alt)</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Text Editor</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Text Block</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Draw Board</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Zoom In</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Zoom Out</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Delete</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Delete (alt)</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Select All</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Bold</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Italic</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Underline</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Undo</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Redo</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Page Search</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Global Search</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Escape</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Inpaint</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Hand Tool</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Rect Tool</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Inpaint Tool</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Pen Tool</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Merge Tool</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>— None —</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Add shortcut</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Remove all shortcuts</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Reset to default</source>
+        <translation type="unfinished"></translation>
+    </message>
+</context>
+<context>
+    <name>ShortcutEditor</name>
+    <message>
+        <source>Navigation</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>View</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Edit</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Tools</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Search</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>General</source>
+        <translation type="unfinished"></translation>
     </message>
 </context>
 </TS>

--- a/resources/translate/hu_HU.ts
+++ b/resources/translate/hu_HU.ts
@@ -294,6 +294,10 @@
         <source>Shortcut</source>
         <translation>Gyorsbillentyű</translation>
     </message>
+    <message>
+        <source>Shortcuts</source>
+        <translation type="unfinished"></translation>
+    </message>
 </context>
 <context>
     <name>DrawingPanel</name>
@@ -1368,6 +1372,156 @@ Minden eddigi fordítás elveszik!</translation>
         <location filename="../ui/mainwindowbars.py" line="571"/>
         <source>Target</source>
         <translation>Cél</translation>
+    </message>
+</context>
+<context>
+    <name>_ShortcutRow</name>
+    <message>
+        <source>Page Up</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Page Down</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Page Up (alt)</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Page Down (alt)</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Text Editor</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Text Block</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Draw Board</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Zoom In</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Zoom Out</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Delete</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Delete (alt)</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Select All</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Bold</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Italic</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Underline</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Undo</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Redo</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Page Search</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Global Search</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Escape</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Inpaint</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Hand Tool</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Rect Tool</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Inpaint Tool</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Pen Tool</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Merge Tool</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>— None —</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Add shortcut</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Remove all shortcuts</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Reset to default</source>
+        <translation type="unfinished"></translation>
+    </message>
+</context>
+<context>
+    <name>ShortcutEditor</name>
+    <message>
+        <source>Navigation</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>View</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Edit</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Tools</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Search</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>General</source>
+        <translation type="unfinished"></translation>
     </message>
 </context>
 </TS>

--- a/resources/translate/hu_HU.ts
+++ b/resources/translate/hu_HU.ts
@@ -814,6 +814,47 @@ Minden eddigi fordítás elveszik!</translation>
         <source>Export to </source>
         <translation>Exportálás ide </translation>
     </message>
+    <message>
+        <source>Warning</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Please open a project first</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>No current file</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Notice</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>No text blocks on current page</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Path Reorder</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Not enough text blocks touched by the path (need at least 2).</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Continue Drawing</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Apply</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Apply reorder?</source>
+        <translation type="unfinished"></translation>
+    </message>
+
 </context>
 <context>
     <name>ModuleManager</name>
@@ -1313,6 +1354,11 @@ Minden eddigi fordítás elveszik!</translation>
         <source>Translate page</source>
         <translation>Oldal fordítása</translation>
     </message>
+    <message>
+        <source>Path Reorder</source>
+        <translation type="unfinished"></translation>
+    </message>
+
 </context>
 <context>
     <name>TranslateThread</name>
@@ -1500,6 +1546,11 @@ Minden eddigi fordítás elveszik!</translation>
         <source>Reset to default</source>
         <translation type="unfinished"></translation>
     </message>
+    <message>
+        <source>Path Reorder</source>
+        <translation type="unfinished"></translation>
+    </message>
+
 </context>
 <context>
     <name>ShortcutEditor</name>

--- a/resources/translate/hu_HU.ts
+++ b/resources/translate/hu_HU.ts
@@ -298,6 +298,10 @@
         <source>Shortcuts</source>
         <translation type="unfinished"></translation>
     </message>
+    <message>
+        <source>Sequence Badge</source>
+        <translation type="unfinished"></translation>
+    </message>
 </context>
 <context>
     <name>DrawingPanel</name>

--- a/resources/translate/ko_KR.ts
+++ b/resources/translate/ko_KR.ts
@@ -554,6 +554,10 @@
         <source>Shortcuts</source>
         <translation type="unfinished"></translation>
     </message>
+    <message>
+        <source>Sequence Badge</source>
+        <translation type="unfinished"></translation>
+    </message>
 </context>
 <context>
     <name>DialogCloseButton</name>

--- a/resources/translate/ko_KR.ts
+++ b/resources/translate/ko_KR.ts
@@ -550,6 +550,10 @@
         <source>Show only custom fonts</source>
         <translation>커스텀 폰트만 표시</translation>
     </message>
+    <message>
+        <source>Shortcuts</source>
+        <translation type="unfinished"></translation>
+    </message>
 </context>
 <context>
     <name>DialogCloseButton</name>
@@ -4242,6 +4246,156 @@ All existing translation results will be cleared!</source>
         <source>Failed to install &apos;pyspellchecker&apos;:
 </source>
         <translation>&apos;pyspellchecker&apos; 설치 실패:</translation>
+    </message>
+</context>
+<context>
+    <name>_ShortcutRow</name>
+    <message>
+        <source>Page Up</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Page Down</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Page Up (alt)</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Page Down (alt)</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Text Editor</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Text Block</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Draw Board</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Zoom In</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Zoom Out</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Delete</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Delete (alt)</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Select All</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Bold</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Italic</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Underline</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Undo</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Redo</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Page Search</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Global Search</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Escape</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Inpaint</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Hand Tool</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Rect Tool</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Inpaint Tool</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Pen Tool</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Merge Tool</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>— None —</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Add shortcut</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Remove all shortcuts</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Reset to default</source>
+        <translation type="unfinished"></translation>
+    </message>
+</context>
+<context>
+    <name>ShortcutEditor</name>
+    <message>
+        <source>Navigation</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>View</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Edit</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Tools</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Search</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>General</source>
+        <translation type="unfinished"></translation>
     </message>
 </context>
 </TS>

--- a/resources/translate/ko_KR.ts
+++ b/resources/translate/ko_KR.ts
@@ -1499,6 +1499,47 @@ All existing translation results will be cleared!</source>
         <source>Keyword substitution for machine translation source text</source>
         <translation>원문에 대한 키워드 치환(전처리)</translation>
     </message>
+    <message>
+        <source>Warning</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Please open a project first</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>No current file</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Notice</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>No text blocks on current page</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Path Reorder</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Not enough text blocks touched by the path (need at least 2).</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Continue Drawing</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Apply</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Apply reorder?</source>
+        <translation type="unfinished"></translation>
+    </message>
+
 </context>
 <context>
     <name>ModuleManager</name>
@@ -3984,6 +4025,11 @@ All existing translation results will be cleared!</source>
         <source>Keyword substitution for machine translation source text</source>
         <translation>원문에 대한 키워드 치환(전처리)</translation>
     </message>
+    <message>
+        <source>Path Reorder</source>
+        <translation type="unfinished"></translation>
+    </message>
+
 </context>
 <context>
     <name>TorchInstallHelperDialog</name>
@@ -4374,6 +4420,11 @@ All existing translation results will be cleared!</source>
         <source>Reset to default</source>
         <translation type="unfinished"></translation>
     </message>
+    <message>
+        <source>Path Reorder</source>
+        <translation type="unfinished"></translation>
+    </message>
+
 </context>
 <context>
     <name>ShortcutEditor</name>

--- a/resources/translate/pt_BR.ts
+++ b/resources/translate/pt_BR.ts
@@ -742,7 +742,47 @@
       <source>Export to </source>
       <translation>Exportar para </translation>
     </message>
-  </context>
+    <message>
+        <source>Warning</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Please open a project first</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>No current file</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Notice</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>No text blocks on current page</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Path Reorder</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Not enough text blocks touched by the path (need at least 2).</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Continue Drawing</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Apply</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Apply reorder?</source>
+        <translation type="unfinished"></translation>
+    </message>
+ </context>
   <context>
     <name>ModuleManager</name>
     <message>
@@ -1181,7 +1221,11 @@
       <source>Translate page</source>
       <translation>Traduzir página</translation>
     </message>
-  </context>
+    <message>
+        <source>Path Reorder</source>
+        <translation type="unfinished"></translation>
+    </message>
+ </context>
   <context>
     <name>TranslateThread</name>
     <message>
@@ -1354,6 +1398,11 @@
         <source>Reset to default</source>
         <translation type="unfinished"></translation>
     </message>
+    <message>
+        <source>Path Reorder</source>
+        <translation type="unfinished"></translation>
+    </message>
+
 </context>
 <context>
     <name>ShortcutEditor</name>

--- a/resources/translate/pt_BR.ts
+++ b/resources/translate/pt_BR.ts
@@ -295,6 +295,10 @@
       <source>Shortcut</source>
       <translation>Atalho</translation>
     </message>
+      <message>
+        <source>Shortcuts</source>
+        <translation type="unfinished"></translation>
+      </message>
   </context>
   <context>
     <name>DrawingPanel</name>
@@ -1228,4 +1232,154 @@
       <translation>Alvo: </translation>
     </message>
   </context>
+<context>
+    <name>_ShortcutRow</name>
+    <message>
+        <source>Page Up</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Page Down</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Page Up (alt)</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Page Down (alt)</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Text Editor</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Text Block</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Draw Board</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Zoom In</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Zoom Out</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Delete</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Delete (alt)</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Select All</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Bold</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Italic</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Underline</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Undo</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Redo</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Page Search</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Global Search</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Escape</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Inpaint</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Hand Tool</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Rect Tool</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Inpaint Tool</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Pen Tool</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Merge Tool</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>— None —</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Add shortcut</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Remove all shortcuts</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Reset to default</source>
+        <translation type="unfinished"></translation>
+    </message>
+</context>
+<context>
+    <name>ShortcutEditor</name>
+    <message>
+        <source>Navigation</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>View</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Edit</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Tools</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Search</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>General</source>
+        <translation type="unfinished"></translation>
+    </message>
+</context>
 </TS>

--- a/resources/translate/ru_RU.ts
+++ b/resources/translate/ru_RU.ts
@@ -446,6 +446,10 @@
         <source>font &amp; stroke color</source>
         <translation type="vanished">цвет шрифта и границ</translation>
     </message>
+    <message>
+        <source>Shortcuts</source>
+        <translation type="unfinished"></translation>
+    </message>
 </context>
 <context>
     <name>DrawingPanel</name>
@@ -2091,6 +2095,156 @@
     <message>
         <source>Target: </source>
         <translation type="vanished">Цель: </translation>
+    </message>
+</context>
+<context>
+    <name>_ShortcutRow</name>
+    <message>
+        <source>Page Up</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Page Down</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Page Up (alt)</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Page Down (alt)</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Text Editor</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Text Block</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Draw Board</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Zoom In</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Zoom Out</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Delete</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Delete (alt)</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Select All</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Bold</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Italic</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Underline</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Undo</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Redo</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Page Search</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Global Search</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Escape</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Inpaint</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Hand Tool</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Rect Tool</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Inpaint Tool</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Pen Tool</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Merge Tool</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>— None —</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Add shortcut</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Remove all shortcuts</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Reset to default</source>
+        <translation type="unfinished"></translation>
+    </message>
+</context>
+<context>
+    <name>ShortcutEditor</name>
+    <message>
+        <source>Navigation</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>View</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Edit</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Tools</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Search</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>General</source>
+        <translation type="unfinished"></translation>
     </message>
 </context>
 </TS>

--- a/resources/translate/ru_RU.ts
+++ b/resources/translate/ru_RU.ts
@@ -1142,6 +1142,47 @@
         <source>Export to </source>
         <translation>Экспортировать как </translation>
     </message>
+    <message>
+        <source>Warning</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Please open a project first</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>No current file</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Notice</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>No text blocks on current page</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Path Reorder</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Not enough text blocks touched by the path (need at least 2).</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Continue Drawing</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Apply</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Apply reorder?</source>
+        <translation type="unfinished"></translation>
+    </message>
+
 </context>
 <context>
     <name>ModuleManager</name>
@@ -1985,6 +2026,11 @@
         <source>Drawing Board </source>
         <translation type="vanished">Режим рисования </translation>
     </message>
+    <message>
+        <source>Path Reorder</source>
+        <translation type="unfinished"></translation>
+    </message>
+
 </context>
 <context>
     <name>TranslateThread</name>
@@ -2223,6 +2269,11 @@
         <source>Reset to default</source>
         <translation type="unfinished"></translation>
     </message>
+    <message>
+        <source>Path Reorder</source>
+        <translation type="unfinished"></translation>
+    </message>
+
 </context>
 <context>
     <name>ShortcutEditor</name>

--- a/resources/translate/ru_RU.ts
+++ b/resources/translate/ru_RU.ts
@@ -450,6 +450,10 @@
         <source>Shortcuts</source>
         <translation type="unfinished"></translation>
     </message>
+    <message>
+        <source>Sequence Badge</source>
+        <translation type="unfinished"></translation>
+    </message>
 </context>
 <context>
     <name>DrawingPanel</name>

--- a/resources/translate/zh_CN.ts
+++ b/resources/translate/zh_CN.ts
@@ -638,6 +638,10 @@
         <source>Shortcuts</source>
         <translation>快捷键</translation>
     </message>
+    <message>
+        <source>Sequence Badge</source>
+        <translation>序号徽标</translation>
+    </message>
 </context>
 <context>
     <name>DialogCloseButton</name>

--- a/resources/translate/zh_CN.ts
+++ b/resources/translate/zh_CN.ts
@@ -1679,6 +1679,47 @@ All existing translation results will be cleared!</source>
         <source>Continue</source>
         <translation type="vanished">继续</translation>
     </message>
+    <message>
+        <source>Warning</source>
+        <translation>警告</translation>
+    </message>
+    <message>
+        <source>Please open a project first</source>
+        <translation>请先打开一个项目</translation>
+    </message>
+    <message>
+        <source>No current file</source>
+        <translation>没有当前文件</translation>
+    </message>
+    <message>
+        <source>Notice</source>
+        <translation>提示</translation>
+    </message>
+    <message>
+        <source>No text blocks on current page</source>
+        <translation>当前页面没有文本框</translation>
+    </message>
+    <message>
+        <source>Path Reorder</source>
+        <translation>路径重排</translation>
+    </message>
+    <message>
+        <source>Not enough text blocks touched by the path (need at least 2).</source>
+        <translation>路径未触碰足够的文本框（至少需要2个）</translation>
+    </message>
+    <message>
+        <source>Continue Drawing</source>
+        <translation>继续绘制</translation>
+    </message>
+    <message>
+        <source>Apply</source>
+        <translation>应用</translation>
+    </message>
+    <message>
+        <source>Apply reorder?</source>
+        <translation>应用重排？</translation>
+    </message>
+
 </context>
 <context>
     <name>ModuleManager</name>
@@ -4457,6 +4498,11 @@ All existing translation results will be cleared!</source>
         <source>Run without update textstyle</source>
         <translation type="vanished">Run且不覆盖已有字体样式</translation>
     </message>
+    <message>
+        <source>Path Reorder</source>
+        <translation>路径重排</translation>
+    </message>
+
 </context>
 <context>
     <name>TorchInstallHelperDialog</name>
@@ -4914,6 +4960,11 @@ All existing translation results will be cleared!</source>
         <source>Reset to default</source>
         <translation>重置为默认</translation>
     </message>
+    <message>
+        <source>Path Reorder</source>
+        <translation>路径重排</translation>
+    </message>
+
 </context>
 <context>
     <name>ShortcutEditor</name>

--- a/resources/translate/zh_CN.ts
+++ b/resources/translate/zh_CN.ts
@@ -634,6 +634,10 @@
         <source>Max spelling difference in letters. Higher values search deeper but perform slower.</source>
         <translation type="vanished">允许的最大拼写错误字符数。数值越大匹配范围越广，但搜索速度越慢。</translation>
     </message>
+    <message>
+        <source>Shortcuts</source>
+        <translation>快捷键</translation>
+    </message>
 </context>
 <context>
     <name>DialogCloseButton</name>
@@ -4782,6 +4786,156 @@ All existing translation results will be cleared!</source>
         <source>Failed to install &apos;pyspellchecker&apos;:
 </source>
         <translation>&apos;pyspellchecker&apos; 安装失败</translation>
+    </message>
+</context>
+<context>
+    <name>_ShortcutRow</name>
+    <message>
+        <source>Page Up</source>
+        <translation>上一页</translation>
+    </message>
+    <message>
+        <source>Page Down</source>
+        <translation>下一页</translation>
+    </message>
+    <message>
+        <source>Page Up (alt)</source>
+        <translation>上一页 (备选)</translation>
+    </message>
+    <message>
+        <source>Page Down (alt)</source>
+        <translation>下一页 (备选)</translation>
+    </message>
+    <message>
+        <source>Text Editor</source>
+        <translation>文本编辑</translation>
+    </message>
+    <message>
+        <source>Text Block</source>
+        <translation>选框模式</translation>
+    </message>
+    <message>
+        <source>Draw Board</source>
+        <translation>画板模式</translation>
+    </message>
+    <message>
+        <source>Zoom In</source>
+        <translation>放大</translation>
+    </message>
+    <message>
+        <source>Zoom Out</source>
+        <translation>缩小</translation>
+    </message>
+    <message>
+        <source>Delete</source>
+        <translation>删除</translation>
+    </message>
+    <message>
+        <source>Delete (alt)</source>
+        <translation>删除 (备选)</translation>
+    </message>
+    <message>
+        <source>Select All</source>
+        <translation>全选</translation>
+    </message>
+    <message>
+        <source>Bold</source>
+        <translation>粗体</translation>
+    </message>
+    <message>
+        <source>Italic</source>
+        <translation>斜体</translation>
+    </message>
+    <message>
+        <source>Underline</source>
+        <translation>下划线</translation>
+    </message>
+    <message>
+        <source>Undo</source>
+        <translation>撤销</translation>
+    </message>
+    <message>
+        <source>Redo</source>
+        <translation>重做</translation>
+    </message>
+    <message>
+        <source>Page Search</source>
+        <translation>页面查找</translation>
+    </message>
+    <message>
+        <source>Global Search</source>
+        <translation>全局查找</translation>
+    </message>
+    <message>
+        <source>Escape</source>
+        <translation>取消</translation>
+    </message>
+    <message>
+        <source>Inpaint</source>
+        <translation>修复</translation>
+    </message>
+    <message>
+        <source>Hand Tool</source>
+        <translation>抓手工具</translation>
+    </message>
+    <message>
+        <source>Rect Tool</source>
+        <translation>矩形工具</translation>
+    </message>
+    <message>
+        <source>Inpaint Tool</source>
+        <translation>修复笔刷</translation>
+    </message>
+    <message>
+        <source>Pen Tool</source>
+        <translation>画笔工具</translation>
+    </message>
+    <message>
+        <source>Merge Tool</source>
+        <translation>合并工具</translation>
+    </message>
+    <message>
+        <source>— None —</source>
+        <translation>— 无 —</translation>
+    </message>
+    <message>
+        <source>Add shortcut</source>
+        <translation>添加快捷键</translation>
+    </message>
+    <message>
+        <source>Remove all shortcuts</source>
+        <translation>清除所有快捷键</translation>
+    </message>
+    <message>
+        <source>Reset to default</source>
+        <translation>重置为默认</translation>
+    </message>
+</context>
+<context>
+    <name>ShortcutEditor</name>
+    <message>
+        <source>Navigation</source>
+        <translation>导航</translation>
+    </message>
+    <message>
+        <source>View</source>
+        <translation>视图</translation>
+    </message>
+    <message>
+        <source>Edit</source>
+        <translation>编辑</translation>
+    </message>
+    <message>
+        <source>Tools</source>
+        <translation>工具</translation>
+    </message>
+    <message>
+        <source>Search</source>
+        <translation>搜索</translation>
+    </message>
+    <message>
+        <source>General</source>
+        <translation>常规</translation>
     </message>
 </context>
 </TS>

--- a/resources/translate/zh_TW.ts
+++ b/resources/translate/zh_TW.ts
@@ -634,6 +634,10 @@
         <source>Max spelling difference in letters. Higher values search deeper but perform slower.</source>
         <translation type="vanished">允許的最大拼寫錯誤字元數。數值越大匹配範圍越廣，但搜索速度越慢。</translation>
     </message>
+    <message>
+        <source>Shortcuts</source>
+        <translation type="unfinished"></translation>
+    </message>
 </context>
 <context>
     <name>DialogCloseButton</name>
@@ -4826,6 +4830,156 @@ All existing translation results will be cleared!</source>
         <source>Failed to install &apos;pyspellchecker&apos;:
 </source>
         <translation>&apos;pyspellchecker&apos; 安裝失敗</translation>
+    </message>
+</context>
+<context>
+    <name>_ShortcutRow</name>
+    <message>
+        <source>Page Up</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Page Down</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Page Up (alt)</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Page Down (alt)</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Text Editor</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Text Block</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Draw Board</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Zoom In</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Zoom Out</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Delete</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Delete (alt)</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Select All</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Bold</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Italic</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Underline</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Undo</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Redo</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Page Search</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Global Search</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Escape</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Inpaint</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Hand Tool</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Rect Tool</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Inpaint Tool</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Pen Tool</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Merge Tool</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>— None —</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Add shortcut</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Remove all shortcuts</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Reset to default</source>
+        <translation type="unfinished"></translation>
+    </message>
+</context>
+<context>
+    <name>ShortcutEditor</name>
+    <message>
+        <source>Navigation</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>View</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Edit</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Tools</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Search</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>General</source>
+        <translation type="unfinished"></translation>
     </message>
 </context>
 </TS>

--- a/resources/translate/zh_TW.ts
+++ b/resources/translate/zh_TW.ts
@@ -638,6 +638,10 @@
         <source>Shortcuts</source>
         <translation type="unfinished"></translation>
     </message>
+    <message>
+        <source>Sequence Badge</source>
+        <translation type="unfinished"></translation>
+    </message>
 </context>
 <context>
     <name>DialogCloseButton</name>

--- a/resources/translate/zh_TW.ts
+++ b/resources/translate/zh_TW.ts
@@ -1667,6 +1667,47 @@ All existing translation results will be cleared!</source>
         <source>Continue</source>
         <translation type="vanished">繼續</translation>
     </message>
+    <message>
+        <source>Warning</source>
+        <translation>警告</translation>
+    </message>
+    <message>
+        <source>Please open a project first</source>
+        <translation>請先打開一個專案</translation>
+    </message>
+    <message>
+        <source>No current file</source>
+        <translation>沒有目前檔案</translation>
+    </message>
+    <message>
+        <source>Notice</source>
+        <translation>提示</translation>
+    </message>
+    <message>
+        <source>No text blocks on current page</source>
+        <translation>目前頁面沒有文字框</translation>
+    </message>
+    <message>
+        <source>Path Reorder</source>
+        <translation>路徑重排</translation>
+    </message>
+    <message>
+        <source>Not enough text blocks touched by the path (need at least 2).</source>
+        <translation>路徑未觸碰足夠的文字框（至少需要2個）</translation>
+    </message>
+    <message>
+        <source>Continue Drawing</source>
+        <translation>繼續繪製</translation>
+    </message>
+    <message>
+        <source>Apply</source>
+        <translation>套用</translation>
+    </message>
+    <message>
+        <source>Apply reorder?</source>
+        <translation>套用重排？</translation>
+    </message>
+
 </context>
 <context>
     <name>ModuleManager</name>
@@ -4501,6 +4542,11 @@ All existing translation results will be cleared!</source>
         <source>Run without update textstyle</source>
         <translation type="vanished">Run且不覆蓋已有字體樣式</translation>
     </message>
+    <message>
+        <source>Path Reorder</source>
+        <translation>路徑重排</translation>
+    </message>
+
 </context>
 <context>
     <name>TorchInstallHelperDialog</name>
@@ -4958,6 +5004,11 @@ All existing translation results will be cleared!</source>
         <source>Reset to default</source>
         <translation type="unfinished"></translation>
     </message>
+    <message>
+        <source>Path Reorder</source>
+        <translation>路徑重排</translation>
+    </message>
+
 </context>
 <context>
     <name>ShortcutEditor</name>


### PR DESCRIPTION
在画布上画一条路径来定义文字块的阅读顺序：路径扫过的文字块按接触顺序重新编号（实时显示在角标上），可一键应用为新的页面阅读顺序。

入口：工具栏"Path Reorder"按钮 + 快捷键（默认无键，可在 PR 1 的快捷键页面自行绑定）。

改动文件：ballontranslator/ui/canvas.py、ui/text_engine/item.py、ui/mainwindow.py、ui/mainwindowbars.py、ui/shortcut_editor.py + 9 个 .ts。

验证：模式进出/笔画接触排序/端到端 Apply 已本地验证；与旧项目 JSON 兼容，无新增依赖，headless 无影响。依赖 PR 1、2，需按顺序合并。