### PR TITLE
Fix macOS CJK IME composition and canvas shortcuts

### DIFF
--- a/ballontranslator/ui/canvas.py
+++ b/ballontranslator/ui/canvas.py
@@ -95,7 +95,7 @@ class CustomGV(QGraphicsView):
     def wheelEvent(self, event : QWheelEvent) -> None:
         # qgraphicsview always scroll content according to wheelevent
         # which is not desired when scaling img
-        if event.modifiers() == Qt.KeyboardModifier.ControlModifier:
+        if event.modifiers() & Qt.KeyboardModifier.ControlModifier:
             if event.angleDelta().y() > 0:
                 self.scale_up_signal.emit()
             else:
@@ -118,17 +118,14 @@ class CustomGV(QGraphicsView):
             return super().keyPressEvent(e)
 
         modifiers = e.modifiers()
-        if modifiers == Qt.KeyboardModifier.ControlModifier:
-            if key == QKEY.Key_V:
-                # self.ctrlv_pressed.emit(e)
-                if self.canvas.handle_ctrlv():
-                    e.accept()
-                    return
-            if key == QKEY.Key_C:
-                if self.canvas.handle_ctrlc():
-                    e.accept()
-                    return
-                
+        if e.matches(QKeySequence.StandardKey.Paste):
+            if self.canvas.handle_ctrlv():
+                e.accept()
+                return
+        elif e.matches(QKeySequence.StandardKey.Copy):
+            if self.canvas.handle_ctrlc():
+                e.accept()
+                return
         elif modifiers & Qt.KeyboardModifier.ControlModifier and modifiers & Qt.KeyboardModifier.ShiftModifier:
             if key == QKEY.Key_C:
                 self.canvas.copy_src_signal.emit()

--- a/ballontranslator/ui/canvas.py
+++ b/ballontranslator/ui/canvas.py
@@ -3,6 +3,7 @@ from typing import Callable, List, Optional, Union
 import os
 
 from qtpy.QtWidgets import QApplication, QSlider, QMenu, QGraphicsScene, QGraphicsSceneDragDropEvent , QGraphicsView, QGraphicsSceneDragDropEvent, QGraphicsRectItem, QGraphicsItem, QScrollBar, QGraphicsPixmapItem, QGraphicsSceneMouseEvent, QGraphicsSceneContextMenuEvent, QRubberBand
+from qtpy.QtWidgets import QShortcut
 from qtpy.QtCore import Qt, QDateTime, QRectF, QPointF, QPoint, Signal, QSize, QSizeF, QEvent, QTimer
 from qtpy.QtGui import QKeySequence, QPixmap, QImage, QHideEvent, QKeyEvent, QWheelEvent, QResizeEvent, QPainter, QPen, QPainterPath, QCursor, QNativeGestureEvent
 from qtpy.QtWidgets import QGraphicsPathItem
@@ -91,6 +92,41 @@ class CustomGV(QGraphicsView):
 
         self.setAlignment(Qt.AlignmentFlag.AlignCenter)
         self.setDragMode(QGraphicsView.DragMode.ScrollHandDrag)
+        self._copy_shortcut = QShortcut(
+            QKeySequence.StandardKey.Copy,
+            self,
+        )
+        self._copy_shortcut.setContext(
+            Qt.ShortcutContext.WidgetWithChildrenShortcut
+        )
+        self._copy_shortcut.activated.connect(self._copy_shortcut_activated)
+        self._paste_shortcut = QShortcut(
+            QKeySequence.StandardKey.Paste,
+            self,
+        )
+        self._paste_shortcut.setContext(
+            Qt.ShortcutContext.WidgetWithChildrenShortcut
+        )
+        self._paste_shortcut.activated.connect(self._paste_shortcut_activated)
+
+    def _copy_shortcut_activated(self) -> None:
+        if self.canvas is None:
+            return
+        item = self.canvas.editing_textblkitem
+        if item is not None and item.isEditing():
+            if item.textCursor().hasSelection():
+                item._copy_selected_text()
+            return
+        self.canvas.handle_ctrlc()
+
+    def _paste_shortcut_activated(self) -> None:
+        if self.canvas is None:
+            return
+        item = self.canvas.editing_textblkitem
+        if item is not None and item.isEditing():
+            item.pasted.emit(item.idx)
+            return
+        self.canvas.handle_ctrlv()
 
     def wheelEvent(self, event : QWheelEvent) -> None:
         # qgraphicsview always scroll content according to wheelevent
