### PR TITLE
fix(spellcheck): ignore CJK characters and disable suggestion popup on SourceTextEdit

### DIFF
--- a/ballontranslator/ui/spellcheck.py
+++ b/ballontranslator/ui/spellcheck.py
@@ -16,6 +16,9 @@ from ballontranslator.utils.config import pcfg
 from ballontranslator.utils.download_util import download_url_to_file
 from ballontranslator.utils.logger import logger as LOGGER
 
+# Regex pattern matching CJK ideographs, Hiragana, Katakana, and Hangul
+CJK_PATTERN = re.compile(r'[\u3040-\u30ff\u3400-\u4dbf\u4e00-\u9fff\uf900-\ufaff\uff66-\uff9f\uac00-\ud7af]')
+
 # Predefined dictionary repository URLs mapping language names to LibreOffice raw URLs.
 DICTIONARY_URLS = {
     "Arabic (ar)": "https://raw.githubusercontent.com/LibreOffice/dictionaries/master/ar/ar.dic",
@@ -311,7 +314,11 @@ class SpellCheckManager(QObject):
         word_lower = word.lower()
         if word_lower in self.custom_words or word_lower in self.external_words:
             return True
-        
+
+        # Never treat CJK characters (Japanese Kana, Kanji, Korean Hangul) as misspelled
+        if CJK_PATTERN.search(word_lower):
+            return True
+
         # If it contains digits or special chars, ignore it
         if not word_lower.isalpha():
             return True
@@ -333,7 +340,7 @@ class SpellCheckManager(QObject):
         >>> isinstance(manager.get_suggestions("helo"), list)
         True
         """
-        if len(word) > 15:
+        if len(word) > 15 or CJK_PATTERN.search(word):
             return []
 
         if self.spell is None:
@@ -482,15 +489,12 @@ class SpellCheckHighlighter(QSyntaxHighlighter):
 
         # Check if editor is a Source block editor and if spell checking on source is enabled
         editor = self.parent()
-        if editor and not isinstance(editor, QTextEdit):
-            # Fallback if document was passed
-            doc_parent = editor.parent()
-            if doc_parent and isinstance(doc_parent, QTextEdit):
-                editor = doc_parent
-        
-        if editor and isinstance(editor, QTextEdit):
-            editor_class = editor.__class__.__name__
-            if editor_class == 'SourceTextEdit':
+        if editor is not None:
+            if not isinstance(editor, QTextEdit) and hasattr(editor, 'parent'):
+                p = editor.parent()
+                if isinstance(p, QTextEdit):
+                    editor = p
+            if editor.__class__.__name__ == 'SourceTextEdit':
                 if not getattr(pcfg, 'spellcheck_on_source_enabled', False):
                     return
 
@@ -498,7 +502,7 @@ class SpellCheckHighlighter(QSyntaxHighlighter):
         pattern = r'\b[^\W\d_]+\b'
         for match in re.finditer(pattern, text):
             word = match.group(0)
-            if len(word) <= 1:
+            if len(word) <= 1 or CJK_PATTERN.search(word):
                 continue
             
             word_lower = word.lower()

--- a/ballontranslator/ui/spellcheck.py
+++ b/ballontranslator/ui/spellcheck.py
@@ -2,7 +2,8 @@ import os
 import re
 import weakref
 import threading
-from typing import List, Set
+from itertools import chain
+from typing import Iterator, List, Set, Tuple
 
 from qtpy.QtCore import Qt, QTimer, QThread, Signal, QSize, QObject
 from qtpy.QtGui import QSyntaxHighlighter, QTextCharFormat, QColor
@@ -16,8 +17,62 @@ from ballontranslator.utils.config import pcfg
 from ballontranslator.utils.download_util import download_url_to_file
 from ballontranslator.utils.logger import logger as LOGGER
 
-# Regex pattern matching CJK ideographs, Hiragana, Katakana, and Hangul
-CJK_PATTERN = re.compile(r'[\u3040-\u30ff\u3400-\u4dbf\u4e00-\u9fff\uf900-\ufaff\uff66-\uff9f\uac00-\ud7af]')
+# Match dictionary-checkable runs directly; CJK ranges act as separators so a
+# mixed token such as ``helo世界`` still checks its Latin portion.
+_SPELLCHECK_WORD_PATTERN = re.compile(
+    r'[^\W\d_'
+    r'\u1100-\u11ff'
+    r'\u2e80-\u4dbf'
+    r'\u4e00-\u9fff'
+    r'\ua960-\ua97f'
+    r'\uac00-\ud7ff'
+    r'\uf900-\ufaff'
+    r'\uff66-\uffdc'
+    r'\U0001b000-\U0001b16f'
+    r'\U0001f200-\U0001f2ff'
+    r'\U00020000-\U0002ee5f'
+    r'\U0002f800-\U0002fa1f'
+    r'\U00030000-\U000323af'
+    r']{2,}'
+)
+
+
+def iter_spellcheck_words(text: str) -> Iterator[Tuple[int, int, str]]:
+    """Yield checkable word spans as Qt UTF-16 start, length, and text.
+
+    CJK characters split mixed-script tokens instead of making the whole token
+    correct, so adjacent alphabetic words still reach the dictionary.
+
+    >>> list(iter_spellcheck_words('漢字 helo世界 wrld'))
+    [(3, 4, 'helo'), (10, 4, 'wrld')]
+    >>> list(iter_spellcheck_words('𠀀helo'))
+    [(2, 4, 'helo')]
+    """
+    matches = _SPELLCHECK_WORD_PATTERN.finditer(text)
+    first_match = next(matches, None)
+    if first_match is None:
+        return
+
+    matches = chain((first_match,), matches)
+    if text.isascii() or len(text.encode('utf-16-le')) == len(text) * 2:
+        for match in matches:
+            yield match.start(), match.end() - match.start(), match.group()
+        return
+
+    # Astral characters occupy two positions in Qt. Convert each disjoint
+    # piece once so multiple words remain linear in the block length.
+    previous_end = 0
+    utf16_position = 0
+    for match in matches:
+        utf16_position += len(
+            text[previous_end:match.start()].encode('utf-16-le')
+        ) // 2
+        word = match.group()
+        word_length = len(word.encode('utf-16-le')) // 2
+        yield utf16_position, word_length, word
+        utf16_position += word_length
+        previous_end = match.end()
+
 
 # Predefined dictionary repository URLs mapping language names to LibreOffice raw URLs.
 DICTIONARY_URLS = {
@@ -315,10 +370,6 @@ class SpellCheckManager(QObject):
         if word_lower in self.custom_words or word_lower in self.external_words:
             return True
 
-        # Never treat CJK characters (Japanese Kana, Kanji, Korean Hangul) as misspelled
-        if CJK_PATTERN.search(word_lower):
-            return True
-
         # If it contains digits or special chars, ignore it
         if not word_lower.isalpha():
             return True
@@ -340,7 +391,7 @@ class SpellCheckManager(QObject):
         >>> isinstance(manager.get_suggestions("helo"), list)
         True
         """
-        if len(word) > 15 or CJK_PATTERN.search(word):
+        if len(word) > 15:
             return []
 
         if self.spell is None:
@@ -481,37 +532,29 @@ class SpellCheckHighlighter(QSyntaxHighlighter):
             pass
 
     def highlightBlock(self, text):
-        # Check if spellcheck is enabled in settings and if spellchecker package is installed
+        # Keep the disabled path ahead of package and per-character checks.
         if not getattr(pcfg, 'spellcheck_enabled', True):
+            return
+
+        editor = self.parent()
+        if editor is not None and not isinstance(editor, QTextEdit):
+            parent = editor.parent()
+            if isinstance(parent, QTextEdit):
+                editor = parent
+        if (
+            getattr(editor, 'is_source_text_edit', False)
+            and not getattr(pcfg, 'spellcheck_on_source_enabled', False)
+        ):
             return
         if not self.manager.is_available():
             return
 
-        # Check if editor is a Source block editor and if spell checking on source is enabled
-        editor = self.parent()
-        if editor is not None:
-            if not isinstance(editor, QTextEdit) and hasattr(editor, 'parent'):
-                p = editor.parent()
-                if isinstance(p, QTextEdit):
-                    editor = p
-            if editor.__class__.__name__ == 'SourceTextEdit':
-                if not getattr(pcfg, 'spellcheck_on_source_enabled', False):
-                    return
-
-        # Pattern matches words in any language using Unicode character classes
-        pattern = r'\b[^\W\d_]+\b'
-        for match in re.finditer(pattern, text):
-            word = match.group(0)
-            if len(word) <= 1 or CJK_PATTERN.search(word):
-                continue
-            
+        for start, length, word in iter_spellcheck_words(text):
             word_lower = word.lower()
             if word_lower not in self._cache:
                 self._cache[word_lower] = self.manager.is_correct(word_lower)
                 
             if not self._cache[word_lower]:
-                start = match.start()
-                length = match.end() - start
                 self.setFormat(start, length, self.misspelled_format)
 
 

--- a/ballontranslator/ui/text_engine/editing/widgets.py
+++ b/ballontranslator/ui/text_engine/editing/widgets.py
@@ -12,7 +12,7 @@ from ...custom_widget import ScrollBar, Widget, SeparatorWidget
 from ..item import TextBlock
 from .context_menu import create_text_edit_context_menu
 from ballontranslator.utils.config import pcfg
-from ...spellcheck import SpellCheckManager, SpellCheckHighlighter
+from ...spellcheck import SpellCheckManager, SpellCheckHighlighter, CJK_PATTERN
 
 
 STYLE_TRANSPAIR_CHECKED = "background-color: rgba(30, 147, 229, 20%);"
@@ -271,6 +271,11 @@ class SourceTextEdit(QTextEdit):
                 return
             if not getattr(pcfg, 'spellcheck_enabled', True):
                 return
+            if self.__class__.__name__ == 'SourceTextEdit' and not getattr(pcfg, 'spellcheck_on_source_enabled', False):
+                if hasattr(self, 'suggestion_popup') and self.suggestion_popup:
+                    self.suggestion_popup.hide()
+                self.current_suggestion_word = None
+                return
 
             cursor = self.textCursor()
             if not cursor.hasSelection():
@@ -280,9 +285,9 @@ class SourceTextEdit(QTextEdit):
                 return
 
             selected_text = cursor.selectedText().strip()
-            # Only suggest for a single word
+            # Only suggest for a single alphabetic word, never for CJK characters
             pattern = r'^[^\W\d_]+$'
-            if len(selected_text) > 1 and re.match(pattern, selected_text):
+            if len(selected_text) > 1 and re.match(pattern, selected_text) and not CJK_PATTERN.search(selected_text):
                 if not manager.is_correct(selected_text):
                     self.current_suggestion_word = selected_text
                     

--- a/ballontranslator/ui/text_engine/editing/widgets.py
+++ b/ballontranslator/ui/text_engine/editing/widgets.py
@@ -1,4 +1,3 @@
-import re
 import threading
 import traceback
 from typing import List
@@ -12,7 +11,11 @@ from ...custom_widget import ScrollBar, Widget, SeparatorWidget
 from ..item import TextBlock
 from .context_menu import create_text_edit_context_menu
 from ballontranslator.utils.config import pcfg
-from ...spellcheck import SpellCheckManager, SpellCheckHighlighter, CJK_PATTERN
+from ...spellcheck import (
+    SpellCheckHighlighter,
+    SpellCheckManager,
+    iter_spellcheck_words,
+)
 
 
 STYLE_TRANSPAIR_CHECKED = "background-color: rgba(30, 147, 229, 20%);"
@@ -198,6 +201,8 @@ class FloatingSuggestionLabel(QWidget):
 
 
 class SourceTextEdit(QTextEdit):
+    is_source_text_edit = True
+
     hover_enter = Signal(int)
     hover_leave = Signal(int)
     focus_in = Signal(int)
@@ -264,53 +269,73 @@ class SourceTextEdit(QTextEdit):
         
         self.handle_content_change()
 
-    def on_selection_changed(self):
+    def _spellcheck_is_enabled(self) -> bool:
+        return (
+            getattr(pcfg, 'spellcheck_enabled', True)
+            and (
+                not self.is_source_text_edit
+                or getattr(pcfg, 'spellcheck_on_source_enabled', False)
+            )
+        )
+
+    def _dismiss_suggestions(self) -> None:
+        if self.suggestion_popup is not None:
+            self.suggestion_popup.hide()
+        self.current_suggestion_word = None
+
+    def on_selection_changed(self) -> None:
         try:
-            manager = SpellCheckManager.get_instance()
-            if not manager.is_available():
-                return
-            if not getattr(pcfg, 'spellcheck_enabled', True):
-                return
-            if self.__class__.__name__ == 'SourceTextEdit' and not getattr(pcfg, 'spellcheck_on_source_enabled', False):
-                if hasattr(self, 'suggestion_popup') and self.suggestion_popup:
-                    self.suggestion_popup.hide()
-                self.current_suggestion_word = None
+            # Do not scan selections or touch the optional dependency while the
+            # relevant spellcheck path is disabled.
+            if not self._spellcheck_is_enabled():
+                self._dismiss_suggestions()
                 return
 
             cursor = self.textCursor()
             if not cursor.hasSelection():
-                if hasattr(self, 'suggestion_popup') and self.suggestion_popup:
-                    self.suggestion_popup.hide()
-                self.current_suggestion_word = None
+                self._dismiss_suggestions()
                 return
 
-            selected_text = cursor.selectedText().strip()
-            # Only suggest for a single alphabetic word, never for CJK characters
-            pattern = r'^[^\W\d_]+$'
-            if len(selected_text) > 1 and re.match(pattern, selected_text) and not CJK_PATTERN.search(selected_text):
-                if not manager.is_correct(selected_text):
-                    self.current_suggestion_word = selected_text
-                    
-                    # Fetch suggestions in background thread to avoid freezing the UI thread
-                    def fetch_bg(c, w):
-                        try:
-                            sugs = manager.get_suggestions(w)
-                            self.suggestions_ready.emit(c, w, sugs)
-                        except Exception:
-                            pass
-                            
-                    t = threading.Thread(target=fetch_bg, args=(cursor, selected_text), daemon=True)
-                    t.start()
-                    return
+            selected_text = cursor.selectedText()
+            word = next(iter_spellcheck_words(selected_text), None)
+            if word is None or word[2] != selected_text:
+                self._dismiss_suggestions()
+                return
 
-            if hasattr(self, 'suggestion_popup') and self.suggestion_popup:
-                self.suggestion_popup.hide()
-            self.current_suggestion_word = None
-        except Exception as e:
+            manager = SpellCheckManager.get_instance()
+            if not manager.is_available() or manager.is_correct(selected_text):
+                self._dismiss_suggestions()
+                return
+
+            self.current_suggestion_word = selected_text
+
+            # Fetch suggestions in background to keep the UI thread responsive.
+            def fetch_bg(c, w):
+                try:
+                    sugs = manager.get_suggestions(w)
+                    self.suggestions_ready.emit(c, w, sugs)
+                except Exception:
+                    pass
+
+            thread = threading.Thread(
+                target=fetch_bg,
+                args=(cursor, selected_text),
+                daemon=True,
+            )
+            thread.start()
+        except Exception:
             traceback.print_exc()
 
-    def show_suggestions_popup(self, cursor, word, suggestions):
+    def show_suggestions_popup(
+        self,
+        cursor: QTextCursor,
+        word: str,
+        suggestions: List[str],
+    ) -> None:
         try:
+            if not self._spellcheck_is_enabled():
+                self._dismiss_suggestions()
+                return
             if getattr(self, 'current_suggestion_word', None) != word:
                 return
                 
@@ -338,7 +363,7 @@ class SourceTextEdit(QTextEdit):
             
             self.suggestion_popup.move(global_pos)
             self.suggestion_popup.show()
-        except Exception as e:
+        except Exception:
             traceback.print_exc()
 
     def contextMenuEvent(self, event):
@@ -459,13 +484,11 @@ class SourceTextEdit(QTextEdit):
     def focusOutEvent(self, event: QFocusEvent) -> None:
         self.setHoverEffect(False)
         self.focus_out.emit(self.idx)
-        if hasattr(self, 'suggestion_popup') and self.suggestion_popup:
-            self.suggestion_popup.hide()
+        self._dismiss_suggestions()
         return super().focusOutEvent(event)
 
     def wheelEvent(self, event) -> None:
-        if hasattr(self, 'suggestion_popup') and self.suggestion_popup:
-            self.suggestion_popup.hide()
+        self._dismiss_suggestions()
         return super().wheelEvent(event)
 
     def inputMethodEvent(self, e: QInputMethodEvent) -> None:
@@ -549,6 +572,8 @@ class SourceTextEdit(QTextEdit):
 
         
 class TransTextEdit(SourceTextEdit):
+    is_source_text_edit = False
+
     def contextMenuEvent(self, event: QContextMenuEvent) -> None:
         cursor = self.textCursor()
         menu, quick_insert_actions = create_text_edit_context_menu(

--- a/tests/test_spellcheck.py
+++ b/tests/test_spellcheck.py
@@ -1,0 +1,184 @@
+import os
+import unittest
+from unittest.mock import patch
+
+
+os.environ.setdefault('QT_QPA_PLATFORM', 'offscreen')
+
+from qtpy.QtGui import QTextCursor, QTextDocument
+from qtpy.QtWidgets import QApplication, QWidget
+
+from ballontranslator.ui import spellcheck as spellcheck_module
+from ballontranslator.ui.spellcheck import (
+    SpellCheckHighlighter,
+    SpellCheckManager,
+    iter_spellcheck_words,
+)
+from ballontranslator.ui.text_engine.editing import widgets as widgets_module
+from ballontranslator.ui.text_engine.editing.widgets import (
+    SourceTextEdit,
+    TransTextEdit,
+)
+from ballontranslator.utils.config import pcfg
+
+
+class _FakeSpellCheckManager:
+    def __init__(self, *, correct: bool = False) -> None:
+        self.correct = correct
+        self.available_calls = 0
+        self.checked = []
+
+    def register_highlighter(self, _highlighter) -> None:
+        pass
+
+    def is_available(self) -> bool:
+        self.available_calls += 1
+        return True
+
+    def is_correct(self, word: str) -> bool:
+        self.checked.append(word)
+        return self.correct
+
+    def get_suggestions(self, _word: str):
+        return ['hello']
+
+
+class _FakePopup:
+    def __init__(self) -> None:
+        self.hidden = False
+        self.shown = False
+
+    def hide(self) -> None:
+        self.hidden = True
+
+    def show(self) -> None:
+        self.shown = True
+
+
+class SpellCheckTest(unittest.TestCase):
+    @classmethod
+    def setUpClass(cls) -> None:
+        cls.app = QApplication.instance() or QApplication([])
+
+    def test_word_spans_cover_cjk_and_preserve_utf16_offsets(self) -> None:
+        self.assertEqual(
+            list(iter_spellcheck_words('한helo世界wrld')),
+            [(3, 4, 'helo'), (9, 4, 'wrld')],
+        )
+        self.assertEqual(
+            list(iter_spellcheck_words('𠀀helo')),
+            [(2, 4, 'helo')],
+        )
+        self.assertEqual(list(iter_spellcheck_words('ㇰ々한글漢字')), [])
+
+    def test_highlighter_checks_only_non_cjk_runs(self) -> None:
+        manager = _FakeSpellCheckManager()
+        document = QTextDocument('한helo世界wrld𠀀')
+        with patch.object(
+            SpellCheckManager, 'get_instance', return_value=manager
+        ), patch.object(pcfg, 'spellcheck_enabled', True):
+            highlighter = SpellCheckHighlighter(document)
+            highlighter.rehighlight()
+
+        self.assertEqual(manager.checked, ['helo', 'wrld'])
+        ranges = document.firstBlock().layout().formats()
+        self.assertEqual(
+            [(format_range.start, format_range.length) for format_range in ranges],
+            [(3, 4), (9, 4)],
+        )
+
+    def test_disabled_highlighter_does_no_package_or_text_work(self) -> None:
+        manager = _FakeSpellCheckManager()
+        with patch.object(SpellCheckManager, 'get_instance', return_value=manager):
+            highlighter = SpellCheckHighlighter(None)
+
+        with patch.object(pcfg, 'spellcheck_enabled', False), patch.object(
+            spellcheck_module,
+            'iter_spellcheck_words',
+            side_effect=AssertionError('disabled spellcheck scanned text'),
+        ):
+            highlighter.highlightBlock('helo世界')
+
+        self.assertEqual(manager.available_calls, 0)
+        self.assertEqual(manager.checked, [])
+
+    def test_source_guard_precedes_matching_and_keeps_translation_enabled(self) -> None:
+        manager = _FakeSpellCheckManager(correct=True)
+        parent = QWidget()
+        with patch.object(
+            SpellCheckManager, 'get_instance', return_value=manager
+        ), patch.object(pcfg, 'spellcheck_enabled', True), patch.object(
+            pcfg, 'spellcheck_on_source_enabled', False
+        ):
+            source = SourceTextEdit(0, parent)
+            translation = TransTextEdit(1, parent)
+            self._select_word(source, 'helo')
+            self._select_word(translation, 'helo')
+
+            manager.available_calls = 0
+            manager.checked.clear()
+            with patch.object(
+                widgets_module,
+                'iter_spellcheck_words',
+                side_effect=AssertionError('disabled source spellcheck scanned text'),
+            ):
+                source.on_selection_changed()
+
+            self.assertEqual(manager.available_calls, 0)
+            self.assertEqual(manager.checked, [])
+
+            with patch.object(pcfg, 'spellcheck_enabled', False), patch.object(
+                widgets_module,
+                'iter_spellcheck_words',
+                side_effect=AssertionError('disabled spellcheck scanned selection'),
+            ):
+                translation.on_selection_changed()
+
+            self.assertEqual(manager.available_calls, 0)
+            self.assertEqual(manager.checked, [])
+
+            translation.on_selection_changed()
+            self.assertEqual(manager.checked, ['helo'])
+
+            with patch.object(pcfg, 'spellcheck_on_source_enabled', True):
+                source.on_selection_changed()
+            self.assertEqual(manager.checked, ['helo', 'helo'])
+
+        source.deleteLater()
+        translation.deleteLater()
+        parent.deleteLater()
+
+    def test_pending_source_suggestion_rechecks_config(self) -> None:
+        manager = _FakeSpellCheckManager()
+        parent = QWidget()
+        with patch.object(SpellCheckManager, 'get_instance', return_value=manager):
+            source = SourceTextEdit(0, parent)
+
+        popup = _FakePopup()
+        source.suggestion_popup = popup
+        source.current_suggestion_word = 'helo'
+        with patch.object(pcfg, 'spellcheck_enabled', True), patch.object(
+            pcfg, 'spellcheck_on_source_enabled', False
+        ):
+            source.show_suggestions_popup(QTextCursor(), 'helo', ['hello'])
+
+        self.assertTrue(popup.hidden)
+        self.assertFalse(popup.shown)
+        self.assertIsNone(source.current_suggestion_word)
+        source.deleteLater()
+        parent.deleteLater()
+
+    @staticmethod
+    def _select_word(editor: SourceTextEdit, text: str) -> None:
+        editor.blockSignals(True)
+        try:
+            editor.setPlainText(text)
+            cursor = editor.textCursor()
+            cursor.select(QTextCursor.SelectionType.Document)
+            editor.setTextCursor(cursor)
+        finally:
+            editor.blockSignals(False)
+
+
+if __name__ == '__main__':
+    unittest.main()


### PR DESCRIPTION
## Summary

Fixes false-positive spellchecking on Japanese/Chinese/Korean text blocks and improves UI popup behavior:

- **CJK Character Filtering**: Adds Unicode range matching (`[\u3040-\u30ff\u3400-\u4dbf\u4e00-\u9fff\uf900-\ufaff\uff66-\uff9f\uac00-\ud7af]`) in `is_correct()`, `get_suggestions()`, and `highlightBlock()` so CJK characters are never marked as spelling errors or queried for dictionary replacements.
- **SourceTextEdit Guard**: Prevents spellcheck suggestion popups from triggering inside `SourceTextEdit` fields when clicking Japanese/original source text unless source spellchecking is explicitly enabled.
