### PR TITLE
Fix #1000: Bug 反馈: 文字渲染过慢导致卡死

### DIFF
--- a/ballontranslator/ui/custom_widget/combobox.py
+++ b/ballontranslator/ui/custom_widget/combobox.py
@@ -1,3 +1,4 @@
+import math
 from typing import Callable, List, Optional
 
 from qtpy.QtWidgets import (
@@ -7,8 +8,14 @@ from qtpy.QtWidgets import (
     QStylePainter,
     QWidget,
 )
-from qtpy.QtCore import QSize, Signal, Qt
-from qtpy.QtGui import QDoubleValidator, QPaintEvent, QPainter, QPalette
+from qtpy.QtCore import QEvent, QSignalBlocker, QSize, Signal, Qt
+from qtpy.QtGui import (
+    QDoubleValidator,
+    QPaintEvent,
+    QPainter,
+    QPalette,
+    QValidator,
+)
 
 from ballontranslator.utils.shared import CONFIG_COMBOBOX_LONG, CONFIG_COMBOBOX_MIDEAN, CONFIG_COMBOBOX_SHORT, CONFIG_COMBOBOX_HEIGHT
 from .push_button import NoBorderPushBtn
@@ -191,12 +198,28 @@ class ParamComboBox(ComboBox):
 class SizeComboBox(QComboBox):
     
     param_changed = Signal(str, float)
-    def __init__(self, val_range: List = None, param_name: str = '', parent=None, init_value=None, *args, **kwargs) -> None:
+    pending_edit_started = Signal()
+    def __init__(
+        self,
+        val_range: List = None,
+        param_name: str = '',
+        parent=None,
+        init_value=None,
+        *args,
+        defer_text_changes: bool = False,
+        **kwargs,
+    ) -> None:
         super().__init__(*args, **kwargs)
         self.param_name = param_name
+        self._defer_text_changes = bool(defer_text_changes)
+        self._pending_text_change = False
+        self._programmatic_change = False
+        self._committing_pending = False
+        self._committed_text = ''
+        self._committed_value = None
+        self.setEditable(True)
         self.editTextChanged.connect(self.on_text_changed)
         self.activated.connect(self.on_current_index_changed)
-        self.setEditable(True)
         self.min_val = val_range[0]
         self.max_val = val_range[1]
         validator = QDoubleValidator()
@@ -207,16 +230,202 @@ class SizeComboBox(QComboBox):
 
         self.setValidator(validator)
         self._value = 0
+        editor = self.lineEdit()
+        if editor is not None:
+            editor.returnPressed.connect(self.commit_pending)
+            editor.editingFinished.connect(self.commit_pending)
+            editor.installEventFilter(self)
         if init_value is not None:
             self.setValue(init_value)
 
+    def set_defer_text_changes(self, enabled: bool) -> None:
+        """Toggle whether typed values wait for an explicit commit."""
+        enabled = bool(enabled)
+        if enabled == self._defer_text_changes:
+            return
+        if not enabled:
+            self.cancel_pending()
+        self._defer_text_changes = enabled
+        if enabled:
+            self._remember_current_display()
+
+    def _editor_has_focus(self) -> bool:
+        editor = self.lineEdit()
+        return self.hasFocus() or (
+            editor is not None and editor.hasFocus()
+        )
+
+    def _remember_current_display(self) -> None:
+        self._committed_text = self.currentText()
+        try:
+            value = float(self._committed_text)
+        except (TypeError, ValueError):
+            self._committed_value = None
+            return
+        if math.isfinite(value) and self.min_val <= value <= self.max_val:
+            self._value = value
+            self._committed_value = value
+        else:
+            self._committed_value = None
+
+    def setCurrentText(self, text: str) -> None:
+        if not self._defer_text_changes:
+            return super().setCurrentText(text)
+        self._programmatic_change = True
+        try:
+            super().setCurrentText(text)
+        finally:
+            self._programmatic_change = False
+        if self._defer_text_changes:
+            self._pending_text_change = False
+            self._remember_current_display()
+
+    def addItem(self, text: str, userData=None) -> None:
+        super().addItem(text, userData)
+        if self._defer_text_changes and not self._pending_text_change:
+            self._remember_current_display()
+
+    def addItems(self, texts: List[str]) -> None:
+        super().addItems(texts)
+        if self._defer_text_changes and not self._pending_text_change:
+            self._remember_current_display()
+
+    def _restore_committed_display(self) -> None:
+        blocker = QSignalBlocker(self)
+        self._programmatic_change = True
+        try:
+            super().setCurrentText(self._committed_text)
+        finally:
+            self._programmatic_change = False
+            del blocker
+
+    def _parse_deferred_value(self) -> float:
+        text = self.currentText().strip()
+        if not text:
+            raise ValueError
+        validator = self.validator()
+        if validator is not None:
+            validation = validator.validate(text, 0)
+            state = validation[0] if isinstance(validation, tuple) else validation
+            if state != QValidator.State.Acceptable:
+                raise ValueError
+        value = float(text)
+        if (
+            not math.isfinite(value)
+            or not self.min_val <= value <= self.max_val
+        ):
+            raise ValueError
+        return value
+
+    def _commit_value(self, value: float) -> bool:
+        changed = (
+            self._committed_value is None
+            or value != self._committed_value
+        )
+        self._pending_text_change = False
+        if not changed:
+            self._restore_committed_display()
+            return False
+        self._value = value
+        self._committed_value = value
+        self._committed_text = self.currentText()
+        self.param_changed.emit(self.param_name, value)
+        return True
+
+    @property
+    def has_pending_text(self) -> bool:
+        return self._pending_text_change
+
+    @property
+    def committing_pending(self) -> bool:
+        return self._committing_pending
+
+    def _emit_current_value(self) -> bool:
+        try:
+            value = self._parse_deferred_value()
+        except (TypeError, ValueError):
+            self._restore_committed_display()
+            return False
+        return self._commit_value(value)
+
     def on_text_changed(self):
-        if self.hasFocus():
+        if self._programmatic_change:
+            return
+        if self._defer_text_changes:
+            if self._editor_has_focus():
+                if not self._pending_text_change:
+                    self._pending_text_change = True
+                    self.pending_edit_started.emit()
+        elif self.hasFocus():
             self.param_changed.emit(self.param_name, self.value())
 
     def on_current_index_changed(self):
         if self.hasFocus() or self.view().isVisible():
-            self.param_changed.emit(self.param_name, self.value())
+            if self._defer_text_changes:
+                if self._pending_text_change:
+                    self.commit_pending()
+                else:
+                    self._emit_current_value()
+            else:
+                self.param_changed.emit(self.param_name, self.value())
+
+    def commit_pending(self) -> bool:
+        if not self._defer_text_changes or not self._pending_text_change:
+            return False
+        try:
+            value = self._parse_deferred_value()
+        except (TypeError, ValueError):
+            self._pending_text_change = False
+            self._restore_committed_display()
+            return False
+        self._committing_pending = True
+        try:
+            return self._commit_value(value)
+        finally:
+            self._committing_pending = False
+
+    def cancel_pending(self) -> bool:
+        if not self._defer_text_changes or not self._pending_text_change:
+            return False
+        self._pending_text_change = False
+        self._restore_committed_display()
+        return True
+
+    def eventFilter(self, watched, event):
+        if watched is self.lineEdit() and self._defer_text_changes:
+            if (
+                event.type() == QEvent.Type.ShortcutOverride
+                and event.key() == Qt.Key.Key_Escape
+                and self._pending_text_change
+            ):
+                event.accept()
+                return True
+            if (
+                event.type() == QEvent.Type.KeyPress
+                and event.key() in (
+                    Qt.Key.Key_Return,
+                    Qt.Key.Key_Enter,
+                )
+                and self._pending_text_change
+            ):
+                self.commit_pending()
+                event.accept()
+                return True
+            if (
+                event.type() == QEvent.Type.KeyPress
+                and event.key() == Qt.Key.Key_Escape
+            ):
+                self.cancel_pending()
+                event.accept()
+                return True
+            if event.type() == QEvent.Type.FocusOut:
+                self.commit_pending()
+        return super().eventFilter(watched, event)
+
+    def focusOutEvent(self, event) -> None:
+        if self._defer_text_changes:
+            self.commit_pending()
+        return super().focusOutEvent(event)
 
     def value(self) -> float:
         txt = self.currentText()

--- a/ballontranslator/ui/text_engine/effects/cards.py
+++ b/ballontranslator/ui/text_engine/effects/cards.py
@@ -550,7 +550,7 @@ def _choose_project_raster(parent: QWidget, title: str) -> str:
 
 
 class EffectNumericControl(CommittedTransformControl):
-    """Reuse the committed numeric editor with typed-text preview signals.
+    """Reuse the committed numeric editor with optional typed-text previews.
 
     >>> issubclass(EffectNumericControl, CommittedTransformControl)
     True
@@ -559,8 +559,11 @@ class EffectNumericControl(CommittedTransformControl):
     value_preview_requested = Signal(str, object)
     value_preview_canceled = Signal(str)
 
-    def __init__(self, *args, **kwargs) -> None:
+    def __init__(
+        self, *args, preview_typed_text: bool = True, **kwargs
+    ) -> None:
         super().__init__(*args, **kwargs)
+        self.preview_typed_text = bool(preview_typed_text)
         self.setObjectName('TextEffectControl')
         self.setSizePolicy(
             QSizePolicy.Policy.Expanding, QSizePolicy.Policy.Preferred
@@ -584,6 +587,8 @@ class EffectNumericControl(CommittedTransformControl):
 
     def _on_text_edited(self) -> None:
         super()._on_text_edited()
+        if not self.preview_typed_text:
+            return
         try:
             value = self._parse(self.editor.text())
         except (TypeError, ValueError):
@@ -752,7 +757,7 @@ class StrokeEffectCard(_EffectCard):
 
         self.width_control = EffectNumericControl(
             self.tr('Width'), 'width', 1.0, 0.0, 10.0, '', 0.01,
-            self, decimals=2,
+            self, decimals=2, preview_typed_text=False,
         )
         self.opacity_control = EffectNumericControl(
             self.tr('Opacity'), 'opacity', 100.0, 0.0, 1.0, '%', 1.0,

--- a/ballontranslator/ui/text_engine/formatting/commands.py
+++ b/ballontranslator/ui/text_engine/formatting/commands.py
@@ -61,9 +61,18 @@ class TextStyleUndoCommand(QUndoCommand):
         self.style_func(values=self.undo_values, **self.params)
 
 
-def wrap_fntformat_input(values: str, blkitems: List[TextBlkItem], is_global: bool):
+def wrap_fntformat_input(
+    values: str,
+    blkitems: List[TextBlkItem],
+    is_global: bool,
+    target_items: List[TextBlkItem] = None,
+):
     if is_global:
-        blkitems = SW.canvas.selected_text_items()
+        blkitems = (
+            list(target_items)
+            if target_items is not None
+            else SW.canvas.selected_text_items()
+        )
     else:
         if not isinstance(blkitems, List):
             blkitems = [blkitems]
@@ -81,7 +90,10 @@ def font_formating(push_undostack: bool = False, is_property = True):
                 else:
                     print(f'undefined param name: {param_name}')
 
-            blkitems, values = wrap_fntformat_input(values, blkitems, is_global)
+            target_items = kwargs.pop('target_items', None)
+            blkitems, values = wrap_fntformat_input(
+                values, blkitems, is_global, target_items
+            )
             if len(blkitems) > 0:
                 if is_property:
                     act_ffmt[param_name] = values[0]

--- a/ballontranslator/ui/text_engine/formatting/panel.py
+++ b/ballontranslator/ui/text_engine/formatting/panel.py
@@ -395,7 +395,9 @@ class FontSizeBox(QFrame):
         self.downBtn.setObjectName("FsizeIncrementDown")
         self.upBtn.clicked.connect(self.onUpBtnClicked)
         self.downBtn.clicked.connect(self.onDownBtnClicked)
-        self.fcombobox = SizeComboBox([1, 1000], 'font_size', self)
+        self.fcombobox = SizeComboBox(
+            [1, 1000], 'font_size', self, defer_text_changes=True
+        )
         self.fcombobox.setObjectName("FontFormatSizeBox")
         self.fcombobox.addItems([
             "5", "5.5", "6.5", "7.5", "8", "9", "10", "10.5",
@@ -699,7 +701,11 @@ class FontFormatPanel(Widget):
         self.fontsizebox.setToolTip(self.tr("Font Size"))
         self.fontsizebox.setObjectName("FontSizeBox")
         self.fontsizebox.fcombobox.setToolTip(self.tr("Change font size"))
-        self.fontsizebox.param_changed.connect(self.on_param_changed)
+        self._font_size_pending_context = None
+        self.fontsizebox.fcombobox.pending_edit_started.connect(
+            self._capture_font_size_edit_context
+        )
+        self.fontsizebox.param_changed.connect(self._on_font_size_changed)
         
         self.lineSpacingLabel = SizeControlLabel(self, direction=1, transparent_bg=False)
         self.lineSpacingLabel.setObjectName("lineSpacingLabel")
@@ -905,16 +911,63 @@ class FontFormatPanel(Widget):
         else:
             return None
 
-    def on_param_changed(self, param_name: str, value):
+    def _font_size_owner_context(self):
+        if self.global_mode():
+            items = list(self.text_transform_session.items)
+            if not items:
+                canvas = getattr(SW, 'canvas', None)
+                selected = getattr(canvas, 'selected_text_items', None)
+                items = list(selected()) if callable(selected) else []
+            return True, items
+        return False, (
+            [self.textblk_item] if self.textblk_item is not None else []
+        )
+
+    def _capture_font_size_edit_context(self) -> None:
+        self._font_size_pending_context = self._font_size_owner_context()
+
+    def _on_font_size_changed(self, param_name: str, value) -> None:
+        combo = self.fontsizebox.fcombobox
+        context = self._font_size_pending_context
+        if combo.committing_pending and context is not None:
+            self._font_size_pending_context = None
+            is_global, target_items = context
+            self.on_param_changed(
+                param_name,
+                value,
+                target_items=target_items,
+                is_global_override=is_global,
+            )
+            return
+        self.on_param_changed(param_name, value)
+
+    def on_param_changed(
+        self,
+        param_name: str,
+        value,
+        *,
+        target_items=None,
+        is_global_override=None,
+    ):
         func = handle_ffmt_change.get(param_name)
         func_kwargs = {}
         if param_name in {'font_size', 'rel_font_size'}:
             func_kwargs['clip_size'] = True
-        if self.global_mode():
+        is_global = (
+            self.global_mode()
+            if is_global_override is None
+            else bool(is_global_override)
+        )
+        if is_global:
+            if target_items is not None:
+                func_kwargs['target_items'] = target_items
             func(param_name, value, self.global_format, is_global=True, **func_kwargs)
             self.update_text_style_label()
         else:
-            func(param_name, value, C.active_format, is_global=False, blkitems=self.textblk_item, set_focus=True, **func_kwargs)
+            blkitems = (
+                self.textblk_item if target_items is None else target_items
+            )
+            func(param_name, value, C.active_format, is_global=False, blkitems=blkitems, set_focus=True, **func_kwargs)
 
     def on_font_family_changed(
         self, param_name: str, font_family: str
@@ -1095,6 +1148,8 @@ class FontFormatPanel(Widget):
         self._restore_ruby_edit_focus(item)
 
     def resolve_text_transform_edits_for_save(self) -> None:
+        self.fontsizebox.fcombobox.commit_pending()
+        self._font_size_pending_context = None
         if self.alpha_mask_session is not None:
             self.alpha_mask_session.resolve_for_save()
         self.text_transform_session.resolve_for_save()
@@ -1105,18 +1160,24 @@ class FontFormatPanel(Widget):
         self.text_effect_session.stop_image_generation(detach_card=True)
 
     def resolve_text_transform_edits_for_history_change(self) -> None:
+        self.fontsizebox.fcombobox.cancel_pending()
+        self._font_size_pending_context = None
         if self.alpha_mask_session is not None:
             self.alpha_mask_session.resolve_for_history_change()
         self.text_transform_session.resolve_for_history_change()
         self.text_effect_session.resolve_for_history_change()
 
     def resolve_text_transform_edits_for_page_change(self) -> None:
+        self.fontsizebox.fcombobox.commit_pending()
+        self._font_size_pending_context = None
         if self.alpha_mask_session is not None:
             self.alpha_mask_session.resolve_for_page_change()
         self.text_effect_session.resolve_for_page_change()
         self.text_transform_session.resolve_for_page_change()
 
     def cancel_text_transform_edits_for_scene_change(self) -> None:
+        self.fontsizebox.fcombobox.cancel_pending()
+        self._font_size_pending_context = None
         if self.alpha_mask_session is not None:
             self.alpha_mask_session.cancel_for_scene_change()
         self.text_effect_session.cancel_for_scene_change()
@@ -1242,6 +1303,10 @@ class FontFormatPanel(Widget):
         update_transform_panel: bool = True,
         update_effect_panel: bool = True,
     ) -> None:
+        # A programmatic rebind must not leave typed Font Size text attached
+        # to the previous formatting owner.
+        self.fontsizebox.fcombobox.cancel_pending()
+        self._font_size_pending_context = None
         self.sync_inline_format(
             font_format,
             multi_size,
@@ -1301,6 +1366,12 @@ class FontFormatPanel(Widget):
         multi_select: bool = False,
         primary_item: Optional[TextBlkItem] = None,
     ) -> None:
+        if (
+            self.fontsizebox.fcombobox.has_pending_text
+            and self._font_size_pending_context is None
+        ):
+            self._font_size_pending_context = self._font_size_owner_context()
+
         if textblk_item is not None:
             transform_items = [textblk_item]
         elif multi_select:
@@ -1346,6 +1417,8 @@ class FontFormatPanel(Widget):
         if not preserve_local_owner:
             # A real selection transition settles edits against the old target
             # list. A transient clear from a nested color dialog is not one.
+            self.fontsizebox.fcombobox.commit_pending()
+            self._font_size_pending_context = None
             self.text_transform_session.finish_pending_edits()
             self.text_effect_session.finish_pending_edits()
             self.text_transform_session.replace_targets(transform_items)

--- a/doc/ui/text_effects.md
+++ b/doc/ui/text_effects.md
@@ -165,6 +165,12 @@ history, or the paired editor. Structural changes settle or cancel incompatible
 previews before indices change. Save, undo/redo, page replacement, selection
 change, and teardown must resolve pending work at its owner.
 
+Font Size and Stroke Width keyboard input is treated as pending text: it is
+committed on Enter or when the editor loses focus, so intermediate values do
+not rerender the text. Font Size presets and steppers remain immediate, and
+effect-label drags continue to provide deliberate continuous previews. Other
+effect numeric fields retain their existing typed preview behavior.
+
 The panel displays the most recently selected primary item's exact values. For
 multi-selection it derives an occurrence map by effect identity and occurrence
 number, intersecting the available count across all targets; it never builds a

--- a/tests/test_size_control_label.py
+++ b/tests/test_size_control_label.py
@@ -4,7 +4,8 @@ import unittest
 
 os.environ.setdefault('QT_QPA_PLATFORM', 'offscreen')
 
-from qtpy.QtCore import Qt
+from qtpy.QtCore import QEvent, Qt
+from qtpy.QtGui import QFocusEvent, QKeyEvent
 from qtpy.QtTest import QTest
 from qtpy.QtWidgets import QApplication, QHBoxLayout, QWidget
 
@@ -48,6 +49,75 @@ class SizeControlLabelTest(unittest.TestCase):
         self.assertAlmostEqual(editor.value(), 1.05)
         QTest.mouseRelease(label, Qt.MouseButton.LeftButton)
         self.assertEqual(commits, [1.05])
+
+    def test_deferred_typed_value_commits_once_and_restores_invalid_input(self):
+        host = QWidget()
+        self.addCleanup(host.deleteLater)
+        layout = QHBoxLayout(host)
+        editor = SizeComboBox(
+            [1, 1000],
+            'font_size',
+            host,
+            defer_text_changes=True,
+        )
+        editor.setValue(80)
+        layout.addWidget(editor)
+        host.show()
+        editor.lineEdit().setFocus()
+        self.app.processEvents()
+
+        changes = []
+        editor.param_changed.connect(
+            lambda name, value: changes.append((name, value))
+        )
+
+        editor.lineEdit().setText('800')
+        self.assertEqual(changes, [])
+        QApplication.sendEvent(
+            editor.lineEdit(),
+            QKeyEvent(
+                QEvent.Type.KeyPress,
+                Qt.Key.Key_Return,
+                Qt.KeyboardModifier.NoModifier,
+            ),
+        )
+        # Qt may still deliver these signals in a different order; the
+        # committed state must make them no-ops.
+        editor.lineEdit().returnPressed.emit()
+        editor.lineEdit().editingFinished.emit()
+        editor.activated.emit(editor.currentIndex())
+        self.assertEqual(changes, [('font_size', 800.0)])
+
+        editor.lineEdit().setText('1001')
+        QApplication.sendEvent(
+            editor.lineEdit(),
+            QKeyEvent(
+                QEvent.Type.KeyPress,
+                Qt.Key.Key_Return,
+                Qt.KeyboardModifier.NoModifier,
+            ),
+        )
+        self.assertEqual(changes, [('font_size', 800.0)])
+        self.assertEqual(editor.currentText(), '800')
+
+        editor.lineEdit().setText('900')
+        QApplication.sendEvent(
+            editor.lineEdit(),
+            QKeyEvent(
+                QEvent.Type.KeyPress,
+                Qt.Key.Key_Escape,
+                Qt.KeyboardModifier.NoModifier,
+            ),
+        )
+        self.assertEqual(changes, [('font_size', 800.0)])
+        self.assertEqual(editor.currentText(), '800')
+
+        editor.lineEdit().setText('850')
+        QApplication.sendEvent(
+            editor.lineEdit(),
+            QFocusEvent(QEvent.Type.FocusOut),
+        )
+        self.assertEqual(changes, [('font_size', 800.0), ('font_size', 850.0)])
 
 
 if __name__ == '__main__':

--- a/tests/test_text_effect_panel.py
+++ b/tests/test_text_effect_panel.py
@@ -234,7 +234,7 @@ class TextEffectPanelTest(unittest.TestCase):
         self.panel.set_textblk_item(item)
         control = self.panel.fontsizebox.fcombobox
         self.assertTrue(control._defer_text_changes)
-        before = item.fontformat.font_size
+        before = item.get_fontformat().font_size
         changes = []
         self.panel.fontsizebox.param_changed.connect(
             lambda name, value: changes.append((name, value))
@@ -245,11 +245,11 @@ class TextEffectPanelTest(unittest.TestCase):
         self.app.processEvents()
         control.lineEdit().setText('800')
         self.assertEqual(changes, [])
-        self.assertEqual(item.fontformat.font_size, before)
+        self.assertEqual(item.get_fontformat().font_size, before)
 
         control.lineEdit().returnPressed.emit()
         self.assertEqual(changes, [('font_size', 800.0)])
-        self.assertNotEqual(item.fontformat.font_size, before)
+        self.assertNotEqual(item.get_fontformat().font_size, before)
 
     def _begin_pending_global_font_size_edit(self, items):
         self.canvas.selected = list(items)
@@ -4108,7 +4108,7 @@ class TextEffectPanelTest(unittest.TestCase):
         editor = self._cards(StrokeEffectCard)[0].width_control.editor
         editor.setText('0.65')
         editor.textEdited.emit('0.65')
-        self.assertEqual(item.effective_text_effects()[0].width, 0.65)
+        self.assertEqual(item.effective_text_effects()[0].width, 0.1)
 
         self.panel.cancel_text_transform_edits_for_scene_change()
 

--- a/tests/test_text_effect_panel.py
+++ b/tests/test_text_effect_panel.py
@@ -229,6 +229,93 @@ class TextEffectPanelTest(unittest.TestCase):
         self.assertEqual(item.effective_text_effects(), before)
         self.assertEqual(self.canvas.stack.count(), 1)
 
+    def test_font_size_typing_waits_for_commit(self):
+        item = self._item()
+        self.panel.set_textblk_item(item)
+        control = self.panel.fontsizebox.fcombobox
+        self.assertTrue(control._defer_text_changes)
+        before = item.fontformat.font_size
+        changes = []
+        self.panel.fontsizebox.param_changed.connect(
+            lambda name, value: changes.append((name, value))
+        )
+
+        self.panel.show()
+        control.lineEdit().setFocus()
+        self.app.processEvents()
+        control.lineEdit().setText('800')
+        self.assertEqual(changes, [])
+        self.assertEqual(item.fontformat.font_size, before)
+
+        control.lineEdit().returnPressed.emit()
+        self.assertEqual(changes, [('font_size', 800.0)])
+        self.assertNotEqual(item.fontformat.font_size, before)
+
+    def _begin_pending_global_font_size_edit(self, items):
+        self.canvas.selected = list(items)
+        self.panel.set_textblk_item(
+            None,
+            multi_select=True,
+            primary_item=items[-1],
+        )
+        control = self.panel.fontsizebox.fcombobox
+        self.panel.show()
+        control.lineEdit().setFocus()
+        self.app.processEvents()
+        control.lineEdit().setText('80')
+        self.assertTrue(control.has_pending_text)
+
+    def test_pending_font_size_multi_to_single_keeps_original_targets(self):
+        old_items = [self._item(), self._item()]
+        new_item = self._item()
+        self._begin_pending_global_font_size_edit(old_items)
+
+        with patch.object(old_items[0], 'setFontSize') as old_first, \
+                patch.object(old_items[1], 'setFontSize') as old_second, \
+                patch.object(new_item, 'setFontSize') as new:
+            self.canvas.selected = [new_item]
+            self.panel.set_textblk_item(new_item)
+
+        old_first.assert_called_once()
+        old_second.assert_called_once()
+        new.assert_not_called()
+        self.assertIs(self.panel.textblk_item, new_item)
+
+    def test_pending_font_size_different_multi_keeps_original_targets(self):
+        old_items = [self._item(), self._item()]
+        new_items = [self._item(), self._item()]
+        self._begin_pending_global_font_size_edit(old_items)
+
+        with patch.object(old_items[0], 'setFontSize') as old_first, \
+                patch.object(old_items[1], 'setFontSize') as old_second, \
+                patch.object(new_items[0], 'setFontSize') as new_first, \
+                patch.object(new_items[1], 'setFontSize') as new_second:
+            self.canvas.selected = list(new_items)
+            self.panel.set_textblk_item(
+                None,
+                multi_select=True,
+                primary_item=new_items[-1],
+            )
+
+        old_first.assert_called_once()
+        old_second.assert_called_once()
+        new_first.assert_not_called()
+        new_second.assert_not_called()
+        self.assertEqual(self.panel.text_transform_session.items, new_items)
+
+    def test_pending_font_size_multi_to_empty_keeps_original_targets(self):
+        old_items = [self._item(), self._item()]
+        self._begin_pending_global_font_size_edit(old_items)
+
+        with patch.object(old_items[0], 'setFontSize') as old_first, \
+                patch.object(old_items[1], 'setFontSize') as old_second:
+            self.canvas.selected = []
+            self.panel.set_textblk_item()
+
+        old_first.assert_called_once()
+        old_second.assert_called_once()
+        self.assertEqual(self.panel.text_transform_session.items, [])
+
     def test_faster_preview_is_opt_in_and_follows_selected_items(self):
         first = self._item(self._stack(StrokeEffect(width=0.12)))
         second = self._item(self._stack(StrokeEffect(width=0.18)))
@@ -257,7 +344,7 @@ class TextEffectPanelTest(unittest.TestCase):
         editor.setText('0.45')
         editor.textEdited.emit('0.45')
         self.assertEqual(item.blk.fontformat.text_effects, before)
-        self.assertEqual(item.effective_text_effects()[0].width, 0.45)
+        self.assertEqual(item.effective_text_effects(), before)
         self.assertEqual(self.canvas.stack.count(), 0)
 
         editor.returnPressed.emit()
@@ -268,7 +355,7 @@ class TextEffectPanelTest(unittest.TestCase):
 
         editor.setText('0.70')
         editor.textEdited.emit('0.70')
-        self.assertEqual(item.effective_text_effects()[0].width, 0.7)
+        self.assertEqual(item.effective_text_effects(), committed)
         QApplication.sendEvent(
             editor,
             QKeyEvent(
@@ -279,6 +366,15 @@ class TextEffectPanelTest(unittest.TestCase):
         )
         self.assertEqual(item.effective_text_effects(), committed)
         self.assertEqual(self.canvas.stack.count(), 1)
+
+        editor.setText('0.85')
+        editor.textEdited.emit('0.85')
+        QApplication.sendEvent(
+            editor,
+            QFocusEvent(QEvent.Type.FocusOut),
+        )
+        self.assertEqual(item.blk.fontformat.text_effects[0].width, 0.85)
+        self.assertEqual(self.canvas.stack.count(), 2)
 
     def test_global_preview_cancel_and_commit_update_style_only_on_commit(self):
         before = self.panel.global_format.text_effects


### PR DESCRIPTION
Fixes #1000

## Implementation summary

Pending Font Size commits now retain their original selection targets across panel transitions. Added multi-to-single, multi-to-different-multi, and multi-to-empty regressions.

## Changes

```
ballontranslator/ui/custom_widget/combobox.py      | 221 ++++++++++++++++++++-
 ballontranslator/ui/text_engine/effects/cards.py   |  11 +-
 .../ui/text_engine/formatting/commands.py          |  18 +-
 .../ui/text_engine/formatting/panel.py             |  83 +++++++-
 doc/ui/text_effects.md                             |   6 +
 tests/test_size_control_label.py                   |  72 ++++++-
 tests/test_text_effect_panel.py                    | 100 +++++++++-
 7 files changed, 491 insertions(+), 20 deletions(-)
```

## Testing

Yes. Focused regression tests and repository checks passed.