@@ -1117,6 +1153,11 @@ class Canvas(QGraphicsScene):
 
     def mousePressEvent(self, event: QGraphicsSceneMouseEvent) -> None:
         btn = event.button()
+        if btn in (
+            Qt.MouseButton.LeftButton,
+            Qt.MouseButton.RightButton,
+        ):
+            self.gv.setFocus(Qt.FocusReason.MouseFocusReason)
         if self.alpha_mask_edit_session.handle_mouse_press(event):
             event.accept()
             return

--- a/ballontranslator/ui/text_engine/editing/widgets.py
+++ b/ballontranslator/ui/text_engine/editing/widgets.py
@@ -548,21 +548,15 @@ class SourceTextEdit(QTextEdit):
                 return super().keyPressEvent(e)
             finally:
                 self.paste_flag = False
-        if e.modifiers() == Qt.KeyboardModifier.ControlModifier:
-            if e.key() == Qt.Key.Key_Z:
-                e.accept()
-                self.undo_signal.emit()
-                return
-            elif e.key() == Qt.Key.Key_Y:
-                e.accept()
-                self.redo_signal.emit()
-                return
-        elif e.modifiers() == Qt.KeyboardModifier.ControlModifier | Qt.KeyboardModifier.ShiftModifier:
-            if e.key() == Qt.Key.Key_Z:
-                e.accept()
-                self.redo_signal.emit()
-                return
-        elif e.key() == Qt.Key.Key_Return:
+        if e.matches(QKeySequence.StandardKey.Undo):
+            e.accept()
+            self.undo_signal.emit()
+            return
+        if e.matches(QKeySequence.StandardKey.Redo):
+            e.accept()
+            self.redo_signal.emit()
+            return
+        if e.key() == Qt.Key.Key_Return:
             e.accept()
             self.textCursor().insertText('\n')
             return

--- a/ballontranslator/ui/text_engine/effects/renderer.py
+++ b/ballontranslator/ui/text_engine/effects/renderer.py
@@ -121,6 +121,7 @@ class _EffectRasterState:
         self.background_pixmap = None
         self.background_pixmap_scale = None
         self.cache_input_key = None
+        self.cache_document_html = None
         # Mask previews only change the final alpha. Keep at most two complete
         # pre-mask surfaces so visible full/tile output can be derived cheaply.
         self.pre_mask_cache = {}
@@ -592,6 +593,39 @@ class TextEffectRenderer:
             layout_render_key,
         ) + cache_key[5:]
 
+    @classmethod
+    def _effect_cache_ime_key(
+        cls,
+        cache_key: tuple,
+        document_html: str,
+    ) -> tuple:
+        """Ignore transient Qt generations but retain committed rich text."""
+        semantic = cls._effect_cache_semantic_key(cache_key)
+        return semantic[:2] + (document_html,) + semantic[3:]
+
+    def _active_cache_matches_committed_document(
+        self,
+        state: Optional[_EffectRasterState],
+        current_key: Optional[tuple] = None,
+    ) -> bool:
+        if (
+            state is None
+            or state.cache_dirty
+            or state.cache_rendered_generation != state.cache_generation
+            or state.cache_input_key is None
+            or state.cache_document_html is None
+        ):
+            return False
+        if current_key is None:
+            current_key = self._effect_cache_input_key()
+        return self._effect_cache_ime_key(
+            state.cache_input_key,
+            state.cache_document_html,
+        ) == self._effect_cache_ime_key(
+            current_key,
+            self.document().toHtml(),
+        )
+
     @staticmethod
     def _effect_cache_key_without_mask(cache_key: tuple) -> tuple:
         return cache_key[:1] + cache_key[2:]
@@ -891,6 +925,18 @@ class TextEffectRenderer:
             return True
         return False
 
+    def repaint_after_document_change(self) -> bool:
+        """Re-key unchanged committed pixels or rebuild them once."""
+        state = self._peek_raster_state()
+        current_key = self._effect_cache_input_key()
+        if self._active_cache_matches_committed_document(
+            state, current_key
+        ):
+            state.cache_input_key = current_key
+            return False
+        self.repaint_background()
+        return True
+
     def _current_stroke(self) -> Optional[StrokeEffect]:
         if self._render_stroke is not None:
             return self._render_stroke
@@ -1089,6 +1135,7 @@ class TextEffectRenderer:
         state.cache_dirty = True
         state.cache_rendered_generation = -1
         state.cache_input_key = None
