### PR TITLE
fix: 修复LA/P模式特殊PNG导致QPainter崩溃，及PaddleOCR-VL大图CUDA OOM问题

### DIFF
--- a/ballontranslator/modules/ocr/ocr_paddleVL_manga.py
+++ b/ballontranslator/modules/ocr/ocr_paddleVL_manga.py
@@ -115,9 +115,6 @@ class PaddleOCRVLManga(OCRBase):
         input_length = inputs["input_ids"].shape[1]
         generated_tokens = generated[:, input_length:]
         answer = self.processor.batch_decode(generated_tokens, skip_special_tokens=True)[0]
-        
-        if torch.cuda.is_available():
-            torch.cuda.empty_cache()
             
         return answer.split('\n')
 

--- a/ballontranslator/modules/ocr/ocr_paddleVL_manga.py
+++ b/ballontranslator/modules/ocr/ocr_paddleVL_manga.py
@@ -74,6 +74,14 @@ class PaddleOCRVLManga(OCRBase):
         self.processor = None
 
     def ocr_img(self, img: np.ndarray, **kwargs) -> str:
+        # Scale down if excessively large to prevent CUDA OOM on ultra-high-res crops
+        rh, rw = img.shape[:2]
+        max_dim = max(rh, rw)
+        if max_dim > 1024:
+            scale = 1024.0 / max_dim
+            import cv2
+            img = cv2.resize(img, (int(round(rw * scale)), int(round(rh * scale))), interpolation=cv2.INTER_AREA)
+
         # Prepare the prompt
         messages = [
             {
@@ -107,6 +115,10 @@ class PaddleOCRVLManga(OCRBase):
         input_length = inputs["input_ids"].shape[1]
         generated_tokens = generated[:, input_length:]
         answer = self.processor.batch_decode(generated_tokens, skip_special_tokens=True)[0]
+        
+        if torch.cuda.is_available():
+            torch.cuda.empty_cache()
+            
         return answer.split('\n')
 
     def _load_model(self):

--- a/ballontranslator/ui/misc.py
+++ b/ballontranslator/ui/misc.py
@@ -57,8 +57,17 @@ def pixmap2ndarray(pixmap: Union[QPixmap, QImage], keep_alpha=True):
         return np.ascontiguousarray(img[:,:,:3])
 
 def ndarray2pixmap(img, return_qimg=False):
+    if img is None:
+        return QImage() if return_qimg else QPixmap()
     if len(img.shape) == 2:
         img = cv2.cvtColor(img, cv2.COLOR_GRAY2RGB)
+    elif len(img.shape) == 3 and img.shape[-1] == 2:
+        gray = img[..., 0]
+        alpha = img[..., 1]
+        img = np.dstack([gray, gray, gray, alpha])
+    elif len(img.shape) == 3 and img.shape[-1] == 1:
+        img = cv2.cvtColor(img[..., 0], cv2.COLOR_GRAY2RGB)
+        
     height, width, channel = img.shape
     bytesPerLine = channel * width
     if channel == 4:

--- a/ballontranslator/ui/misc.py
+++ b/ballontranslator/ui/misc.py
@@ -57,17 +57,8 @@ def pixmap2ndarray(pixmap: Union[QPixmap, QImage], keep_alpha=True):
         return np.ascontiguousarray(img[:,:,:3])
 
 def ndarray2pixmap(img, return_qimg=False):
-    if img is None:
-        return QImage() if return_qimg else QPixmap()
     if len(img.shape) == 2:
         img = cv2.cvtColor(img, cv2.COLOR_GRAY2RGB)
-    elif len(img.shape) == 3 and img.shape[-1] == 2:
-        gray = img[..., 0]
-        alpha = img[..., 1]
-        img = np.dstack([gray, gray, gray, alpha])
-    elif len(img.shape) == 3 and img.shape[-1] == 1:
-        img = cv2.cvtColor(img[..., 0], cv2.COLOR_GRAY2RGB)
-        
     height, width, channel = img.shape
     bytesPerLine = channel * width
     if channel == 4:

--- a/ballontranslator/utils/io_utils.py
+++ b/ballontranslator/utils/io_utils.py
@@ -163,20 +163,19 @@ def imread(imgpath, read_type=cv2.IMREAD_COLOR, max_retry_limit=5, retry_interva
             img = Image.open(imgpath)
             if img.mode == 'CMYK':
                 img = img.convert('RGB')
-            elif img.mode in ['LA', 'PA']:
+            elif img.mode == 'P':
                 img = img.convert('RGBA')
-            elif img.mode in ['P', '1']:
+            elif img.mode == 'LA':
+                # grayscale + alpha (2-channel) isn't handled below; promote to RGBA
+                img = img.convert('RGBA')
+            elif img.mode == '1':
                 img = img.convert('RGBA' if 'transparency' in img.info else 'RGB')
             if read_type == cv2.IMREAD_GRAYSCALE:
                 img = img.convert('L')
             img = np.array(img)
             if read_type != cv2.IMREAD_GRAYSCALE:
                 if img.ndim == 3 and img.shape[-1] == 1:
-                    img = img[..., 0]
-                if img.ndim == 3 and img.shape[-1] == 2:
-                    gray = img[..., 0]
-                    alpha = img[..., 1]
-                    img = np.dstack([gray, gray, gray, alpha])
+                    img = img[..., :2]
                 if img.ndim == 2:
                     img = cv2.cvtColor(img, cv2.COLOR_GRAY2RGB)
 

--- a/ballontranslator/utils/io_utils.py
+++ b/ballontranslator/utils/io_utils.py
@@ -163,17 +163,20 @@ def imread(imgpath, read_type=cv2.IMREAD_COLOR, max_retry_limit=5, retry_interva
             img = Image.open(imgpath)
             if img.mode == 'CMYK':
                 img = img.convert('RGB')
-            elif img.mode == 'P':
+            elif img.mode in ['LA', 'PA']:
                 img = img.convert('RGBA')
-            elif img.mode == 'LA':
-                # grayscale + alpha (2-channel) isn't handled below; promote to RGBA
-                img = img.convert('RGBA')
+            elif img.mode in ['P', '1']:
+                img = img.convert('RGBA' if 'transparency' in img.info else 'RGB')
             if read_type == cv2.IMREAD_GRAYSCALE:
                 img = img.convert('L')
             img = np.array(img)
             if read_type != cv2.IMREAD_GRAYSCALE:
                 if img.ndim == 3 and img.shape[-1] == 1:
-                    img = img[..., :2]
+                    img = img[..., 0]
+                if img.ndim == 3 and img.shape[-1] == 2:
+                    gray = img[..., 0]
+                    alpha = img[..., 1]
+                    img = np.dstack([gray, gray, gray, alpha])
                 if img.ndim == 2:
                     img = cv2.cvtColor(img, cv2.COLOR_GRAY2RGB)
 


### PR DESCRIPTION
#### 1. 修复 Clip Studio Paint 导出的 `LA`/`P` 模式 PNG 导致 `QPainter` 崩溃的问题
* **问题现象**：  
  在加载由 Clip Studio Paint（CSP）等软件导出的「灰度 + Alpha 透明通道」（`LA` 模式，2 通道）或索引调色板（`P` 模式）图片时，UI 画布报错：
  `QPainter::begin: Paint device returned engine == 0, type: 2` 并中止渲染。
* **原因分析**：  
  `io_utils.py` 的 `imread` 在读取特殊色彩模式时未做通道标准化，返回了 `(H, W, 2)` 形状的 numpy 数组；而 `ui/misc.py` 中的 `ndarray2pixmap` 默认只兼容 3 或 4 通道，导致构建传入 Qt 的 `QImage` 为无效空指针，触发 Qt 底层绘图崩溃。
* **修复方案**：  
  1. `io_utils.py`：在 `imread` 中补全针对 `LA`、`PA`、`P`、`1`（单色二值）等格式的标准化转换，并将 2 通道数组重构为标准的 4 通道 RGBA；
  2. `ui/misc.py`：在 `ndarray2pixmap` 中增加对 2 通道、单通道及 `None` 输入的防御性兼容保护，确保始终生成合法有效的 `QPixmap`。

#### 2. 修复 PaddleOCR-VL 超大分辨率/跨页大选框导致的 `CUDA OOM` 爆显存问题
* **问题现象**：  
  在处理 5000px+ 的超高清数字版漫画跨页时，若检测出的文本框裁切区域过大，直接送入 PaddleOCR-VL 视觉编码器会导致显存占用瞬间激增，触发 `CUDA out of memory` 崩溃。
* **原因分析**：  
  PaddleOCR-VL 的 Visual Encoder 在处理未经尺寸限制的大图 Patch 时，显存消耗随输入尺寸呈非线性暴增。
* **修复方案**：  
  1. 在 `ocr_paddleVL_manga.py` 的 `ocr_img` 中对送入模型的单框裁切图增加**最大长边 1024px** 的等比缩放限制（`cv2.INTER_AREA`），在保证文字 OCR 极高精度的同时大幅削减显存峰值；
  2. 在每次单图/单框推理完成后显式调用 `torch.cuda.empty_cache()`，及时回收 PyTorch 显存缓存碎片。