### PR TITLE
Fix horizontal shift in center-aligned soft-wrapped text

### DIFF
--- a/ballontranslator/ui/text_engine/horizontal_layout.py
+++ b/ballontranslator/ui/text_engine/horizontal_layout.py
@@ -168,6 +168,19 @@ class HorizontalTextDocumentLayout(SceneTextLayout):
         if not spaces:
             return suffix_start, []
 
+        alignment = block.layout().textOption().alignment()
+        line_end = line_start + line.textLength()
+        next_character = _utf16_slice(text, line_end, 1)
+        # Keep a single U+0020 soft-wrap separator editable, but do not let
+        # the part of its advance excluded from naturalTextWidth() shift the
+        # line content Qt has already centered.
+        centered_soft_wrap_separator = (
+            suffix_length == 1
+            and bool(next_character)
+            and not next_character.isspace()
+            and bool(alignment & Qt.AlignmentFlag.AlignHCenter)
+        )
+
         # Qt sometimes includes fitting terminal spaces in naturalTextWidth(),
         # but excludes the identical suffix when another word follows. Shift
         # only the width Qt did not already use for paragraph alignment.
@@ -176,13 +189,16 @@ class HorizontalTextDocumentLayout(SceneTextLayout):
             max(0.0, line.naturalTextWidth() - base_advance),
         )
         extra_aligned_width = max(0.0, fitted_width - native_space_width)
-        if extra_aligned_width > 1e-6:
+        if (
+            extra_aligned_width > 1e-6
+            and not centered_soft_wrap_separator
+        ):
             position = line.position()
             position.setX(
                 position.x()
                 + self._line_space_alignment_shift(
                     extra_aligned_width,
-                    block.layout().textOption().alignment(),
+                    alignment,
                     block.textDirection() == Qt.LayoutDirection.RightToLeft,
                 )
             )


### PR DESCRIPTION
## Summary

Fixes a horizontal shift in center-aligned text when narrowing a text box causes a line to soft-wrap at a normal space.

## Cause

When the text box is narrowed, Qt may soft-wrap at a normal `U+0020` space while retaining that separator within the preceding `QTextLine`'s logical text range.

Qt already centers the visible text, but BallonsTranslator treated the portion of the separator width excluded from `naturalTextWidth()` as additional alignment width and applied another X-position correction. As a result, the visible line shifted by half of that excluded width.

## Fix

When a center-aligned `QTextLine` retains exactly one `U+0020` soft-wrap separator at the end of its logical text range and the following character is non-whitespace, BallonsTranslator skips the redundant X-position correction.

The separator keeps its editing position, while other whitespace cases continue to use the existing handling.

## Before

Narrowing the text box causes the automatically wrapped line to shift away from the center.

<img width="2560" height="1398" alt="Before" src="https://github.com/user-attachments/assets/a802fffa-2448-4611-9488-51ea7f1b6d0a" />

## After

The same text remains centered after automatically wrapping at the space.

<img width="2560" height="1398" alt="After" src="https://github.com/user-attachments/assets/753b7616-c959-4664-ab67-c13ce2ee656e" />

## Video

The video alternates between the unpatched and patched layouts to show the horizontal alignment difference.

https://github.com/user-attachments/assets/f67350a9-15b6-4971-afc7-a4fc4ebb0a0e