### PR TITLE
Fix CJK IME composition handling in the text editor

### DIFF
--- a/ballontranslator/ui/canvas.py
+++ b/ballontranslator/ui/canvas.py
@@ -1117,6 +1117,11 @@ class Canvas(QGraphicsScene):
 
     def mousePressEvent(self, event: QGraphicsSceneMouseEvent) -> None:
         btn = event.button()
+        if btn in (
+            Qt.MouseButton.LeftButton,
+            Qt.MouseButton.RightButton,
+        ):
+            self.gv.setFocus(Qt.FocusReason.MouseFocusReason)
         if self.alpha_mask_edit_session.handle_mouse_press(event):
             event.accept()
             return

--- a/ballontranslator/ui/canvas.py
+++ b/ballontranslator/ui/canvas.py
@@ -1426,6 +1426,7 @@ class Canvas(QGraphicsScene):
                 and editing_item.isEditing()
             ):
                 editing_item.show_editing_context_menu(pos, self.gv)
+                self.gv.setFocus(Qt.FocusReason.MouseFocusReason)
                 return
 
             menu = QMenu(self.gv)
@@ -1456,6 +1457,7 @@ class Canvas(QGraphicsScene):
             inpaint_act = menu.addAction(self.tr("inpaint"))
 
             rst = menu.exec(pos)
+            self.gv.setFocus(Qt.FocusReason.MouseFocusReason)
             
             if rst == delete_act:
                 self.delete_textblks.emit(0)

--- a/ballontranslator/ui/canvas.py
+++ b/ballontranslator/ui/canvas.py
@@ -95,7 +95,7 @@ class CustomGV(QGraphicsView):
     def wheelEvent(self, event : QWheelEvent) -> None:
         # qgraphicsview always scroll content according to wheelevent
         # which is not desired when scaling img
-        if event.modifiers() == Qt.KeyboardModifier.ControlModifier:
+        if event.modifiers() & Qt.KeyboardModifier.ControlModifier:
             if event.angleDelta().y() > 0:
                 self.scale_up_signal.emit()
             else:
@@ -118,17 +118,14 @@ class CustomGV(QGraphicsView):
             return super().keyPressEvent(e)
 
         modifiers = e.modifiers()
-        if modifiers == Qt.KeyboardModifier.ControlModifier:
-            if key == QKEY.Key_V:
-                # self.ctrlv_pressed.emit(e)
-                if self.canvas.handle_ctrlv():
-                    e.accept()
-                    return
-            if key == QKEY.Key_C:
-                if self.canvas.handle_ctrlc():
-                    e.accept()
-                    return
-                
+        if e.matches(QKeySequence.StandardKey.Paste):
+            if self.canvas.handle_ctrlv():
+                e.accept()
+                return
+        elif e.matches(QKeySequence.StandardKey.Copy):
+            if self.canvas.handle_ctrlc():
+                e.accept()
+                return
         elif modifiers & Qt.KeyboardModifier.ControlModifier and modifiers & Qt.KeyboardModifier.ShiftModifier:
             if key == QKEY.Key_C:
                 self.canvas.copy_src_signal.emit()

--- a/ballontranslator/ui/text_engine/editing/widgets.py
+++ b/ballontranslator/ui/text_engine/editing/widgets.py
@@ -562,21 +562,15 @@ class SourceTextEdit(QTextEdit):
                 return super().keyPressEvent(e)
             finally:
                 self.paste_flag = False
-        if e.modifiers() == Qt.KeyboardModifier.ControlModifier:
-            if e.key() == Qt.Key.Key_Z:
-                e.accept()
-                self.undo_signal.emit()
-                return
-            elif e.key() == Qt.Key.Key_Y:
-                e.accept()
-                self.redo_signal.emit()
-                return
-        elif e.modifiers() == Qt.KeyboardModifier.ControlModifier | Qt.KeyboardModifier.ShiftModifier:
-            if e.key() == Qt.Key.Key_Z:
-                e.accept()
-                self.redo_signal.emit()
-                return
-        elif e.key() == Qt.Key.Key_Return:
+        if e.matches(QKeySequence.StandardKey.Undo):
+            e.accept()
+            self.undo_signal.emit()
+            return
+        if e.matches(QKeySequence.StandardKey.Redo):
+            e.accept()
+            self.redo_signal.emit()
+            return
+        if e.key() == Qt.Key.Key_Return:
             e.accept()
             self.textCursor().insertText('\n')
             return

--- a/ballontranslator/ui/text_engine/editing/widgets.py
+++ b/ballontranslator/ui/text_engine/editing/widgets.py
@@ -413,7 +413,9 @@ class SourceTextEdit(QTextEdit):
             if not self.highlighting:
                 self.text_changed.emit()
                 
-        if self.hasFocus() and not self.pre_editing and not self.highlighting and not self.in_acts:
+        if (
+            self.hasFocus() or self.input_method_from != -1
+        ) and not self.pre_editing and not self.highlighting and not self.in_acts:
             self.handle_content_change()
 
     def handle_content_change(self):
@@ -503,6 +505,9 @@ class SourceTextEdit(QTextEdit):
         return super().wheelEvent(event)
 
     def inputMethodEvent(self, e: QInputMethodEvent) -> None:
+        continues_composing = bool(e.preeditString())
+        commit_text = e.commitString()
+        commits_text = bool(commit_text) or e.replacementLength() > 0
         if not self.pre_editing:
             cursor = self.textCursor()
             self.input_method_from = cursor.selectionStart()
@@ -525,16 +530,25 @@ class SourceTextEdit(QTextEdit):
             )
             self.input_method_from = replacement_start
             self.input_method_removed = replacement_end - replacement_start
-        if e.preeditString() == '':
+        if commits_text:
+            # contentsChanged is synchronous; expose this committed portion
+            # even when the same IME event starts the next preedit.
             self.pre_editing = False
-            self.input_method_text = e.commitString()
+            self.input_method_text = commit_text
         else:
-            self.pre_editing = True
+            self.pre_editing = continues_composing
         super().inputMethodEvent(e)
+        self.pre_editing = continues_composing
+        if continues_composing and commits_text:
+            cursor = self.textCursor()
+            self.input_method_from = cursor.selectionStart()
+            self.input_method_removed = (
+                cursor.selectionEnd() - cursor.selectionStart()
+            )
         if (
-            e.preeditString() == ''
-            and not e.commitString()
-            and e.replacementLength() == 0
+            not continues_composing
+            and not commits_text
+            and self.input_method_from != -1
         ):
             self.input_method_from = -1
             self.input_method_removed = 0

--- a/ballontranslator/ui/text_engine/item.py
+++ b/ballontranslator/ui/text_engine/item.py
@@ -14,7 +14,7 @@ from qtpy.QtWidgets import (
     QGraphicsSceneMouseEvent,
 )
 from qtpy.QtCore import Qt, QRect, QRectF, QPoint, QPointF, QMimeData, Signal
