### PR TITLE
PR4-点击空白弃选文本框

### DIFF
--- a/ballontranslator/ui/canvas.py
+++ b/ballontranslator/ui/canvas.py
@@ -835,6 +835,19 @@ class Canvas(QGraphicsScene):
                         on_update=self._select_scene_items_in_rect,
                     )
 
+        if btn == Qt.MouseButton.LeftButton and self.txtblkShapeControl.isVisible():
+            items_at = self.items(event.scenePos())
+            # Keep the editing overlays (shape handles / grid handles) alive
+            # when the press lands on one of them; only an empty-space click
+            # clears the control frames (fully deselecting the block).
+            if not any(
+                isinstance(item, TextBlkItem)
+                or item.data(CONTROL_ITEM_DATA_KEY)
+                for item in items_at
+            ):
+                self.txtblkShapeControl.setBlkItem(None)
+                self.clear_text_transform_controls()
+
         return super().mousePressEvent(event)
 
     @property

--- a/ballontranslator/ui/canvas.py
+++ b/ballontranslator/ui/canvas.py
@@ -837,16 +837,14 @@ class Canvas(QGraphicsScene):
 
         if btn == Qt.MouseButton.LeftButton and self.txtblkShapeControl.isVisible():
             items_at = self.items(event.scenePos())
-            # Keep the editing overlays (shape handles / grid handles) alive
-            # when the press lands on one of them; only an empty-space click
-            # clears the control frames (fully deselecting the block).
+            # Transform controllers own their outside-click gestures and
+            # lifecycle; this path only dismisses the ordinary shape frame.
             if not any(
                 isinstance(item, TextBlkItem)
                 or item.data(CONTROL_ITEM_DATA_KEY)
                 for item in items_at
             ):
                 self.txtblkShapeControl.setBlkItem(None)
-                self.clear_text_transform_controls()
 
         return super().mousePressEvent(event)
 


### PR DESCRIPTION
画布上点击空白处时完全取消选中：除了清除选区，同时隐藏并解绑文字块形状控制框（此前点击空白仍会残留蓝框）。12 行小改动。

改动文件：ballontranslator/ui/canvas.py（+13 行）

验证：空白点击隐藏并解绑/点击文字块保留/点击覆盖物保留均已本地验证；与旧项目 JSON 兼容，无新增依赖，headless 无影响。