+        state.cache_document_html = None
         state.tile_cache.clear()
         state.pre_mask_cache.clear()
         state.pre_filter_cache.clear()
@@ -1107,6 +1154,7 @@ class TextEffectRenderer:
         state.cache_dirty = True
         state.cache_rendered_generation = -1
         state.cache_input_key = None
+        state.cache_document_html = None
         state.tile_cache.clear()
         state.background_pixmap = None
         state.background_pixmap_scale = None
@@ -1122,6 +1170,7 @@ class TextEffectRenderer:
         state.cache_dirty = True
         state.cache_rendered_generation = -1
         state.cache_input_key = None
+        state.cache_document_html = None
         state.tile_cache.clear()
         state.pre_mask_cache.clear()
         state.pre_filter_cache.clear()
@@ -1567,6 +1616,12 @@ class TextEffectRenderer:
                 option.state = QStyle.State_None
                 base_paint(painter, option, widget)
                 return
+            if (
+                self.pre_editing
+                and not self._preedit_effect_cache_is_reusable(painter)
+            ):
+                base_paint(painter, option, widget)
+                return
             interaction_option = QStyleOptionGraphicsItem(option)
             if any(flags):
                 self._draw_effects(
@@ -1620,6 +1675,23 @@ class TextEffectRenderer:
             state is not None
             and not state.cache_dirty
             and state.cache_rendered_generation == state.cache_generation
+        )
+
+    def _preedit_effect_cache_is_reusable(self, painter: QPainter) -> bool:
+        state = self._peek_raster_state()
+        if not self._active_cache_matches_committed_document(state):
+            return False
+        if state.force_tiles or state.background_pixmap is None:
+            return False
+        rect = self.boundingRect()
+        plan = plan_effect_raster(
+            rect.width(),
+            rect.height(),
+            self._raster_request(self._paint_device_scale(painter)),
+        )
+        return (
+            plan.mode == 'full'
+            and state.background_pixmap_scale == plan.tier
         )
 
     def _paint_effect_interaction(
@@ -4155,8 +4227,8 @@ class TextEffectRenderer:
             or (self.reshaping and not self._export_active)
             or (self.pre_editing and not self._export_active)
         ):
-            # Avoid reshape/reentrant work. During IME, reuse the preedit-free
-            # cache because PaintContext cannot exclude active preedit glyphs.
+            # Avoid reshape/reentrant work. During IME, preserve the completed
+            # preedit-free cache; paint_item decides whether it is still safe.
             return
 
         planned_here = nodes is None
@@ -4271,19 +4343,23 @@ class TextEffectRenderer:
             self.force_tiles = False
             self.cache_dirty = False
             self.cache_rendered_generation = self.cache_generation
-            self._raster_state().cache_input_key = (
-                self._effect_cache_input_key()
-            )
+            self._stamp_active_cache_input()
         finally:
             self.repainting = False
         self.item.update()
 
+
+    def _stamp_active_cache_input(self) -> None:
+        state = self._raster_state()
+        state.cache_input_key = self._effect_cache_input_key()
+        state.cache_document_html = self.document().toHtml()
 
     def _mark_effect_cache_dirty(self) -> None:
         state = self._raster_state()
         state.cache_generation += 1
         state.cache_dirty = True
         state.cache_input_key = None
+        state.cache_document_html = None
         state.tile_cache.clear()
         state.pre_mask_cache.clear()
         # Completed effect pixels contain the previous paint parameters.
@@ -4296,6 +4372,7 @@ class TextEffectRenderer:
         state.cache_generation += 1
         state.cache_dirty = True
         state.cache_input_key = None
+        state.cache_document_html = None
         state.tile_cache.clear()
         self.background_pixmap = None
         self.background_pixmap_scale = None
@@ -4360,9 +4437,7 @@ class TextEffectRenderer:
             self.direct_stroke = True
             self.cache_dirty = False
             self.cache_rendered_generation = self.cache_generation
-            self._raster_state().cache_input_key = (
-                self._effect_cache_input_key()
-            )
+            self._stamp_active_cache_input()
             self.force_tiles = False
             return
         included_filters = self._retained_filter_indices(nodes)
@@ -4580,9 +4655,7 @@ class TextEffectRenderer:
         self.direct_stroke = vector_stroke_direct
         self.cache_dirty = False
         self.cache_rendered_generation = self.cache_generation
-        self._raster_state().cache_input_key = (
-            self._effect_cache_input_key()
-        )
+        self._stamp_active_cache_input()
         self.force_tiles = False
 
     def _draw_direct_stroke(self, painter: QPainter) -> None:

