### PR TITLE
docs: add Telegram community badge and copyable QQ group

### DIFF
--- a/README.md
+++ b/README.md
@@ -19,7 +19,11 @@
 
 
 
-<p align="center">交流反馈 QQ 群：719881337 </p>
+<p align="center">
+  <a href="https://t.me/BallonTranslatorforum"><img src="https://img.shields.io/badge/Telegram-%E7%94%A8%E6%88%B7%E4%BA%A4%E6%B5%81%E7%BE%A4-26A5E4?style=flat-square&logo=telegram&logoColor=white" style="vertical-align: middle;" alt="Telegram Group"/></a>
+  &nbsp;&nbsp;|&nbsp;&nbsp;
+  <span style="vertical-align: middle;"><b>QQ 交流反馈群：</b><code>719881337</code></span>
+</p>
 
  
 

--- a/README_EN.md
+++ b/README_EN.md
@@ -14,6 +14,12 @@
   <a href="/README.md">简体中文</a> | English | <a href="/doc/README_RU.md">Русский</a> | <a href="/doc/README_JA.md">日本語</a> | <a href="/doc/README_ES.md">Español</a> | <a href="/doc/README_FR.md">Français</a> | <a href="/doc/README_PT-BR.md">pt-BR</a> | <a href="/doc/README_KO.md">한국어</a> | <a href="/doc/README_ID.md">Indonesia</a> | <a href="/doc/README_VI.md">Tiếng Việt</a>
 </p>
 
+<p align="center">
+  <a href="https://t.me/BallonTranslatorforum"><img src="https://img.shields.io/badge/Telegram-Discussion%20Group-26A5E4?style=flat-square&logo=telegram&logoColor=white" style="vertical-align: middle;" alt="Telegram Group"/></a>
+  &nbsp;&nbsp;|&nbsp;&nbsp;
+  <span style="vertical-align: middle;"><b>QQ Group:</b> <code>719881337</code></span>
+</p>
+
 # Features
 > [!IMPORTANT]
 > **If you're sharing the translated result publicly and no experienced human translator participated in a throughout translating or proofreading, please mark it as machine translation somewhere clear to see.**

--- a/doc/README_RU.md
+++ b/doc/README_RU.md
@@ -14,6 +14,12 @@
   <a href="/README.md">简体中文</a> | <a href="/README_EN.md">English</a> | Русский | <a href="/doc/README_JA.md">日本語</a> | <a href="/doc/README_ES.md">Español</a> | <a href="/doc/README_FR.md">Français</a> | <a href="/doc/README_PT-BR.md">pt-BR</a> | <a href="/doc/README_KO.md">한국어</a> | <a href="/doc/README_ID.md">Indonesia</a> | <a href="/doc/README_VI.md">Tiếng Việt</a>
 </p>
 
+<p align="center">
+  <a href="https://t.me/BallonTranslatorforum"><img src="https://img.shields.io/badge/Telegram-%D0%A7%D0%B0%D1%82%20%D0%B8%20%D0%A4%D0%BE%D1%80%D1%83%D0%BC-26A5E4?style=flat-square&logo=telegram&logoColor=white" style="vertical-align: middle;" alt="Telegram Forum"/></a>
+  &nbsp;&nbsp;|&nbsp;&nbsp;
+  <span style="vertical-align: middle;"><b>QQ Группа:</b> <code>719881337</code></span>
+</p>
+
 # Особенности
 > [!IMPORTANT]
 > **Если вы публично делитесь переведенным результатом, и опытный переводчик-человек не участвовал в тщательном переводе или проверке, пожалуйста, отметьте его как машинный перевод в заметном месте. Если на нормальном русском. Если вы не способны сделать минимальную проверку качества, перед публикацией, или вы не умеете в тайп, то укажите в описании к загражуемой манге, что это "машинный" перевод. Большинство русских сервисов тупо забанит вам аккаунт после попытки залива "машинного" перевода. Уделите хоть каплю внимания редактуре.**


### PR DESCRIPTION
## Summary

Adds Telegram community forum link badge alongside the QQ group in `README.md`, `README_EN.md`, and `doc/README_RU.md`.

- Formats both links in a single centered row with a separator (`|`) and aligned vertical baseline.
- Keeps the QQ group number as selectable `<code>719881337</code>` text so users can directly copy it.
