### PR TITLE
Add screentone preservation for LaMa inpainting

### DIFF
--- a/ballontranslator/modules/inpaint/inpaint_default.py
+++ b/ballontranslator/modules/inpaint/inpaint_default.py
@@ -202,7 +202,13 @@ class LamaInpainterMPE(InpainterBase):
             'value': 2048,
             'display_name': 'Inpaint Size'
         },
-        'device': DEVICE_SELECTOR(not_supported=['privateuseone'])
+        'device': DEVICE_SELECTOR(not_supported=['privateuseone']),
+        'preserve screentones': {
+            'type': 'checkbox',
+            'value': False,
+            'display_name': 'Preserve Screentones (Experimental)',
+            'description': 'Restore regular monochrome dots from nearby background after inpainting, while retaining shading and strong edges. Unsupported areas keep the normal result.',
+        },
     }
 
     download_file_list = [{
@@ -297,6 +303,9 @@ class LamaInpainterMPE(InpainterBase):
         new_shape = img_inpainted.shape[:2]
         if new_shape[0] != im_h or new_shape[1] != im_w :
             img_inpainted = cv2.resize(img_inpainted, (im_w, im_h), interpolation = cv2.INTER_LINEAR)
+        if self.get_param_value('preserve screentones'):
+            from .screentone import restore_screentone
+            img_inpainted = restore_screentone(img, mask, img_inpainted)
         img_inpainted = img_inpainted * mask_original + img_original * (1 - mask_original)
         
         return img_inpainted
@@ -349,7 +358,13 @@ class LamaLarge(LamaInpainterMPE):
                 'bf16'
             ], 
             'value': 'bf16' if BF16_SUPPORTED == 'cuda' else 'fp32'
-        }, 
+        },
+        'preserve screentones': {
+            'type': 'checkbox',
+            'value': False,
+            'display_name': 'Preserve Screentones (Experimental)',
+            'description': 'Restore regular monochrome dots from nearby background after inpainting, while retaining shading and strong edges. Unsupported areas keep the normal result.',
+        },
     }
 
     download_file_list = [{

--- a/ballontranslator/modules/inpaint/screentone.py
+++ b/ballontranslator/modules/inpaint/screentone.py
@@ -1,0 +1,186 @@
+"""Restore native-resolution periodic texture over a normal LaMa result."""
+
+from typing import Optional, Tuple
+
+import cv2
+import numpy as np
+
+from ballontranslator.utils.logger import logger as LOGGER
+
+
+def _find_lattice(
+    gray: np.ndarray, known: np.ndarray,
+) -> Optional[Tuple[Tuple[int, int], Tuple[int, int]]]:
+    """Find two independent integer translations supported by known pixels.
+
+    >>> _find_lattice(np.zeros((32, 32), np.float32),
+    ...               np.ones((32, 32), bool)) is None
+    True
+    """
+    weights = known.astype(np.float32)
+    low = cv2.GaussianBlur(gray * weights, (0, 0), 2)
+    low /= np.maximum(cv2.GaussianBlur(weights, (0, 0), 2), 1e-4)
+    signal = (gray - low) * weights
+    if known.sum() < 512 or np.std(signal[known]) < 5:
+        return None
+
+    # Zero padding and pairwise energies avoid wraparound and masked-text peaks.
+    shape = tuple(cv2.getOptimalDFTSize(2 * size) for size in gray.shape)
+    spectrum = np.fft.rfft2(signal, s=shape)
+    valid_spectrum = np.fft.rfft2(weights, s=shape)
+    numerator = np.fft.irfft2(spectrum * spectrum.conj(), s=shape)
+    energy = np.fft.irfft2(
+        np.fft.rfft2(signal**2, s=shape) * valid_spectrum.conj(), s=shape
+    )
+    overlap = np.fft.irfft2(valid_spectrum * valid_spectrum.conj(), s=shape)
+    radius = min(24, min(gray.shape) // 3)
+    y, x = np.mgrid[-radius:radius + 1, -radius:radius + 1]
+    denominator = np.sqrt(np.maximum(energy[y, x] * energy[-y, -x], 0))
+    score = numerator[y, x] / np.maximum(denominator, 1e-5)
+    score[overlap[y, x] < max(128, known.sum() * 0.2)] = 0
+    peaks = score >= cv2.dilate(score, np.ones((3, 3), np.uint8)) - 1e-8
+    peaks &= (score > 0.85) & (x*x + y*y >= 4)
+    peaks &= (y > 0) | ((y == 0) & (x > 0))
+    candidates = [
+        (float(score[i, j]), int(x[i, j]), int(y[i, j]))
+        for i, j in zip(*np.where(peaks))
+    ]
+    if not candidates:
+        return None
+    best = max(candidate[0] for candidate in candidates)
+    candidates = sorted(
+        (candidate for candidate in candidates if candidate[0] >= best - 0.04),
+        key=lambda candidate: candidate[1]**2 + candidate[2]**2,
+    )
+    _, ax, ay = candidates[0]
+    for _, bx, by in candidates[1:]:
+        if 4 <= abs(ax * by - ay * bx) <= 144:
+            return (ax, ay), (bx, by)
+    return None
+
+
+def restore_screentone(
+    image: np.ndarray, mask: np.ndarray, result: np.ndarray,
+) -> np.ndarray:
+    """Match nearby screen pixels and shading while keeping strong LaMa edges.
+
+    Only masked, locally supported pixels are changed. Pattern detection and
+    donors use the original unmasked image; unsupported regions retain the
+    normal inference result. Nothing is mutated and no extra inference runs.
+
+    >>> image = np.full((32, 32, 3), 127, np.uint8)
+    >>> restore_screentone(image, np.zeros((32, 32), np.uint8), image) is image
+    True
+    """
+    if image.dtype != np.uint8 or image.ndim != 3 or image.shape[2] != 3:
+        raise ValueError('Screentone restoration requires a uint8 RGB image.')
+    if mask.dtype != np.uint8 or mask.shape != image.shape[:2]:
+        raise ValueError('Screentone restoration requires a matching uint8 mask.')
+    if result.dtype != np.uint8 or result.shape != image.shape:
+        raise ValueError('Screentone restoration requires a matching uint8 RGB result.')
+    texture = _estimate_texture(image, mask)
+    if texture is None:
+        return result
+    detail, background, confidence, period = texture
+
+    # Use the normal result to protect reconstructed structural edges.
+    sigma = max(1.0, period / 3)
+    smooth = cv2.GaussianBlur(result.astype(np.float32), (0, 0), sigma)
+    shade = cv2.cvtColor(smooth, cv2.COLOR_RGB2GRAY)
+    grad_x = cv2.Sobel(shade, cv2.CV_32F, 1, 0, ksize=3) / 8
+    grad_y = cv2.Sobel(shade, cv2.CV_32F, 0, 1, ksize=3) / 8
+    radius = int(np.ceil(sigma))
+    edges = cv2.dilate(cv2.magnitude(grad_x, grad_y),
+                       np.ones((2*radius + 1, 2*radius + 1), np.uint8))
+    confidence *= 1 - np.clip((edges - 6) / 10, 0, 1)
+    # Match both brightness and contrast to the same source donors. Scaling the
+    # dots by model brightness would retain glyph-shaped low-frequency blobs.
+    restored = smooth + (background - shade + detail)[..., None]
+    blended = result * (1 - confidence[..., None]) + restored * confidence[..., None]
+    output = result.copy()
+    selected = (mask > 127) & (confidence > 0)
+    output[selected] = np.clip(np.rint(blended[selected]), 0, 255).astype(np.uint8)
+    LOGGER.debug('Screentone restoration: %.1f%% of masked pixels have strong support.',
+                 100 * float(np.mean(confidence[mask > 127] > 0.5)))
+    return output
+
+
+def _estimate_texture(
+    image: np.ndarray, mask: np.ndarray,
+) -> Optional[Tuple[np.ndarray, np.ndarray, np.ndarray, float]]:
+    """Interpolate local same-phase donors, excluding text and masked pixels.
+
+    >>> image = np.full((32, 32, 3), 127, np.uint8)
+    >>> _estimate_texture(image, np.full((32, 32), 255, np.uint8)) is None
+    True
+    """
+    height, width = mask.shape
+    missing = mask > 127
+    if min(height, width) < 16 or not missing.any() or missing.all():
+        return None
+    # This first version handles monochrome screens, not colored print screens.
+    if np.mean(np.ptp(image[~missing].astype(np.int16), axis=1)) > 8:
+        return None
+    gray = cv2.cvtColor(image, cv2.COLOR_RGB2GRAY).astype(np.float32)
+    known = cv2.erode((~missing).astype(np.uint8), np.ones((3, 3), np.uint8)) > 0
+    if known.sum() < 512:
+        return None
+
+    # Bound FFT work without resizing fine dots. Try the best intact crop first.
+    sample_h, sample_w = min(height, 192), min(width, 192)
+    samples = []
+    tops = sorted(set(range(0, height - sample_h + 1, sample_h)) | {height - sample_h})
+    lefts = sorted(set(range(0, width - sample_w + 1, sample_w)) | {width - sample_w})
+    for top in tops:
+        for left in lefts:
+            region = np.s_[top:top + sample_h, left:left + sample_w]
+            count = int(known[region].sum())
+            samples.append((count, top, left))
+    lattice = None
+    for count, top, left in sorted(samples, reverse=True)[:8]:
+        if count < 512:
+            continue
+        region = np.s_[top:top + sample_h, left:left + sample_w]
+        lattice = _find_lattice(gray[region], known[region])
+        if lattice is not None:
+            break
+    if lattice is None:
+        return None
+
+    (ax, ay), (bx, by) = lattice
+    determinant = abs(ax * by - ay * bx)
+    y, x = np.indices((height, width), dtype=np.int32)
+    phases = ((by*x - bx*y) % determinant) * determinant
+    phases += (-ay*x + ax*y) % determinant
+    keys, counts = np.unique(phases[known], return_counts=True)
+    if len(keys) != determinant or counts.min() < 4:
+        return None
+    period = max(np.hypot(ax, ay), np.hypot(bx, by))
+    sigma = max(8.0, period * 3)
+    predicted = np.zeros_like(gray)
+    background = np.zeros_like(gray)
+    support = np.full_like(gray, np.inf)
+    # Estimate each phase from its own valid neighbors, instead of interpolating
+    # a binary reliability flag through glyph-shaped holes. Keep memory O(HW).
+    for key in keys:
+        phase = phases == key
+        weights = (known & phase).astype(np.float32)
+        mass = cv2.GaussianBlur(weights, (0, 0), sigma)
+        estimate = cv2.GaussianBlur(gray * weights, (0, 0), sigma) / np.maximum(mass, 1e-8)
+        background += estimate / len(keys)
+        np.copyto(predicted, estimate, where=phase)
+        support = np.minimum(support, mass * len(keys))
+
+    # Prediction residual checks phase agreement, not only whether a lattice
+    # exists elsewhere in the crop. Distant/absent donors contribute no repair.
+    weights = known.astype(np.float32)
+    noise = cv2.GaussianBlur((gray - predicted)**2 * weights, (0, 0), sigma)
+    energy = cv2.GaussianBlur((gray - background)**2 * weights, (0, 0), sigma)
+    confidence = np.clip((1 - noise / np.maximum(energy, 1e-5) - 0.75) / 0.2, 0, 1)
+    confidence *= np.clip((support - 0.01) / 0.04, 0, 1)
+    strength = cv2.GaussianBlur((predicted - background)**2 * weights, (0, 0), sigma)
+    strength /= np.maximum(cv2.GaussianBlur(weights, (0, 0), sigma), 1e-8)
+    confidence[strength < 25] = 0
+    if not np.any(confidence[missing] > 0):
+        return None
+    return predicted - background, background, confidence, float(period)

--- a/ballontranslator/ui/_generated/module_param_dialog_i18n_catalog.py
+++ b/ballontranslator/ui/_generated/module_param_dialog_i18n_catalog.py
@@ -85,11 +85,23 @@ MODULE_PARAM_CATALOG = {
     ('inpainter', 'lama_large_512px', 'precision', 'display_name'): {
         "source": 'precision', "translate": lambda: QCoreApplication.translate('ModuleParamDialog', 'precision'),
     },
+    ('inpainter', 'lama_large_512px', 'preserve screentones', 'description'): {
+        "source": 'Restore regular monochrome dots from nearby background after inpainting, while retaining shading and strong edges. Unsupported areas keep the normal result.', "translate": lambda: QCoreApplication.translate('ModuleParamDialog', 'Restore regular monochrome dots from nearby background after inpainting, while retaining shading and strong edges. Unsupported areas keep the normal result.'),
+    },
+    ('inpainter', 'lama_large_512px', 'preserve screentones', 'display_name'): {
+        "source": 'Preserve Screentones (Experimental)', "translate": lambda: QCoreApplication.translate('ModuleParamDialog', 'Preserve Screentones (Experimental)'),
+    },
     ('inpainter', 'lama_mpe', 'device', 'display_name'): {
         "source": 'device', "translate": lambda: QCoreApplication.translate('ModuleParamDialog', 'device'),
     },
     ('inpainter', 'lama_mpe', 'inpaint_size', 'display_name'): {
         "source": 'Inpaint Size', "translate": lambda: QCoreApplication.translate('ModuleParamDialog', 'Inpaint Size'),
+    },
+    ('inpainter', 'lama_mpe', 'preserve screentones', 'description'): {
+        "source": 'Restore regular monochrome dots from nearby background after inpainting, while retaining shading and strong edges. Unsupported areas keep the normal result.', "translate": lambda: QCoreApplication.translate('ModuleParamDialog', 'Restore regular monochrome dots from nearby background after inpainting, while retaining shading and strong edges. Unsupported areas keep the normal result.'),
+    },
+    ('inpainter', 'lama_mpe', 'preserve screentones', 'display_name'): {
+        "source": 'Preserve Screentones (Experimental)', "translate": lambda: QCoreApplication.translate('ModuleParamDialog', 'Preserve Screentones (Experimental)'),
     },
     ('ocr', 'LLMOCR', '', 'description'): {
         "source": 'OCR using the selected vision-capable LLM profile.', "translate": lambda: QCoreApplication.translate('ModuleParamDialog', 'OCR using the selected vision-capable LLM profile.'),

--- a/doc/modules/inpaint_screentones.md
+++ b/doc/modules/inpaint_screentones.md
@@ -1,0 +1,43 @@
+# Experimental screentone preservation
+
+`lama_mpe` and `lama_large_512px` expose **Preserve Screentones
+(Experimental)** in their existing module settings. It is off by default;
+enabling it does not change the model, download assets, or use a CLI/service.
+
+LaMa runs once with its normal image and mask. After inference and resizing,
+`modules/inpaint/screentone.py` analyzes original unmasked pixels at native
+resolution. It estimates a repeating lattice from bounded reference crops and
+interpolates nearby source pixels separately for each lattice phase. Local
+means describe brightness; deviations describe the dot texture. Each phase
+needs donor support, and local prediction error reduces confidence where the
+pattern does not match.
+
+The local source donors supply both brightness and dot contrast, so generated
+brightness blobs are not carried into the restored screen. LaMa supplies the
+structural-edge reference. Strong structural edges reduce replacement, retaining
+the normal model result around linework. Confidence varies locally; insufficient
+support does not change the model input or affect supported areas elsewhere.
+Only masked pixels are composited. Unmasked source pixels remain identical.
+The debug log reports masked coverage with strong support.
+
+This is a local monochrome-texture method, not semantic manga segmentation.
+Missing linework and unsupported areas still depend on LaMa. Nearby source
+context is needed for each phase; large holes and different or warped screens may retain
+some normal-model artifacts. Colored screens and crops without a reliable
+lattice keep the normal result. The integer lattice handles pixel-aligned
+screens and small local appearance variations, not arbitrary geometric
+warping. Turning the option off restores the existing workflow.
+
+The implementation uses the existing NumPy/OpenCV dependencies. It does not
+require the optional native PatchMatch binary. Regression tests use synthetic
+masked screens, including dense glyph masks, to check phase, shading, dark
+linework, donor exclusion, local fallbacks, lazy settings metadata and the
+unchanged LaMa inference path:
+
+```sh
+PYTHONPATH=tests python -m unittest test_screentone_inpaint test_lama_padding
+```
+
+For quality evaluation, hide a known text-free screen region and compare the
+restoration against those held-out pixels. Do not judge quality only by input
+and output dimensions or assume generated missing linework is ground truth.

--- a/resources/translate/ko_KR.ts
+++ b/resources/translate/ko_KR.ts
@@ -2634,6 +2634,14 @@ All existing translation results will be cleared!</source>
         <translation>인페인트 크기</translation>
     </message>
     <message>
+        <source>Preserve Screentones (Experimental)</source>
+        <translation>망점 보존 (실험적)</translation>
+    </message>
+    <message>
+        <source>Restore regular monochrome dots from nearby background after inpainting, while retaining shading and strong edges. Unsupported areas keep the normal result.</source>
+        <translation>인페인팅 후 주변 배경에서 규칙적인 흑백 망점을 복원하며 명암과 뚜렷한 윤곽을 유지합니다. 근거가 부족한 영역은 일반 인페인팅 결과를 유지합니다.</translation>
+    </message>
+    <message>
         <location filename="../../ballontranslator/ui/_generated/module_param_dialog_i18n_catalog.py" line="74"/>
         <source>model</source>
         <translation>모델</translation>

--- a/tests/test_screentone_inpaint.py
+++ b/tests/test_screentone_inpaint.py
@@ -1,0 +1,197 @@
+import copy
+import unittest
+from typing import Tuple
+from unittest.mock import Mock, patch
+
+import cv2
+import numpy as np
+
+from ballontranslator.modules.inpaint.inpaint_default import LamaInpainterMPE, LamaLarge, torch
+from ballontranslator.modules.inpaint.screentone import restore_screentone
+from ballontranslator.modules.lazy_registry import _scan_file, validate_lazy_module_specs
+
+
+def _screen(
+    diagonal: bool = False, gradient: bool = False, offset: int = 0,
+) -> Tuple[np.ndarray, np.ndarray, np.ndarray, np.ndarray]:
+    y, x = np.indices((128, 128))
+    if diagonal:
+        dots = ((x + y + offset) % 8 < 2) & ((y - x + offset) % 8 < 2)
+        mean = 200 - 170 / 16
+    else:
+        dots = ((x + offset) % 6 < 2) & ((y + offset) % 6 < 2)
+        mean = 200 - 170 / 9
+    light = 0.55 + 0.4*x/128 if gradient else np.ones_like(x)
+    source = np.repeat(np.rint(np.where(dots, 30, 200) * light).astype(np.uint8)[..., None], 3, axis=2)
+    base = np.repeat(np.rint(mean * light).astype(np.uint8)[..., None], 3, axis=2)
+    mask = np.zeros((128, 128), dtype=np.uint8)
+    mask[40:90, 45:80] = 255
+    damaged = source.copy()
+    damaged[mask > 0] = 255
+    return source, damaged, mask, base
+
+
+class ScreentoneTest(unittest.TestCase):
+    def test_period_and_phase_are_restored_without_losing_shading(self) -> None:
+        for diagonal in (False, True):
+            for gradient in (False, True):
+                for offset in (0, 3):
+                    with self.subTest(diagonal=diagonal, gradient=gradient, offset=offset):
+                        source, damaged, mask, base = _screen(diagonal, gradient, offset)
+                        restored = restore_screentone(damaged, mask, base)
+                        error = np.abs(restored.astype(float) - source)[mask > 0].mean()
+                        self.assertLess(error, 5)
+                        np.testing.assert_array_equal(restored[mask == 0], base[mask == 0])
+
+    def test_dense_glyph_masks_receive_texture_not_just_fallback(self) -> None:
+        y, x = np.indices((619, 174))
+        gray = 72 + 45*np.cos(np.pi*(x+y)/2) + 38*np.sin(np.pi*(x-y)/2)
+        source = np.repeat(np.clip(np.rint(gray), 0, 255).astype(np.uint8)[..., None], 3, axis=2)
+        mask = np.zeros(gray.shape, dtype=np.uint8)
+        for left in (8, 62, 116):
+            for row, char in enumerate('TEXTMASKDATA'):
+                cv2.putText(mask, char, (left, 43 + row*51),
+                            cv2.FONT_HERSHEY_SIMPLEX, 1.3, 255, 7, cv2.LINE_AA)
+        mask = cv2.dilate((mask > 0).astype(np.uint8)*255, np.ones((3, 3), np.uint8))
+        damaged = source.copy()
+        damaged[mask > 0] = 255
+        base = np.full_like(source, 72)
+        restored = restore_screentone(damaged, mask, base)
+        before = np.abs(base.astype(float) - source)[mask > 0].mean()
+        after = np.abs(restored.astype(float) - source)[mask > 0].mean()
+        self.assertLess(after, before * 0.3)
+        np.testing.assert_array_equal(restored[mask == 0], base[mask == 0])
+
+    def test_masked_content_is_never_a_donor_and_inputs_are_unchanged(self) -> None:
+        _, damaged, mask, base = _screen()
+        original_image, original_mask, original_base = damaged.copy(), mask.copy(), base.copy()
+        first = restore_screentone(damaged, mask, base)
+        np.testing.assert_array_equal(damaged, original_image)
+        np.testing.assert_array_equal(mask, original_mask)
+        np.testing.assert_array_equal(base, original_base)
+        damaged[mask > 0] = (0, 150, 50)
+        np.testing.assert_array_equal(first, restore_screentone(damaged, mask, base))
+
+    def test_reconstructed_black_linework_is_not_replaced_by_dots(self) -> None:
+        _, damaged, mask, base = _screen(gradient=True)
+        base[60:64, :] = 0
+        restored = restore_screentone(damaged, mask, base)
+        np.testing.assert_array_equal(restored[60:64], base[60:64])
+
+    def test_generated_brightness_blobs_do_not_modulate_the_restored_screen(self) -> None:
+        source, damaged, mask, base = _screen(gradient=True)
+        y, x = np.indices(mask.shape)
+        # A smooth model artifact must not change the source tone's contrast.
+        blob = 18*np.exp(-((x-63)**2+(y-63)**2)/220)
+        base = np.clip(base.astype(float)+blob[..., None], 0, 255).astype(np.uint8)
+        restored = restore_screentone(damaged, mask, base)
+        error = np.abs(restored.astype(float)-source).mean(axis=2)
+        boundary = (mask > 0) & (cv2.erode(mask, np.ones((3, 3), np.uint8)) == 0)
+        self.assertLess(error[mask > 0].mean(), 5)
+        self.assertLess(error[boundary].mean(), 5)
+        np.testing.assert_array_equal(restored[mask == 0], base[mask == 0])
+
+    def test_nonperiodic_and_insufficient_evidence_keep_normal_result(self) -> None:
+        source, _, mask, base = _screen()
+        rng = np.random.default_rng(3)
+        noise = np.repeat(rng.integers(0, 256, mask.shape, dtype=np.uint8)[..., None], 3, axis=2)
+        for image in (np.full(noise.shape, 127, np.uint8), noise):
+            self.assertIs(restore_screentone(image, mask, base), base)
+        for fill in (0, 255):
+            self.assertIs(restore_screentone(source, np.full(mask.shape, fill, np.uint8), base), base)
+        mask[:] = 255
+        mask[:2] = 0
+        self.assertIs(restore_screentone(source, mask, base), base)
+
+    def test_color_screens_are_not_treated_as_monochrome(self) -> None:
+        _, damaged, mask, base = _screen()
+        damaged[:, :, 0] = 0
+        self.assertIs(restore_screentone(damaged, mask, base), base)
+
+    def test_solid_region_keeps_the_normal_result(self) -> None:
+        source, _, mask, base = _screen()
+        source[28:105, 30:95] = 127
+        source[mask > 0] = 255
+        base[:] = 127
+        restored = restore_screentone(source, mask, base)
+        np.testing.assert_array_equal(restored[52:78, 54:71], base[52:78, 54:71])
+
+    def test_single_line_is_not_a_repeating_screen(self) -> None:
+        _, _, mask, base = _screen()
+        source = np.full((128, 128, 3), 192, np.uint8)
+        cv2.line(source, (0, 30), (127, 80), (0, 0, 0), 3)
+        source[mask > 0] = 255
+        self.assertIs(restore_screentone(source, mask, base), base)
+
+    def test_invalid_inputs_are_rejected(self) -> None:
+        _, damaged, mask, base = _screen()
+        for image, invalid_mask, result in ((damaged.astype(float), mask, base),
+                                           (damaged, mask[:-1], base),
+                                           (damaged, mask.astype(float), base),
+                                           (damaged, mask, base[:-1]),
+                                           (damaged, mask, base.astype(float))):
+            with self.assertRaises(ValueError):
+                restore_screentone(image, invalid_mask, result)
+
+    def test_option_metadata_is_lazy_and_disabled_by_default(self) -> None:
+        specs = _scan_file('ballontranslator/modules/inpaint/inpaint_default.py', 'inpainter')
+        for spec in specs:
+            if spec.key in ('lama_mpe', 'lama_large_512px'):
+                option = spec.params['preserve screentones']
+                self.assertEqual(option['type'], 'checkbox')
+                self.assertIs(option['value'], False)
+                self.assertEqual(validate_lazy_module_specs([spec]), [])
+
+
+@unittest.skipIf(torch is None, 'torch is not installed')
+class ScreentoneIntegrationTest(unittest.TestCase):
+    def test_one_normal_inference_is_followed_by_masked_texture_restoration(self) -> None:
+        for cls in (LamaInpainterMPE, LamaLarge):
+            with self.subTest(model=cls.__name__), patch.object(cls, 'params', copy.deepcopy(cls.params)):
+                inpainter = cls(**copy.deepcopy(cls.params))
+                inpainter.device, inpainter.precision = 'cpu', 'fp32'
+                source, damaged, mask, base = _screen()
+                model = Mock()
+                model.load_masked_position_encoding.return_value = (
+                    np.zeros(mask.shape, np.int32), np.zeros(mask.shape, np.int32),
+                    np.zeros(mask.shape + (4,), np.int32),
+                )
+                model.return_value = torch.from_numpy(base).permute(2, 0, 1).unsqueeze(0).float() / 255.0
+                inpainter.model = model
+                results, inputs = [], []
+                for enabled in (False, True):
+                    inpainter.set_param_value('preserve screentones', enabled)
+                    results.append(inpainter._inpaint(damaged, mask))
+                    inputs.append(model.call_args.args[0].clone())
+                self.assertEqual(model.call_count, 2)
+                self.assertTrue(torch.equal(inputs[0], inputs[1]))
+                np.testing.assert_array_equal(results[1][mask == 0], damaged[mask == 0])
+                before = np.abs(results[0].astype(float) - source)[mask > 0].mean()
+                after = np.abs(results[1].astype(float) - source)[mask > 0].mean()
+                self.assertLess(after, before * 0.3)
+
+    def test_disabled_or_unrecognized_pattern_keeps_normal_path(self) -> None:
+        for enabled in (False, True):
+            with self.subTest(enabled=enabled), patch.object(LamaLarge, 'params', copy.deepcopy(LamaLarge.params)):
+                inpainter = LamaLarge(**copy.deepcopy(LamaLarge.params))
+                inpainter.device, inpainter.precision = 'cpu', 'fp32'
+                inpainter.set_param_value('preserve screentones', enabled)
+                image = np.full((64, 64, 3), 127, np.uint8)
+                mask = np.zeros((64, 64), np.uint8)
+                mask[20:40, 20:40] = 255
+                model = Mock()
+                model.load_masked_position_encoding.return_value = (
+                    np.zeros(mask.shape, np.int32), np.zeros(mask.shape, np.int32),
+                    np.zeros(mask.shape + (4,), np.int32),
+                )
+                model.return_value = torch.full((1, 3, 64, 64), 0.5)
+                inpainter.model = model
+                with patch('ballontranslator.modules.inpaint.screentone.restore_screentone', wraps=restore_screentone) as restore:
+                    result = inpainter._inpaint(image, mask)
+                self.assertEqual(restore.call_count, int(enabled))
+                np.testing.assert_array_equal(result[mask > 0], 128)
+                np.testing.assert_array_equal(result[mask == 0], image[mask == 0])
+
+
+if __name__ == '__main__':
+    unittest.main()


### PR DESCRIPTION
## Background

Manga commonly represents gray shading with screentones: regular halftone dot patterns rather than flat gray pixels. Because the spacing, angle, and phase of these dots remain consistent across an area, even a small discontinuity after inpainting can be visually noticeable.

LaMa works well for reconstructing ordinary backgrounds, but it is not designed to continue the exact pixel-level phase of a periodic pattern. Under dense text masks, it can blur the dots, replace them with nearly flat gray, or generate a similar pattern whose phase does not align with the surrounding area.

## Changes

This PR adds an opt-in `Preserve Screentones (Experimental)` setting to `lama_mpe` and `lama_large_512px`.

When enabled, it estimates a locally supported periodic pattern from unmasked source pixels and restores same-phase brightness and dot detail inside the mask. Strong edges and areas where the pattern estimate is unreliable retain the normal LaMa result.

The setting is disabled by default and does not require an additional model inference pass.

## Feedback requested

Please try it on a few screentone-heavy pages and let me know whether this direction seems useful for BallonsTranslator.

Feedback would be especially helpful for different screentone sizes, angles, densities, gradients, and distorted or mixed patterns.

## Example

The following results use the same source image and mask.

| Original | Normal LaMa | Preserve Screentones |
| --- | --- | --- |
| <img width="103" height="727" alt="스크린샷 2026-09-06 오후 4 54 20" src="https://github.com/user-attachments/assets/04236d3e-311b-4fbc-96d2-ca902eb4616b" /> | <img width="103" height="727" alt="스크린샷 2026-09-06 오후 4 53 38" src="https://github.com/user-attachments/assets/38cacbb9-757c-484c-a151-497fa864f453" /> | <img width="103" height="727" alt="스크린샷 2026-09-06 오후 4 54 16" src="https://github.com/user-attachments/assets/df08e087-92ac-41f8-a035-97f19f82e2d3" /> |
| <img width="73" height="824" alt="스크린샷 2026-09-06 오후 4 58 24" src="https://github.com/user-attachments/assets/ebc56bdb-43ef-4610-9835-a33894de4680" /> | <img width="73" height="824" alt="스크린샷 2026-09-06 오후 4 58 48" src="https://github.com/user-attachments/assets/bb128e62-3c71-4cb6-ada0-1634c3511478" /> | <img width="73" height="824" alt="스크린샷 2026-09-06 오후 4 59 42" src="https://github.com/user-attachments/assets/520cc538-36f8-4699-9a01-8e90b4508fcb" /> |