-from qtpy.QtGui import (QKeyEvent, QFont, QTextCursor,
+from qtpy.QtGui import (QKeyEvent, QKeySequence, QFont, QTextCursor,
                        QInputMethodEvent, QPainter, QColor, QTextCharFormat,
                        QBrush, QFontMetrics, QPen,
                        QFocusEvent, QTextBlockFormat)
@@ -1114,35 +1114,30 @@ class TextBlkItem(QGraphicsTextItem):
             return
         self._vertical_navigation_y = None
 
-        if e.modifiers() == Qt.KeyboardModifier.ControlModifier:
-            if e.key() == Qt.Key.Key_Z:
-                e.accept()
-                self.undo_signal.emit()
-                return
-            elif e.key() == Qt.Key.Key_Y:
-                e.accept()
-                self.redo_signal.emit()
-                return
-            elif e.key() == Qt.Key.Key_V:
-                if self.isEditing():
-                    e.accept()
-                    self.pasted.emit(self.idx)
-                    return
-            elif e.key() in (Qt.Key.Key_C, Qt.Key.Key_X):
-                cursor = self.textCursor()
-                if cursor.hasSelection():
-                    self._copy_selected_text()
-                    if e.key() == Qt.Key.Key_X:
-                        cursor.removeSelectedText()
-                        self.setTextCursor(cursor)
-                e.accept()
-                return
-        elif e.modifiers() == Qt.KeyboardModifier.ControlModifier | Qt.KeyboardModifier.ShiftModifier:
-            if e.key() == Qt.Key.Key_Z:
-                e.accept()
-                self.redo_signal.emit()
-                return
-        elif e.key() in (Qt.Key.Key_Return, Qt.Key.Key_Enter):
+        if e.matches(QKeySequence.StandardKey.Undo):
+            e.accept()
+            self.undo_signal.emit()
+            return
+        if e.matches(QKeySequence.StandardKey.Redo):
+            e.accept()
+            self.redo_signal.emit()
+            return
+        if e.matches(QKeySequence.StandardKey.Paste) and self.isEditing():
+            e.accept()
+            self.pasted.emit(self.idx)
+            return
+        is_copy = e.matches(QKeySequence.StandardKey.Copy)
+        is_cut = e.matches(QKeySequence.StandardKey.Cut)
+        if is_copy or is_cut:
+            cursor = self.textCursor()
+            if cursor.hasSelection():
+                self._copy_selected_text()
+                if is_cut:
+                    cursor.removeSelectedText()
+                    self.setTextCursor(cursor)
+            e.accept()
+            return
+        if e.key() in (Qt.Key.Key_Return, Qt.Key.Key_Enter):
             e.accept()
             cursor = self.textCursor()
             cursor.beginEditBlock()

--- a/ballontranslator/ui/text_engine/item.py
+++ b/ballontranslator/ui/text_engine/item.py
@@ -17,7 +17,7 @@ from qtpy.QtCore import Qt, QRect, QRectF, QPoint, QPointF, QMimeData, Signal
 from qtpy.QtGui import (QKeyEvent, QFont, QTextCursor,
                        QInputMethodEvent, QPainter, QColor, QTextCharFormat,
                        QBrush, QFontMetrics, QPen,
-                       QTextBlockFormat)
+                       QFocusEvent, QTextBlockFormat)
 
 from ballontranslator.utils.textblock import TextBlock
 from ballontranslator.utils.text_alpha_mask import TextAlphaMask
@@ -48,6 +48,7 @@ from .horizontal_layout import HorizontalTextDocumentLayout
 from .vertical_layout import VerticalTextDocumentLayout
 from .effects.renderer import TextEffectRenderer
 from .geometry import TextItemGeometryController
+from .rendering.indexing import _utf16_length
 from .annotations import (
     AnnotationProperty,
     LIGATURE_COMMON,
@@ -218,6 +219,7 @@ class TextBlkItem(QGraphicsTextItem):
         self.input_method_from = -1
         self.input_method_removed = 0
         self.input_method_text = ''
+        self._preedit_cursor_position: Optional[int] = None
         self.block_change_signal = False
         self._vertical_navigation_y: Optional[float] = None
 
@@ -236,17 +238,26 @@ class TextBlkItem(QGraphicsTextItem):
 
     def inputMethodEvent(self, e: QInputMethodEvent) -> None:
         self._vertical_navigation_y = None
+        was_composing = self.pre_editing
+        continues_composing = bool(e.preeditString())
+        commit_text = e.commitString()
+        commits_text = bool(commit_text) or e.replacementLength() > 0
+        self._preedit_cursor_position = self._input_method_cursor_position(e)
+        if continues_composing or commits_text:
+            self._ensure_empty_input_foreground()
         if not self.pre_editing:
             cursor = self.textCursor()
             self.input_method_from = cursor.selectionStart()
             self.input_method_removed = (
                 cursor.selectionEnd() - cursor.selectionStart()
             )
-        if e.preeditString() == '':
+        if commits_text:
+            # contentsChanged is synchronous; expose this committed portion
+            # even when the same IME event starts the next preedit.
             self.pre_editing = False
-            self.input_method_text = e.commitString()
+            self.input_method_text = commit_text
         else:
-            self.pre_editing = True
+            self.pre_editing = continues_composing
         replacement_length = e.replacementLength()
         replacement_start = None
         replacement_end = None
@@ -265,7 +276,7 @@ class TextBlkItem(QGraphicsTextItem):
             )
             self.input_method_from = replacement_start
             self.input_method_removed = replacement_end - replacement_start
-        if e.commitString():
+        if commit_text:
             cursor = self.textCursor()
             cursor.beginEditBlock()
             prepare_cursor = QTextCursor(cursor)
@@ -274,7 +285,7 @@ class TextBlkItem(QGraphicsTextItem):
                 prepare_cursor.setPosition(
                     replacement_end, QTextCursor.MoveMode.KeepAnchor
                 )
-            prepare_ruby_insertion(prepare_cursor, e.commitString())
+            prepare_ruby_insertion(prepare_cursor, commit_text)
             if replacement_length == 0:
                 cursor = prepare_cursor
             super().setTextCursor(cursor)
@@ -284,10 +295,27 @@ class TextBlkItem(QGraphicsTextItem):
                 cursor.endEditBlock()
         else:
             super().inputMethodEvent(e)
+        self.pre_editing = continues_composing
         if (
-            e.preeditString() == ''
-            and not e.commitString()
-            and replacement_length == 0
+            isinstance(self.layout, VerticalTextDocumentLayout)
+            and (was_composing or continues_composing)
+        ):
+            self.layout.set_preedit_formats(
+                self._input_method_formats(e)
+            )
+            if continues_composing or not commits_text:
+                # Preedit changes QTextLayout without changing QTextDocument.
+                self.layout.reLayout()
+        if continues_composing and commits_text:
+            cursor = self.textCursor()
+            self.input_method_from = cursor.selectionStart()
+            self.input_method_removed = (
+                cursor.selectionEnd() - cursor.selectionStart()
+            )
+        if (
+            not continues_composing
+            and not commits_text
+            and self.input_method_from != -1
         ):
             self.input_method_from = -1
             self.input_method_removed = 0