--- a/ballontranslator/ui/text_engine/item.py
+++ b/ballontranslator/ui/text_engine/item.py
@@ -21,6 +21,7 @@ from qtpy.QtGui import (QKeyEvent, QKeySequence, QFont, QTextCursor,
 
 from ballontranslator.utils.textblock import TextBlock
 from ballontranslator.utils.text_alpha_mask import TextAlphaMask
+from ballontranslator.utils import shared
 from ballontranslator.utils.text_effects import (
     SolidPaint,
     TextEffect,
@@ -85,6 +86,22 @@ from .annotations import (
 
 TEXTRECT_SHOW_COLOR = QColor(30, 147, 229, 170)
 TEXTRECT_SELECTED_COLOR = QColor(248, 64, 147, 170)
+
+
+def _discard_macos_marked_text() -> None:
+    try:
+        from AppKit import NSApp
+    except ImportError:
+        return
+
+    window = NSApp.keyWindow()
+    responder = window.firstResponder() if window is not None else None
+    if responder is None or not responder.respondsToSelector_(b'unmarkText'):
+        return
+    responder.unmarkText()
+    context = responder.inputContext()
+    if context is not None:
+        context.discardMarkedText()
 
 
 class _OrderBadgeItem(QGraphicsItem):
@@ -1217,12 +1234,28 @@ class TextBlkItem(QGraphicsTextItem):
             cursor.setPosition(hit)
             self.setTextCursor(cursor)
 
-    def endEdit(self, keep_focus=True) -> None:
+    def endEdit(self, keep_focus: bool = True) -> None:
+        input_method = None
+        if shared.ON_MACOS and self.pre_editing:
+            preedit_text = self.textCursor().block().layout().preeditAreaText()
+            if preedit_text:
+                input_method = QApplication.inputMethod()
+                input_method.commit()
+                if self.pre_editing:
+                    # Qt 6.11's Cocoa context can leave marked text visible
+                    # without delivering its final commit to a graphics item.
+                    event = QInputMethodEvent('', [])
+                    event.setCommitString(preedit_text)
+                    self.inputMethodEvent(event)
         self.end_edit.emit(self.idx)
         cursor = self.textCursor()
         cursor.clearSelection()
         self.setTextCursor(cursor)
         self.setTextInteractionFlags(Qt.TextInteractionFlag.NoTextInteraction)
+        if input_method is not None:
+            # The canvas QNSView can retain marked text after Qt drops the
+            # final commit, so clear it after duplicate insertion is disabled.
+            _discard_macos_marked_text()
         self.refresh_cache_policy()
         self._sync_order_badge()
         if keep_focus:

--- a/ballontranslator/ui/text_engine/item.py
+++ b/ballontranslator/ui/text_engine/item.py
@@ -14,7 +14,7 @@ from qtpy.QtWidgets import (
     QGraphicsSceneMouseEvent,
 )
 from qtpy.QtCore import Qt, QRect, QRectF, QPoint, QPointF, QMimeData, Signal
-from qtpy.QtGui import (QKeyEvent, QFont, QTextCursor,
+from qtpy.QtGui import (QKeyEvent, QKeySequence, QFont, QTextCursor,
                        QInputMethodEvent, QPainter, QColor, QTextCharFormat,
                        QBrush, QFontMetrics, QPen,
                        QTextBlockFormat)
@@ -1012,35 +1012,30 @@ class TextBlkItem(QGraphicsTextItem):
             return
         self._vertical_navigation_y = None
 
-        if e.modifiers() == Qt.KeyboardModifier.ControlModifier:
-            if e.key() == Qt.Key.Key_Z:
-                e.accept()
-                self.undo_signal.emit()
-                return
-            elif e.key() == Qt.Key.Key_Y:
-                e.accept()
-                self.redo_signal.emit()
-                return
-            elif e.key() == Qt.Key.Key_V:
-                if self.isEditing():
-                    e.accept()
-                    self.pasted.emit(self.idx)
-                    return
-            elif e.key() in (Qt.Key.Key_C, Qt.Key.Key_X):
-                cursor = self.textCursor()
-                if cursor.hasSelection():
-                    self._copy_selected_text()
-                    if e.key() == Qt.Key.Key_X:
-                        cursor.removeSelectedText()
-                        self.setTextCursor(cursor)
-                e.accept()
-                return
-        elif e.modifiers() == Qt.KeyboardModifier.ControlModifier | Qt.KeyboardModifier.ShiftModifier:
-            if e.key() == Qt.Key.Key_Z:
-                e.accept()
-                self.redo_signal.emit()
-                return
-        elif e.key() in (Qt.Key.Key_Return, Qt.Key.Key_Enter):
+        if e.matches(QKeySequence.StandardKey.Undo):
+            e.accept()
+            self.undo_signal.emit()
+            return
+        if e.matches(QKeySequence.StandardKey.Redo):
+            e.accept()
+            self.redo_signal.emit()
+            return
+        if e.matches(QKeySequence.StandardKey.Paste) and self.isEditing():
+            e.accept()
+            self.pasted.emit(self.idx)
+            return
+        is_copy = e.matches(QKeySequence.StandardKey.Copy)
+        is_cut = e.matches(QKeySequence.StandardKey.Cut)
+        if is_copy or is_cut:
+            cursor = self.textCursor()
+            if cursor.hasSelection():
+                self._copy_selected_text()
+                if is_cut:
+                    cursor.removeSelectedText()
+                    self.setTextCursor(cursor)
+            e.accept()
+            return
+        if e.key() in (Qt.Key.Key_Return, Qt.Key.Key_Enter):
             e.accept()
             cursor = self.textCursor()
             cursor.beginEditBlock()

--- a/ballontranslator/ui/text_engine/item.py
+++ b/ballontranslator/ui/text_engine/item.py
@@ -309,11 +309,10 @@ class TextBlkItem(QGraphicsTextItem):
             self.input_method_from = -1
             self.input_method_removed = 0
             self.input_method_text = ''
-        # Preedit text and attributes live in QTextLayout, so they need an
-        # explicit surface invalidation even when the document revision does
-        # not change. The next paint is cached until another IME event.
+        # Preedit text and attributes live in QTextLayout, so they may not
+        # change the document revision or schedule an item repaint.
         self.geometry_controller.invalidate_surface_cache()
-        self._update_nonlinear_editing_ui()
+        self.update()
 
     def setTextCursor(self, cursor: QTextCursor) -> None:
         self._vertical_navigation_y = None
@@ -458,7 +457,7 @@ class TextBlkItem(QGraphicsTextItem):
             self._update_effect_padding()
             if self.repaint_on_changed:
                 if not self.repainting:
-                    self.repaint_background()
+                    self.effect_renderer.repaint_after_document_change()
             self.update()
 
     def repaint_background(self, render_scale: float = 1.0):

--- a/doc/ui/text_effects.md
+++ b/doc/ui/text_effects.md
@@ -110,6 +110,9 @@ and Eraser cannot alter editing feedback. Image layers are intentionally omitted
 during native horizontal and vertical text editing; ordinary Filters remain
 active. Editing visibility participates in cache identity so settled Image
 pixels cannot leak into the editing surface or vice versa.
+IME may reuse a completed effect surface only while its committed document and
+effect semantics still match. Otherwise editing temporarily uses native paint
+and rebuilds the effects once the composition settles.
 
 Interactive rendering may bypass an active missing optional raster, invalid
 Filter, or bounded allocation failure with a warning and compatible fallback.

--- a/tests/test_text_transform_undo.py
+++ b/tests/test_text_transform_undo.py
@@ -12,7 +12,7 @@ import numpy as np
 
 os.environ.setdefault("QT_QPA_PLATFORM", "offscreen")
 
-from qtpy.QtCore import QEvent, QPointF, QRectF, Qt
+from qtpy.QtCore import QEvent, QPoint, QPointF, QRectF, Qt
 from qtpy.QtGui import (
     QColor,
     QImage,
@@ -30,6 +30,7 @@ from qtpy.QtWidgets import (
     QGraphicsScene,
     QGraphicsTextItem,
     QGraphicsView,
+    QLineEdit,
     QStyleOptionGraphicsItem,
     QVBoxLayout,
     QWidget,
@@ -1564,6 +1565,30 @@ class TextTransformUndoTest(TextTransformTestBase):
 
         self.assertEqual(calls, ['copy', 'paste'])
 
+    def test_canvas_pointer_input_restores_keyboard_focus(self) -> None:
+        canvas = Canvas()
+        canvas.imgtrans_proj = SimpleNamespace(img_valid=False)
+        editor = QLineEdit()
+        host = QWidget()
+        layout = QVBoxLayout(host)
+        layout.addWidget(editor)
+        layout.addWidget(canvas.gv)
+        host.show()
+        editor.setFocus()
+        self.app.processEvents()
+        self.assertTrue(editor.hasFocus())
+
+        QTest.mouseClick(
+            canvas.gv.viewport(),
+            Qt.MouseButton.LeftButton,
+            Qt.KeyboardModifier.NoModifier,
+            QPoint(20, 20),
+        )
+        self.app.processEvents()
+
+        self.assertTrue(canvas.gv.hasFocus())
+        host.close()
+
     def test_text_edit_shortcuts_accept_transient_modifiers(self) -> None:
         item, pair = self._make_pair(0, 'text', False)
         modifiers = (
@@ -1610,6 +1635,61 @@ class TextTransformUndoTest(TextTransformTestBase):
         self.assertEqual(self.app.clipboard().text(), 'te')
         self.assertEqual(item_events, ['paste', 'undo', 'redo'])
         self.assertEqual(pair_events, ['undo', 'redo'])
+
+    def test_canvas_end_edit_commits_macos_ime_before_disabling(self) -> None:
+        item, pair = self._make_pair(0, '테스', False)
+        scene = QGraphicsScene()
+        scene.addItem(item)
+        view = QGraphicsView(scene)
+        view.show()
+        item.startEdit()
+        cursor = item.textCursor()
+        cursor.movePosition(QTextCursor.MoveOperation.End)
+        item.setTextCursor(cursor)
+        item.inputMethodEvent(QInputMethodEvent('트', []))
+        self.app.processEvents()
+        item.propagate_user_edited.connect(
+            lambda *args: propagate_user_edit(pair.e_trans, *args)
+        )
+
+        calls = []
+
+        def commit() -> None:
+            self.assertTrue(item.isEditing())
+            self.assertTrue(item.hasFocus())
+            calls.append(('commit', item.isEditing()))
+
+        def discard() -> None:
+            calls.append(('discard', item.isEditing()))
+
+        try:
+            with (
+                patch(
+                    'ballontranslator.ui.text_engine.item.shared.ON_MACOS',
+                    True,
+                ),
+                patch(
+                    'ballontranslator.ui.text_engine.item.QApplication.inputMethod',
+                    return_value=SimpleNamespace(commit=commit),
+                ),
+                patch(
+                    'ballontranslator.ui.text_engine.item._discard_macos_marked_text',
+                    side_effect=discard,
+                ),
+            ):
+                item.endEdit()
+
+            self.assertEqual(item.toPlainText(), '테스트')
+            self.assertEqual(pair.e_trans.toPlainText(), '테스트')
+            self.assertFalse(item.isEditing())
+            self.assertEqual(
+                item.document().firstBlock().layout().preeditAreaText(),
+                '',
+            )
+            self.assertEqual(calls, [('commit', True), ('discard', False)])
+        finally:
+            view.close()
+            scene.removeItem(item)
 
     def test_pair_editor_paste_shortcuts_at_document_start_stay_synced(self):
         shortcuts = (

--- a/tests/test_text_transform_undo.py
+++ b/tests/test_text_transform_undo.py
@@ -1691,6 +1691,35 @@ class TextTransformUndoTest(TextTransformTestBase):
             view.close()
             scene.removeItem(item)
 
+    def test_canvas_ime_preedit_requests_full_repaint(self) -> None:
+        class RecordingTextBlkItem(TextBlkItem):
+            def __init__(self, *args, **kwargs):
+                self.full_update_count = 0
+                super().__init__(*args, **kwargs)
+
+            def update(self, *args) -> None:
+                if not args:
+                    self.full_update_count += 1
+                super().update(*args)
+
+        block = TextBlock([0, 0, 92, 162])
+        block._bounding_rect = [0, 0, 92, 162]
+        block.translation = '테스트'
+        item = RecordingTextBlkItem(block, 0)
+        item.startEdit()
+        cursor = item.textCursor()
+        cursor.select(QTextCursor.SelectionType.Document)
+        item.setTextCursor(cursor)
+        item.full_update_count = 0
+
+        item.inputMethodEvent(QInputMethodEvent('테스트', []))
+
+        self.assertEqual(
+            item.document().firstBlock().layout().preeditAreaText(),
+            '테스트',
+        )
+        self.assertGreaterEqual(item.full_update_count, 1)
+
     def test_pair_editor_paste_shortcuts_at_document_start_stay_synced(self):
         shortcuts = (
             (Qt.Key.Key_V, Qt.KeyboardModifier.ControlModifier),

--- a/tests/test_text_transform_undo.py
+++ b/tests/test_text_transform_undo.py
@@ -1543,6 +1543,74 @@ class TextTransformPanelTest(TextTransformTestBase):
 
 
 class TextTransformUndoTest(TextTransformTestBase):
+    def test_canvas_block_shortcuts_accept_transient_modifiers(self) -> None:
+        canvas = Canvas()
+        canvas.editor_index = 1
+        calls = []
+        canvas.handle_ctrlc = lambda: calls.append('copy') or True
+        canvas.handle_ctrlv = lambda: calls.append('paste') or True
+        canvas.gv.show()
+        canvas.gv.setFocus()
+        self.app.processEvents()
+
+        modifiers = (
+            Qt.KeyboardModifier.ControlModifier
+            | Qt.KeyboardModifier.KeypadModifier
+        )
+        QTest.keyClick(canvas.gv, Qt.Key.Key_C, modifiers)
+        QTest.keyClick(canvas.gv, Qt.Key.Key_V, modifiers)
+        self.app.processEvents()
+        canvas.gv.close()
+
+        self.assertEqual(calls, ['copy', 'paste'])
+
+    def test_text_edit_shortcuts_accept_transient_modifiers(self) -> None:
+        item, pair = self._make_pair(0, 'text', False)
+        modifiers = (
+            Qt.KeyboardModifier.ControlModifier
+            | Qt.KeyboardModifier.KeypadModifier
+        )
+        item.startEdit()
+        cursor = item.textCursor()
+        cursor.setPosition(0)
+        cursor.setPosition(2, QTextCursor.MoveMode.KeepAnchor)
+        item.setTextCursor(cursor)
+        self.app.clipboard().clear()
+        item.keyPressEvent(QKeyEvent(
+            QEvent.Type.KeyPress,
+            Qt.Key.Key_C,
+            modifiers,
+        ))
+
+        item_events = []
+        item.pasted.connect(lambda _index: item_events.append('paste'))
+        item.undo_signal.connect(lambda: item_events.append('undo'))
+        item.redo_signal.connect(lambda: item_events.append('redo'))
+        for key in (Qt.Key.Key_V, Qt.Key.Key_Z, Qt.Key.Key_Y):
+            item.keyPressEvent(QKeyEvent(
+                QEvent.Type.KeyPress,
+                key,
+                modifiers,
+            ))
+
+        pair_events = []
+        pair.e_trans.undo_signal.connect(
+            lambda: pair_events.append('undo')
+        )
+        pair.e_trans.redo_signal.connect(
+            lambda: pair_events.append('redo')
+        )
+        for key in (Qt.Key.Key_Z, Qt.Key.Key_Y):
+            pair.e_trans.keyPressEvent(QKeyEvent(
+                QEvent.Type.KeyPress,
+                key,
+                modifiers,
+            ))
+
+        self.assertEqual(self.app.clipboard().text(), 'te')
+        self.assertEqual(item_events, ['paste', 'undo', 'redo'])
+        self.assertEqual(pair_events, ['undo', 'redo'])
+
     def test_pair_editor_paste_shortcuts_at_document_start_stay_synced(self):
         shortcuts = (
             (Qt.Key.Key_V, Qt.KeyboardModifier.ControlModifier),

--- a/tests/test_typed_text_effect_renderer.py
+++ b/tests/test_typed_text_effect_renderer.py
@@ -2089,6 +2089,104 @@ class TypedTextEffectRendererTest(unittest.TestCase):
         ), 0)
         view.close()
 
+    def test_gradient_reuses_effect_cache_for_transient_preedit(self):
+        item = self._item(TextEffectStack(effects=(TextFillEffect(
+            paint=self._constant_gradient((0, 0, 255))
+        ),)))
+        scene = QGraphicsScene()
+        scene.addItem(item)
+        view = QGraphicsView(scene)
+        view.show()
+        item.startEdit()
+        view.setFocus()
+        item.setFocus()
+        self.app.processEvents()
+        before = self._render(item)
+        renderer = item.effect_renderer
+        state = renderer._peek_raster_state()
+        cached_pixmap_key = state.background_pixmap.cacheKey()
+        cursor = item.textCursor()
+        cursor.movePosition(QTextCursor.MoveOperation.End)
+        item.setTextCursor(cursor)
+
+        with patch.object(
+            renderer,
+            '_render_effect_surface',
+            wraps=renderer._render_effect_surface,
+        ) as render_surface:
+            item.inputMethodEvent(QInputMethodEvent('かな', []))
+            during = self._render(item)
+            item.inputMethodEvent(QInputMethodEvent('', []))
+            after = self._render(item)
+
+        self.assertEqual(render_surface.call_count, 0)
+        self.assertEqual(
+            state.background_pixmap.cacheKey(), cached_pixmap_key
+        )
+        self.assertEqual(
+            state.cache_input_key, renderer._effect_cache_input_key()
+        )
+        self.assertGreater(np.count_nonzero(
+            (before[..., 2] > 180) & (before[..., 3] > 0)
+        ), 0)
+        self.assertGreater(np.count_nonzero(
+            (during[..., 0] > 180)
+            & (during[..., 1] < 80)
+            & (during[..., 2] < 80)
+            & (during[..., 3] > 0)
+        ), 0)
+        self.assertGreater(np.count_nonzero(
+            (after[..., 2] > 180) & (after[..., 3] > 0)
+        ), 0)
+        view.close()
+
+    def test_gradient_preedit_replacement_hides_stale_effect_cache(self):
+        item = self._item(TextEffectStack(effects=(TextFillEffect(
+            paint=self._constant_gradient((0, 0, 255))
+        ),)))
+        scene = QGraphicsScene()
+        scene.addItem(item)
+        view = QGraphicsView(scene)
+        view.show()
+        item.startEdit()
+        view.setFocus()
+        item.setFocus()
+        self.app.processEvents()
+        before = self._render(item)
+        renderer = item.effect_renderer
+        state = renderer._peek_raster_state()
+        cached_pixmap_key = state.background_pixmap.cacheKey()
+        cursor = item.textCursor()
+        cursor.select(QTextCursor.SelectionType.Document)
+        item.setTextCursor(cursor)
+
+        with patch.object(
+            renderer,
+            '_draw_surface_pixmap',
+            wraps=renderer._draw_surface_pixmap,
+        ) as draw_surface:
+            item.inputMethodEvent(QInputMethodEvent('かな', []))
+            during = self._render(item)
+
+        before_blue = np.count_nonzero(
+            (before[..., 2] > 180) & (before[..., 3] > 0)
+        )
+        during_blue = np.count_nonzero(
+            (during[..., 2] > 180) & (during[..., 3] > 0)
+        )
+        self.assertGreater(before_blue, 0)
+        self.assertLess(during_blue, before_blue / 2)
+        self.assertGreater(np.count_nonzero(during[..., 3]), 0)
+        draw_surface.assert_not_called()
+        self.assertEqual(
+            item.document().firstBlock().layout().preeditAreaText(),
+            'かな',
+        )
+        self.assertEqual(
+            state.background_pixmap.cacheKey(), cached_pixmap_key
+        )
+        view.close()
+
     def test_deferred_cursor_is_visible_over_neutral_effect_surface(self):
         item = self._item(TextEffectStack(effects=(HollowEffect(),)))
         cursor_rect = QRectF(20, 20, 3, 18)


### PR DESCRIPTION
## Problem

On macOS with Qt/PyQt 6.11, ending a canvas text edit while a CJK IME composition is active can leave the final character visible but absent from the stored text. The remaining native input state can also consume the first Cmd+A/C/V shortcut or commit the character again after focus changes.

This supersedes #1306 with a narrower fix based on a minimal Qt Cocoa reproduction.

## Changes

- Ask the platform input method to commit before disabling canvas text editing.
- If Qt drops that commit, commit the captured preedit text while the canvas item and paired editor are still synchronized.
- Clear marked text from the actual Cocoa first responder only after duplicate insertion is no longer possible.
- Restore canvas keyboard focus on pointer input.
- Route view-scoped Copy and Paste through platform-standard shortcuts while preserving text-selection and block operations.
- Use platform-standard Copy, Cut, Paste, Undo, and Redo matching in the existing edit handlers.

## Manual verification

Verified on macOS 26.5.2 with Qt/PyQt 6.11 and Apple’s 2-Set Korean IME:

- Entering a single Korean character and clicking the canvas background.
- Entering 테스트 while the final character is still marked, then ending the edit.
- Re-entering the block and using Cmd+A immediately.
- Copying a block with Cmd+C, clearing the selection, and pasting it with Cmd+V.
- Confirming that the canvas item and paired editor contain the same committed text.

Additional manual verification is still needed on Windows and Linux, and with native Japanese and Chinese IMEs.