@@ -297,6 +325,73 @@ class TextBlkItem(QGraphicsTextItem):
         # not change. The next paint is cached until another IME event.
         self.geometry_controller.invalidate_surface_cache()
         self._update_nonlinear_editing_ui()
+        self.updateMicroFocus()
+
+    @staticmethod
+    def _input_method_cursor_position(
+        event: QInputMethodEvent,
+    ) -> Optional[int]:
+        preedit_text = event.preeditString()
+        if not preedit_text:
+            return None
+        cursor_type = (
+            QInputMethodEvent.AttributeType.Cursor
+            if hasattr(QInputMethodEvent, 'AttributeType')
+            else QInputMethodEvent.Cursor
+        )
+        for attribute in event.attributes():
+            if attribute.type == cursor_type:
+                return max(
+                    0,
+                    min(attribute.start, _utf16_length(preedit_text)),
+                )
+        return _utf16_length(preedit_text)
+
+    @staticmethod
+    def _input_method_formats(
+        event: QInputMethodEvent,
+    ) -> List[Tuple[int, int, QTextCharFormat]]:
+        preedit_length = _utf16_length(event.preeditString())
+        if preedit_length == 0:
+            return []
+        format_type = (
+            QInputMethodEvent.AttributeType.TextFormat
+            if hasattr(QInputMethodEvent, 'AttributeType')
+            else QInputMethodEvent.TextFormat
+        )
+        formats = []
+        for attribute in event.attributes():
+            if attribute.type != format_type or attribute.length <= 0:
+                continue
+            start = max(0, min(attribute.start, preedit_length))
+            end = max(start, min(
+                attribute.start + attribute.length,
+                preedit_length,
+            ))
+            if end == start:
+                continue
+            try:
+                char_format = QTextCharFormat(attribute.value)
+            except (TypeError, ValueError):
+                continue
+            formats.append((start, end - start, char_format))
+        return formats
+
+    def _ensure_empty_input_foreground(self) -> None:
+        if not self.document().isEmpty():
+            return
+        cursor = self.textCursor()
+        if cursor.charFormat().foreground().style() != Qt.BrushStyle.NoBrush:
+            return
+
+        # A document-wide deletion can discard the insertion brush. Without
+        # an explicit color, a dark system palette paints IME text white.
+        char_format = QTextCharFormat()
+        char_format.setForeground(
+            QColor(*self.fontformat.foreground_color())
+        )
+        cursor.mergeCharFormat(char_format)
+        self.setTextCursor(cursor)
 
     def setTextCursor(self, cursor: QTextCursor) -> None:
         self._vertical_navigation_y = None
@@ -387,7 +482,13 @@ class TextBlkItem(QGraphicsTextItem):
         
     def on_content_changed(self):
         self.geometry_controller.invalidate_surface_cache()
-        if (self.hasFocus() or self.is_formatting) and not self.pre_editing and not self.block_change_signal:   
+        if self.document().isEmpty():
+            self._ensure_empty_input_foreground()
+        if (
+            self.hasFocus()
+            or self.is_formatting
+            or self.input_method_from != -1
+        ) and not self.pre_editing and not self.block_change_signal:
             # self.content_changed.emit(self)
             if not self.in_redo_undo:
                 undo_steps = self.document().availableUndoSteps()
@@ -728,9 +829,10 @@ class TextBlkItem(QGraphicsTextItem):
             query == Qt.InputMethodQuery.ImCursorRectangle
             and self.layout is not None
         ):
-            cursor_rect = self.layout.source_cursor_rect(
-                self.textCursor().position()
-            )
+            cursor_position = self.textCursor().position()
+            if self._preedit_cursor_position is not None:
+                cursor_position = -(self._preedit_cursor_position + 2)
+            cursor_rect = self.layout.source_cursor_rect(cursor_position)
             if cursor_rect is not None:
                 value = cursor_rect
         mapper = self.geometry_controller.visual_mapper
@@ -1208,9 +1310,32 @@ class TextBlkItem(QGraphicsTextItem):
         self._sync_order_badge()
         self.update()
 
+    def focusOutEvent(self, event: QFocusEvent) -> None:
+        # Flush before Qt tears down the preedit layout for the old item.
+        self.commit_active_input_method()
+        super().focusOutEvent(event)
+
+    def commit_active_input_method(self) -> None:
+        if not self.pre_editing:
+            return
+        block = self.textCursor().block()
+        preedit_text = block.layout().preeditAreaText()
+        input_method = QApplication.inputMethod()
+        input_method.commit()
+        if self.pre_editing and preedit_text:
+            # macOS can leave a QGraphicsTextItem's marked text active when
+            # its scene edit is ended without changing the view focus.
+            event = QInputMethodEvent('', [])
+            event.setCommitString(preedit_text)
+            self.inputMethodEvent(event)
+            input_method.reset()
+
 
     def startEdit(self, pos: QPointF = None) -> None:
         self.pre_editing = False
+        self._preedit_cursor_position = None
+        if isinstance(self.layout, VerticalTextDocumentLayout):
+            self.layout.set_preedit_formats([])
         self.setTextInteractionFlags(Qt.TextInteractionFlag.TextEditorInteraction)
         self.refresh_cache_policy()
         self._sync_order_badge()
@@ -1223,6 +1348,10 @@ class TextBlkItem(QGraphicsTextItem):
             self.setTextCursor(cursor)
 
     def endEdit(self, keep_focus=True) -> None:
+        if self.pre_editing and self.hasFocus():
+            # Deliver the final commit while document, pair, and undo signals
+            # still observe an active text editor.
+            self.commit_active_input_method()
         self.end_edit.emit(self.idx)
         cursor = self.textCursor()
         cursor.clearSelection()

--- a/ballontranslator/ui/text_engine/vertical_layout.py
+++ b/ballontranslator/ui/text_engine/vertical_layout.py
@@ -112,6 +112,67 @@ Miscellaneous_Symbols_Pattern = r'\u2600-\u26FF'  # align center in vertical mod
 vertical_force_aligncentel_pattern = re.compile('[' + Dingbats_vertical_aligncenter + Miscellaneous_Symbols_Pattern + r'⁁⁂⁇⁈⁉⁊⁋⁎※⁑⁒⁕⁖⁘⁙⁛⁜‼‽]')
 
 
+def _compose_layout_text(
+    text: str,
+    preedit_position: int,
+    preedit_text: str,
+    *,
+    utf16: bool,
+) -> Tuple[str, int, int]:
+    """Return QTextLayout's transient text including active IME input.
+
+    >>> _compose_layout_text('기존', 1, '가', utf16=False)
+    ('기가존', 1, 1)
+    """
+    text_length = _utf16_length(text) if utf16 else len(text)
+    if not preedit_text or preedit_position < 0:
+        return text, -1, 0
+    position = min(preedit_position, text_length)
+    preedit_length = (
+        _utf16_length(preedit_text) if utf16 else len(preedit_text)
+    )
+    if utf16:
+        before = _utf16_slice(text, 0, position)
+        after = _utf16_slice(text, position, text_length - position)
+    else:
+        before = text[:position]
+        after = text[position:]
+    return before + preedit_text + after, position, preedit_length
+
+
+def _layout_to_document_index(
+    index: int,
+    preedit_position: int,
+    preedit_length: int,
+    document_length: int,
+) -> int:
+    """Map a transient layout index to the committed document.
+
+    >>> [_layout_to_document_index(i, 1, 1, 2) for i in range(3)]
+    [0, 1, 1]
+    """
+    if preedit_length <= 0 or index < preedit_position:
+        return index
+    if index < preedit_position + preedit_length:
+        return min(preedit_position, max(document_length - 1, 0))
+    return index - preedit_length
+
+
+def _document_to_layout_index(
+    index: int,
+    preedit_position: int,
+    preedit_length: int,
+) -> int:
+    """Shift a committed boundary past transient IME text.
+
+    >>> [_document_to_layout_index(i, 1, 1) for i in range(3)]
+    [0, 2, 3]
+    """
+    if preedit_length > 0 and index >= preedit_position:
+        return index + preedit_length
+    return index
+
+
 @lru_cache(maxsize=512)
 def _is_non_fullwidth_roman(char: str) -> bool:
     """Return whether a glyph follows the item-wide Roman orientation.
@@ -322,6 +383,18 @@ class VerticalTextDocumentLayout(SceneTextLayout):
         self._resize_layout_available_height = None
         self._resize_layout_padding = None
         self._selection_geometry_cache = {}
+        self._preedit_formats: List[
+            Tuple[int, int, QTextCharFormat]
+        ] = []
+
+    def set_preedit_formats(
+        self,
+        formats: List[Tuple[int, int, QTextCharFormat]],
+    ) -> None:
+        self._preedit_formats = [
+            (start, length, QTextCharFormat(char_format))
+            for start, length, char_format in formats
+        ]
 
     def needs_vertical_rotation(self, char: str) -> bool:
         rotation_chars = (
@@ -618,6 +691,19 @@ class VerticalTextDocumentLayout(SceneTextLayout):
             blk_text_len = (
                 _utf16_length(blk_text) if utf16_indexing else len(blk_text)
             )
+            layout_text, preedit_position, preedit_length = (
+                _compose_layout_text(
+                    blk_text,
+                    layout.preeditAreaPosition(),
+                    layout.preeditAreaText(),
+                    utf16=utf16_indexing,
+                )
+            )
+            layout_text_len = (
+                _utf16_length(layout_text)
+                if utf16_indexing
+                else len(layout_text)
+            )
 
             line_spaces_lst = self.line_spaces_lst[blk_no]
             char_records = self.per_char_records[blk_no]
@@ -633,16 +719,27 @@ class VerticalTextDocumentLayout(SceneTextLayout):
                     # The run-level transform performs all cell alignment.
                     continue
                 num_rspaces, num_lspaces, _, line_pos  = line_spaces_lst[ii]
-                char_idx = min(line_pos + num_lspaces, blk_text_len - 1)
+                char_idx = min(
+                    line_pos + num_lspaces,
+                    layout_text_len - 1,
+                )
                 if char_idx < 0:
                     continue
 
                 char = (
-                    _utf16_char_at(blk_text, char_idx)
+                    _utf16_char_at(layout_text, char_idx)
                     if utf16_indexing
-                    else blk_text[char_idx]
+                    else layout_text[char_idx]
                 )
-                cfmt = self.get_char_fontfmt(blk_no, char_idx)
+                document_index = _layout_to_document_index(
+                    char_idx,
+                    preedit_position,
+                    preedit_length,
+                    blk_text_len,
+                )
+                cfmt = self.get_char_fontfmt(blk_no, document_index)
+                if cfmt is None:
+                    cfmt = CharFontFormat(block.charFormat())
 
                 line_width = -1
                 if char_idx in char_records:
@@ -671,9 +768,9 @@ class VerticalTextDocumentLayout(SceneTextLayout):
 
                 if self.needs_vertical_rotation(char):
                     char = (
-                        _utf16_char_at(blk_text, char_idx)
+                        _utf16_char_at(layout_text, char_idx)
                         if utf16_indexing
-                        else blk_text[char_idx]
+                        else layout_text[char_idx]
                     )
                     if char.isalpha():
                         xoff = 0
@@ -1615,6 +1712,20 @@ class VerticalTextDocumentLayout(SceneTextLayout):
             blk_text_len = (
                 _utf16_length(blk_text) if utf16_indexing else len(blk_text)
             )
+            layout_text, preedit_start, preedit_length = (
+                _compose_layout_text(
+                    blk_text,
+                    layout.preeditAreaPosition(),
+                    layout.preeditAreaText(),
+                    utf16=utf16_indexing,
+                )
+            )
+            layout_text_len = (
+                _utf16_length(layout_text)
+                if utf16_indexing
+                else len(layout_text)
+            )
+            preedit_end = preedit_start + preedit_length
             line_spaces_lst = self.line_spaces_lst[blk_no]
             uniform_block_drawn = (
                 custom_rendering
@@ -1634,8 +1745,23 @@ class VerticalTextDocumentLayout(SceneTextLayout):
                 line = layout.lineAt(ii)
                 if line.textLength() == 0:
                     continue
+                line_start = line.textStart()
+                line_end = line_start + line.textLength()
+                if (
+                    preedit_length > 0
+                    and line_start < preedit_end
+                    and line_end > preedit_start
+                ):
+                    # The transient glyph and underline exist only in the
+                    # QTextLayout, outside committed annotation/effect state.
+                    xoff, yoff = self._draw_offset[blk_no][ii]
+                    line.draw(painter, QPointF(xoff, yoff))
+                    continue
                 num_rspaces, num_lspaces, _, line_pos  = line_spaces_lst[ii]
-                char_idx = min(line_pos + num_lspaces, blk_text_len - 1)
+                char_idx = min(
+                    line_pos + num_lspaces,
+                    layout_text_len - 1,
+                )
                 if char_idx < 0:
                     if custom_rendering:
                         if not uniform_block_drawn:
@@ -1920,6 +2046,9 @@ class VerticalTextDocumentLayout(SceneTextLayout):
         doc = self.document()
         compact_punctuation = pcfg.compact_vertical_punctuation_spacing
 
+        tl = block.layout()
+        preedit_text = tl.preeditAreaText()
+        preedit_position = tl.preeditAreaPosition()
         block.clearLayout()
         clear_horizontal_ruby_layout(block)
         doc_margin = self._effect_padding
@@ -1930,19 +2059,75 @@ class VerticalTextDocumentLayout(SceneTextLayout):
         block_no = block.blockNumber()
         blk_text = block.text()
         custom_rendering = self.render_delegate is not None
-        text_combine_ranges = text_combine_upright_ranges(block)
-        self.text_combine_ranges.append(text_combine_ranges)
+        document_text_combine_ranges = text_combine_upright_ranges(block)
         self._prepare_tate_chu_yoko_layout_formats(
-            block, text_combine_ranges
+            block, document_text_combine_ranges
         )
+        if preedit_text and self._preedit_formats:
+            tl = block.layout()
+            formats = tl.formats()
+            for start, length, char_format in self._preedit_formats:
+                entry = QTextLayout.FormatRange()
+                entry.start = preedit_position + start
+                entry.length = length
+                entry.format = QTextCharFormat(char_format)
+                formats.append(entry)
+            tl.setFormats(formats)
         ruby_metrics = vertical_ruby_metrics(
             block,
             self.needs_vertical_rotation,
             self.letter_spacing,
         )
         self._ruby_metrics.append(ruby_metrics)
+        utf16_indexing = (
+            custom_rendering
+            or bool(document_text_combine_ranges)
+            or _utf16_length(blk_text) != len(blk_text)
+            or _utf16_length(preedit_text) != len(preedit_text)
+        )
+        blk_text_len = (
+            _utf16_length(blk_text) if utf16_indexing else len(blk_text)
+        )
+        layout_text, preedit_position, preedit_length = _compose_layout_text(
+            blk_text,
+            preedit_position,
+            preedit_text,
+            utf16=utf16_indexing,
+        )
+        layout_text_len = (
+            _utf16_length(layout_text)
+            if utf16_indexing
+            else len(layout_text)
+        )
+
+        def to_layout(index: int) -> int:
+            return _document_to_layout_index(
+                index,
+                preedit_position,
+                preedit_length,
+            )
+
+        def char_format(index: int) -> CharFontFormat:
+            document_index = _layout_to_document_index(
+                index,
+                preedit_position,
+                preedit_length,
+                blk_text_len,
+            )
+            value = self.get_char_fontfmt(block_no, document_index)
+            return value or CharFontFormat(block.charFormat())
+
+        text_combine_ranges = [
+            (
+                to_layout(start),
+                to_layout(start + length) - to_layout(start),
+                group_id,
+            )
+            for start, length, group_id in document_text_combine_ranges
+        ]
+        self.text_combine_ranges.append(text_combine_ranges)
         ruby_starts = {
-            metric.unit.start - block.position(): metric
+            to_layout(metric.unit.start - block.position()): metric
             for metric in ruby_metrics
         }
         inline_unit_boundaries = None
@@ -1951,27 +2136,22 @@ class VerticalTextDocumentLayout(SceneTextLayout):
         for metric in ruby_metrics:
             if metric.extra <= 1e-6:
                 continue
-            unit_start = metric.unit.start - block.position()
-            unit_end = metric.unit.end - block.position()
+            document_unit_start = metric.unit.start - block.position()
+            unit_start = to_layout(document_unit_start)
+            unit_end = to_layout(metric.unit.end - block.position())
             half_gap = metric.base_gap / 2
             ruby_base_leading[unit_start] = half_gap
             ruby_base_trailing[unit_end] = half_gap
             for boundary in metric.base_opportunity_ends:
-                local_boundary = unit_start + boundary
+                local_boundary = to_layout(
+                    document_unit_start + boundary
+                )
                 ruby_base_leading[local_boundary] = half_gap
                 ruby_base_trailing[local_boundary] = half_gap
         text_combine_lengths = {
             start: length for start, length, _group_id in text_combine_ranges
         }
-        utf16_indexing = (
-            custom_rendering
-            or bool(text_combine_ranges)
-            or _utf16_length(blk_text) != len(blk_text)
-        )
-        blk_text_len = (
-            _utf16_length(blk_text) if utf16_indexing else len(blk_text)
-        )
-        if blk_text_len != 0:
+        if layout_text_len != 0:
             block_width = self.block_ideal_width[block_no]
         else:
             block_width = CharFontFormat(block.charFormat()).tbr.width()
@@ -2014,13 +2194,13 @@ class VerticalTextDocumentLayout(SceneTextLayout):
             is_text_combine = text_combine_length is not None
             if is_text_combine:
                 combined_text = _utf16_slice(
-                    blk_text, char_idx, text_combine_length
+                    layout_text, char_idx, text_combine_length
                 )
                 line.setNumColumns(max(1, _grapheme_count(combined_text)))
             else:
                 line.setNumColumns(1)
                 punctuation_run = _inseparable_punctuation_run(
-                    blk_text, char_idx
+                    layout_text, char_idx
                 )
                 if punctuation_run is not None:
                     if inline_unit_boundaries is None:
@@ -2029,8 +2209,12 @@ class VerticalTextDocumentLayout(SceneTextLayout):
                             boundaries.update((start, start + length))
                         for metric in ruby_metrics:
                             boundaries.update((
-                                metric.unit.start - block.position(),
-                                metric.unit.end - block.position(),
+                                to_layout(
+                                    metric.unit.start - block.position()
+                                ),
+                                to_layout(
+                                    metric.unit.end - block.position()
+                                ),
                             ))
                         inline_unit_boundaries = tuple(sorted(boundaries))
                     run_start, punctuation_columns = punctuation_run
@@ -2062,19 +2246,23 @@ class VerticalTextDocumentLayout(SceneTextLayout):
 
             available_height = self.available_height + doc_margin
             text_len = line.textLength()
-            end_char = char_idx + text_len >= blk_text_len
+            end_char = char_idx + text_len >= layout_text_len
             if active_ruby_metric is None:
                 active_ruby_metric = ruby_starts.get(char_idx)
             ruby_metric = active_ruby_metric
             ruby_unit_start = (
                 -1
                 if ruby_metric is None
-                else ruby_metric.unit.start - block.position()
+                else to_layout(
+                    ruby_metric.unit.start - block.position()
+                )
             )
             ruby_unit_end = (
                 -1
                 if ruby_metric is None
-                else ruby_metric.unit.end - block.position()
+                else to_layout(
+                    ruby_metric.unit.end - block.position()
+                )
             )
             ruby_leading = ruby_base_leading.get(char_idx, 0.0)
             ruby_trailing = ruby_base_trailing.get(
@@ -2099,7 +2287,7 @@ class VerticalTextDocumentLayout(SceneTextLayout):
             is_first_lbracket = False
             # _lbracket_shift = 0
 
-            if char_idx + text_len > blk_text_len:
+            if char_idx + text_len > layout_text_len:
                 ypos = ypos_list[-1] if len(ypos_list) > 0 else 0
                 blk_line_spaces.append([0, 0, [ypos], char_idx])
                 line.setPosition(QPointF(x_offset - block_width, ypos))
@@ -2108,14 +2296,16 @@ class VerticalTextDocumentLayout(SceneTextLayout):
             num_rspaces, num_lspaces = 0, 0
             if utf16_indexing:
                 text = _utf16_slice(
-                    blk_text, char_idx, text_len
+                    layout_text, char_idx, text_len
                 ).replace('\n', '')
                 num_rspaces = _utf16_length(text[len(text.rstrip()):])
                 num_lspaces = _utf16_length(
                     text[:len(text) - len(text.lstrip())]
                 )
             else:
-                text = blk_text[char_idx: char_idx + text_len].replace('\n', '')
+                text = layout_text[
+                    char_idx: char_idx + text_len
+                ].replace('\n', '')
                 num_rspaces = text_len - len(text.rstrip())
                 num_lspaces = text_len - len(text.lstrip())
 
@@ -2135,12 +2325,12 @@ class VerticalTextDocumentLayout(SceneTextLayout):
             text_combine_line_metrics = None
             line_base_width = block_width
 
-            if char_idx < blk_text_len:
-                cfmt = self.get_char_fontfmt(block_no, char_idx)
+            if char_idx < layout_text_len:
+                cfmt = char_format(char_idx)
                 line_base_width = cfmt.tbr.width()
                 if inseparable_run_range is not None:
                     line_base_width = max(
-                        self.get_char_fontfmt(block_no, position).tbr.width()
+                        char_format(position).tbr.width()
                         for position in range(*inseparable_run_range)
                     )
                 space_shift = 0
@@ -2154,9 +2344,9 @@ class VerticalTextDocumentLayout(SceneTextLayout):
 
                 tbr_h = cfmt.tbr.height() + spacing_advance
                 source_char = (
-                    _utf16_char_at(blk_text, char_idx)
+                    _utf16_char_at(layout_text, char_idx)
                     if utf16_indexing
-                    else blk_text[char_idx]
+                    else layout_text[char_idx]
                 )
                 char = (
                     source_char
@@ -2252,8 +2442,8 @@ class VerticalTextDocumentLayout(SceneTextLayout):
                             full_advance - compact_advance,
                             0.0,
                         )
-            elif char_idx - num_lspaces < blk_text_len:
-                cfmt = self.get_char_fontfmt(block_no, char_idx - num_lspaces)
+            elif char_idx - num_lspaces < layout_text_len:
+                cfmt = char_format(char_idx - num_lspaces)
                 line_base_width = cfmt.tbr.width()
                 tbr_h = cfmt.tbr.height() + cfmt.font_metrics.descent()
                 space_w = cfmt.space_width
@@ -2292,7 +2482,7 @@ class VerticalTextDocumentLayout(SceneTextLayout):
                     char_yoffset_lst.append(min(char_yoffset_lst[-1] + space_w, available_height))
                 line_bottom = char_yoffset_lst[-1] + ruby_trailing
             else:
-                cfmt = self.get_char_fontfmt(block_no, char_idx)
+                cfmt = char_format(char_idx)
                 if cfmt is not None:
                     if text_combine_line_metrics is None:
                         right_margin, left_margin = emphasis_margins(

--- a/tests/test_text_transform_undo.py
+++ b/tests/test_text_transform_undo.py
@@ -1587,6 +1587,16 @@ class TextTransformUndoTest(TextTransformTestBase):
         )
         self.app.processEvents()
         self.assertTrue(canvas.gv.hasFocus())
+
+        focus_editor.setFocus()
+        self.app.processEvents()
+        with patch(
+            'ballontranslator.ui.canvas.QMenu.exec',
+            return_value=None,
+        ):
+            canvas.editor_index = 1
+            canvas.on_create_contextmenu(QPoint(20, 20), False)
+        self.assertTrue(canvas.gv.hasFocus())
         host.close()
 
     def test_text_edit_shortcuts_accept_transient_modifiers(self) -> None:

--- a/tests/test_text_transform_undo.py
+++ b/tests/test_text_transform_undo.py
@@ -19,6 +19,7 @@ from qtpy.QtGui import (
     QInputMethodEvent,
     QKeyEvent,
     QPainter,
+    QPalette,
     QTextCharFormat,
     QTextCursor,
 )
@@ -1656,6 +1657,345 @@ class TextTransformUndoTest(TextTransformTestBase):
 
         self.assertEqual(edit.toPlainText(), 'aZX')
         self.assertEqual(propagated, [(1, 0, 'Z', False)])
+
+    def test_hangul_mixed_commit_and_preedit_stay_synchronized(self):
+        for edit_on_canvas in (False, True):
+            with self.subTest(edit_on_canvas=edit_on_canvas):
+                item, pair = self._make_pair(0, '앞', False)
+
+                if edit_on_canvas:
+                    scene = QGraphicsScene()
+                    scene.addItem(item)
+                    view = QGraphicsView(scene)
+                    view.show()
+                    item.startEdit()
+                    source = item
+                    target = pair.e_trans
+                else:
+                    pair.show()
+                    source = pair.e_trans
+                    target = item
+                    source.setFocus()
+
+                self.app.processEvents()
+                cursor = source.textCursor()
+                cursor.movePosition(QTextCursor.MoveOperation.End)
+                source.setTextCursor(cursor)
+                propagated = []
+
+                def on_propagate(
+                    position, removed, added_text, joint_previous
+                ):
+                    propagated.append((
+                        position,
+                        removed,
+                        added_text,
+                        joint_previous,
+                    ))
+                    propagate_user_edit(
+                        target,
+                        position,
+                        removed,
+                        added_text,
+                        joint_previous,
+                    )
+
+                source.propagate_user_edited.connect(on_propagate)
+
+                def send_input_method_event(preedit_text, commit_text=''):
+                    event = QInputMethodEvent(preedit_text, [])
+                    if commit_text:
+                        event.setCommitString(commit_text)
+                    if edit_on_canvas:
+                        source.inputMethodEvent(event)
+                    else:
+                        QApplication.sendEvent(source, event)
+                    self.app.processEvents()
+
+                try:
+                    send_input_method_event('가')
+                    send_input_method_event('나', '가')
+                    self.assertTrue(source.pre_editing)
+                    self.assertEqual(source.toPlainText(), '앞가')
+                    self.assertEqual(target.toPlainText(), '앞가')
+                    send_input_method_event('', '나')
+                finally:
+                    source.propagate_user_edited.disconnect(on_propagate)
+
+                self.assertEqual(source.toPlainText(), '앞가나')
+                self.assertEqual(target.toPlainText(), '앞가나')
+                self.assertEqual(
+                    propagated,
+                    [(1, 0, '가', False), (2, 0, '나', False)],
+                )
+
+                if edit_on_canvas:
+                    item.endEdit()
+                    view.close()
+                    scene.removeItem(item)
+                else:
+                    pair.hide()
+
+    def test_canvas_end_edit_falls_back_when_platform_commit_is_noop(self):
+        item, pair = self._make_pair(0, '문장 ', False)
+        scene = QGraphicsScene()
+        scene.addItem(item)
+        view = QGraphicsView(scene)
+        view.show()
+        item.startEdit()
+        cursor = item.textCursor()
+        cursor.movePosition(QTextCursor.MoveOperation.End)
+        item.setTextCursor(cursor)
+        self.app.processEvents()
+        propagated = []
+
+        def on_propagate(position, removed, added_text, joint_previous):
+            propagated.append((
+                position,
+                removed,
+                added_text,
+                joint_previous,
+            ))
+            propagate_user_edit(
+                pair.e_trans,
+                position,
+                removed,
+                added_text,
+                joint_previous,
+            )
+
+        item.propagate_user_edited.connect(on_propagate)
+        try:
+            item.inputMethodEvent(QInputMethodEvent('마지막', []))
+            with patch(
+                'ballontranslator.ui.text_engine.item.QApplication'
+            ) as application:
+                item.endEdit()
+                application.inputMethod.return_value.commit.assert_called_once_with()
+                application.inputMethod.return_value.reset.assert_called_once_with()
+        finally:
+            item.propagate_user_edited.disconnect(on_propagate)
+            if item.isEditing():
+                item.endEdit()
+            view.close()
+            scene.removeItem(item)
+
+        self.assertFalse(item.pre_editing)
+        self.assertEqual(item.toPlainText(), '문장 마지막')
+        self.assertEqual(pair.e_trans.toPlainText(), '문장 마지막')
+        self.assertEqual(propagated, [(3, 0, '마지막', False)])
+        self.assertEqual(
+            item.document().firstBlock().layout().preeditAreaText(),
+            '',
+        )
+
+    def test_vertical_cjk_preedit_cursor_query_and_commit(self):
+        cases = (
+            ('Japanese', 'かな', 1, '仮名', 'つぎ', 1, '次'),
+            ('Chinese', 'nihao', 3, '你好', 'ma', 1, '吗'),
+        )
+        for (
+            language,
+            preedit_text,
+            preedit_cursor,
+            commit_text,
+            next_preedit,
+            next_cursor,
+            final_commit,
+        ) in cases:
+            with self.subTest(language=language):
+                item, pair = self._make_pair(0, '前', True)
+                scene = QGraphicsScene()
+                scene.addItem(item)
+                view = QGraphicsView(scene)
+                view.show()
+                item.startEdit()
+                cursor = item.textCursor()
+                cursor.movePosition(QTextCursor.MoveOperation.End)
+                item.setTextCursor(cursor)
+                propagated = []
+
+                def on_propagate(
+                    position, removed, added_text, joint_previous
+                ):
+                    propagated.append((
+                        position,
+                        removed,
+                        added_text,
+                        joint_previous,
+                    ))
+                    propagate_user_edit(
+                        pair.e_trans,
+                        position,
+                        removed,
+                        added_text,
+                        joint_previous,
+                    )
+
+                item.propagate_user_edited.connect(on_propagate)
+
+                def send_event(preedit, cursor_position, commit=''):
+                    cursor_attribute = QInputMethodEvent.Attribute(
+                        QInputMethodEvent.AttributeType.Cursor,
+                        cursor_position,
+                        1,
+                        None,
+                    )
+                    underline = QTextCharFormat()
+                    underline.setFontUnderline(True)
+                    format_attribute = QInputMethodEvent.Attribute(
+                        QInputMethodEvent.AttributeType.TextFormat,
+                        0,
+                        len(preedit),
+                        underline,
+                    )
+                    event = QInputMethodEvent(
+                        preedit,
+                        [cursor_attribute, format_attribute],
+                    )
+                    if commit:
+                        event.setCommitString(commit)
+                    item.inputMethodEvent(event)
+                    self.app.processEvents()
+
+                try:
+                    send_event(preedit_text, preedit_cursor)
+                    self._render_scene(scene)
+                    expected = item.layout.source_cursor_rect(
+                        -(preedit_cursor + 2)
+                    )
+                    actual = QRectF(item.inputMethodQuery(
+                        Qt.InputMethodQuery.ImCursorRectangle
+                    ))
+                    committed_cursor = item.layout.source_cursor_rect(
+                        item.textCursor().position()
+                    )
+                    preedit_formats = (
+                        item.document().firstBlock().layout().formats()
+                    )
+                    layout = item.document().firstBlock().layout()
+                    positions = [
+                        layout.lineAt(index).position()
+                        for index in range(layout.lineCount())
+                    ]
+                    self.assertEqual(actual, expected)
+                    self.assertNotEqual(actual, committed_cursor)
+                    self.assertEqual(
+                        item.layout.deferred_cursor_position,
+                        -(preedit_cursor + 2),
+                    )
+                    self.assertTrue(any(
+                        entry.format.fontUnderline()
+                        for entry in preedit_formats
+                    ), preedit_formats)
+                    self.assertTrue(all(
+                        math.isclose(
+                            position.x(),
+                            positions[0].x(),
+                            abs_tol=0.1,
+                        )
+                        for position in positions[1:]
+                    ), positions)
+                    self.assertTrue(all(
+                        first.y() < second.y()
+                        for first, second in zip(positions, positions[1:])
+                    ), positions)
+
+                    send_event(next_preedit, next_cursor, commit_text)
+                    self.assertEqual(item.toPlainText(), '前' + commit_text)
+                    self.assertEqual(
+                        pair.e_trans.toPlainText(),
+                        '前' + commit_text,
+                    )
+                    expected = item.layout.source_cursor_rect(
+                        -(next_cursor + 2)
+                    )
+                    actual = QRectF(item.inputMethodQuery(
+                        Qt.InputMethodQuery.ImCursorRectangle
+                    ))
+                    self.assertEqual(actual, expected)
+
+                    final = QInputMethodEvent('', [])
+                    final.setCommitString(final_commit)
+                    item.inputMethodEvent(final)
+                finally:
+                    item.propagate_user_edited.disconnect(on_propagate)
+                    if item.isEditing():
+                        item.endEdit()
+                    view.close()
+                    scene.removeItem(item)
+
+                expected_text = '前' + commit_text + final_commit
+                self.assertEqual(item.toPlainText(), expected_text)
+                self.assertEqual(pair.e_trans.toPlainText(), expected_text)
+                self.assertEqual(
+                    propagated,
+                    [
+                        (1, 0, commit_text, False),
+                        (1 + len(commit_text), 0, final_commit, False),
+                    ],
+                )
+
+    def test_empty_canvas_hangul_keeps_explicit_foreground(self):
+        item, _pair = self._make_pair(0, '기존', False)
+        scene = QGraphicsScene()
+        scene.setBackgroundBrush(QColor('white'))
+        scene.addItem(item)
+        view = QGraphicsView(scene)
+        view.show()
+        original_palette = self.app.palette()
+        dark_palette = QPalette(original_palette)
+        dark_palette.setColor(QPalette.ColorRole.Text, QColor('white'))
+        self.app.setPalette(dark_palette)
+
+        def dark_pixel_count():
+            image = QImage(
+                900,
+                600,
+                QImage.Format.Format_ARGB32_Premultiplied,
+            )
+            image.fill(QColor('white'))
+            painter = QPainter(image)
+            previous = item.layout.defer_cursor_paint
+            item.layout.defer_cursor_paint = True
+            try:
+                scene.render(
+                    painter,
+                    QRectF(0, 0, 900, 600),
+                    QRectF(-50, -50, 900, 600),
+                )
+            finally:
+                item.layout.defer_cursor_paint = previous
+                painter.end()
+            pixels = np.frombuffer(
+                image.bits().asstring(image.sizeInBytes()),
+                dtype=np.uint8,
+            ).reshape(image.height(), image.width(), 4)
+            return int(np.count_nonzero(np.all(
+                pixels[..., :3] < 50,
+                axis=2,
+            )))
+
+        try:
+            item.startEdit()
+            self.app.processEvents()
+            cursor = item.textCursor()
+            cursor.select(QTextCursor.SelectionType.Document)
+            cursor.removeSelectedText()
+            item.setTextCursor(cursor)
+            item.inputMethodEvent(QInputMethodEvent('가', []))
+            self.app.processEvents()
+
+            self.assertNotEqual(
+                item.textCursor().charFormat().foreground().style(),
+                Qt.BrushStyle.NoBrush,
+            )
+            self.assertGreater(dark_pixel_count(), 50)
+        finally:
+            self.app.setPalette(original_palette)
+            item.endEdit()
+            view.close()
+            scene.removeItem(item)
 
     def test_capitalize_selected_items_is_one_synced_undo_command(self):
         original = 'hELLO WORLD. next ONE!'

--- a/tests/test_text_transform_undo.py
+++ b/tests/test_text_transform_undo.py
@@ -1544,6 +1544,74 @@ class TextTransformPanelTest(TextTransformTestBase):
 
 
 class TextTransformUndoTest(TextTransformTestBase):
+    def test_canvas_block_shortcuts_accept_transient_modifiers(self) -> None:
+        canvas = Canvas()
+        canvas.editor_index = 1
+        calls = []
+        canvas.handle_ctrlc = lambda: calls.append('copy') or True
+        canvas.handle_ctrlv = lambda: calls.append('paste') or True
+        canvas.gv.show()
+        canvas.gv.setFocus()
+        self.app.processEvents()
+
+        modifiers = (
+            Qt.KeyboardModifier.ControlModifier
+            | Qt.KeyboardModifier.KeypadModifier
+        )
+        QTest.keyClick(canvas.gv, Qt.Key.Key_C, modifiers)
+        QTest.keyClick(canvas.gv, Qt.Key.Key_V, modifiers)
+        self.app.processEvents()
+        canvas.gv.close()
+
+        self.assertEqual(calls, ['copy', 'paste'])
+
+    def test_text_edit_shortcuts_accept_transient_modifiers(self) -> None:
+        item, pair = self._make_pair(0, 'text', False)
+        modifiers = (
+            Qt.KeyboardModifier.ControlModifier
+            | Qt.KeyboardModifier.KeypadModifier
+        )
+        item.startEdit()
+        cursor = item.textCursor()
+        cursor.setPosition(0)
+        cursor.setPosition(2, QTextCursor.MoveMode.KeepAnchor)
+        item.setTextCursor(cursor)
+        self.app.clipboard().clear()
+        item.keyPressEvent(QKeyEvent(
+            QEvent.Type.KeyPress,
+            Qt.Key.Key_C,
+            modifiers,
+        ))
+
+        item_events = []
+        item.pasted.connect(lambda _index: item_events.append('paste'))
+        item.undo_signal.connect(lambda: item_events.append('undo'))
+        item.redo_signal.connect(lambda: item_events.append('redo'))
+        for key in (Qt.Key.Key_V, Qt.Key.Key_Z, Qt.Key.Key_Y):
+            item.keyPressEvent(QKeyEvent(
+                QEvent.Type.KeyPress,
+                key,
+                modifiers,
+            ))
+
+        pair_events = []
+        pair.e_trans.undo_signal.connect(
+            lambda: pair_events.append('undo')
+        )
+        pair.e_trans.redo_signal.connect(
+            lambda: pair_events.append('redo')
+        )
+        for key in (Qt.Key.Key_Z, Qt.Key.Key_Y):
+            pair.e_trans.keyPressEvent(QKeyEvent(
+                QEvent.Type.KeyPress,
+                key,
+                modifiers,
+            ))
+
+        self.assertEqual(self.app.clipboard().text(), 'te')
+        self.assertEqual(item_events, ['paste', 'undo', 'redo'])
+        self.assertEqual(pair_events, ['undo', 'redo'])
+
     def test_pair_editor_paste_shortcuts_at_document_start_stay_synced(self):
         shortcuts = (
             (Qt.Key.Key_V, Qt.KeyboardModifier.ControlModifier),

--- a/tests/test_text_transform_undo.py
+++ b/tests/test_text_transform_undo.py
@@ -12,7 +12,7 @@ import numpy as np
 
 os.environ.setdefault("QT_QPA_PLATFORM", "offscreen")
 
-from qtpy.QtCore import QEvent, QPointF, QRectF, Qt
+from qtpy.QtCore import QEvent, QPoint, QPointF, QRectF, Qt
 from qtpy.QtGui import (
     QColor,
     QImage,
@@ -31,6 +31,7 @@ from qtpy.QtWidgets import (
     QGraphicsScene,
     QGraphicsTextItem,
     QGraphicsView,
+    QLineEdit,
     QStyleOptionGraphicsItem,
     QVBoxLayout,
     QWidget,
@@ -1564,6 +1565,29 @@ class TextTransformUndoTest(TextTransformTestBase):
         canvas.gv.close()
 
         self.assertEqual(calls, ['copy', 'paste'])
+
+    def test_canvas_right_click_restores_keyboard_focus(self) -> None:
+        canvas = Canvas()
+        canvas.imgtrans_proj = SimpleNamespace(img_valid=False)
+        focus_editor = QLineEdit()
+        host = QWidget()
+        layout = QVBoxLayout(host)
+        layout.addWidget(focus_editor)
+        layout.addWidget(canvas.gv)
+        host.show()
+        focus_editor.setFocus()
+        self.app.processEvents()
+        self.assertTrue(focus_editor.hasFocus())
+
+        QTest.mouseClick(
+            canvas.gv.viewport(),
+            Qt.MouseButton.RightButton,
+            Qt.KeyboardModifier.NoModifier,
+            QPoint(20, 20),
+        )
+        self.app.processEvents()
+        self.assertTrue(canvas.gv.hasFocus())
+        host.close()
 
     def test_text_edit_shortcuts_accept_transient_modifiers(self) -> None:
         item, pair = self._make_pair(0, 'text', False)


### PR DESCRIPTION
## Problem

When a canvas text block loses focus while an IME composition is still
active, the final composed character may remain visible with the composition
underline but may not be stored in the actual text data.

This can cause the final character to disappear after focus loss or produce
an invalid placeholder when the user tries to delete it. On macOS,
`QInputMethod.commit()` may also return without delivering the expected commit
event to the canvas text item.

Mixed IME events containing both a committed string and the next preedit
string can also leave the canvas text item and the paired editor out of sync.

## Changes

- Keep mixed IME commit and preedit updates synchronized between canvas text
  items and paired editors.
- Commit the remaining composition before persisting a text block when focus
  is lost and the platform commit request does not deliver a commit event.
- Preserve transient preedit text, IME formatting attributes, and cursor state
  while composition is active.
- Handle composition rendering and cursor queries consistently in horizontal
  and vertical text layouts.
- Add focused regression coverage for the affected composition paths.

## Manual verification

The following cases were manually verified in the application on macOS using
the system Korean IME:

- Entering a single Korean character.
- Clicking the canvas background while the final character is still being
  composed.
- Losing focus and focusing the text block again.
- Deleting text immediately after composition.
- Synchronization between the canvas text item and the paired editor.

Additional manual verification is still needed on Windows and Linux because
IME event sequences and focus behavior can differ between platforms.

Manual verification with native Japanese and Chinese IMEs is also still
needed.