### PR TITLE
feat(QColorDialog): Persist custom colors across application restarts

### DIFF
--- a/ballontranslator/ui/mainwindow.py
+++ b/ballontranslator/ui/mainwindow.py
@@ -7,9 +7,9 @@ from functools import partial
 import time
 
 from tqdm import tqdm
-from qtpy.QtWidgets import QAction, QFileDialog, QMenu, QHBoxLayout, QVBoxLayout, QApplication, QStackedWidget, QSplitter, QListWidget, QShortcut, QListWidgetItem, QMessageBox, QTextEdit, QPlainTextEdit, QDialog, QWidget
+from qtpy.QtWidgets import QAction, QFileDialog, QMenu, QHBoxLayout, QVBoxLayout, QApplication, QStackedWidget, QSplitter, QListWidget, QShortcut, QListWidgetItem, QMessageBox, QTextEdit, QPlainTextEdit, QDialog, QWidget, QColorDialog
 from qtpy.QtCore import Qt, QPoint, QSize, QEvent, Signal, QTimer
-from qtpy.QtGui import QContextMenuEvent, QTextCursor, QGuiApplication, QIcon, QCloseEvent, QKeySequence, QPainter, QClipboard
+from qtpy.QtGui import QContextMenuEvent, QTextCursor, QGuiApplication, QIcon, QCloseEvent, QKeySequence, QPainter, QClipboard, QColor
 
 from ballontranslator.utils.logger import logger as LOGGER
 from ballontranslator.utils.text_processing import is_cjk
@@ -72,6 +72,21 @@ from .module_parse_widgets import ModuleParamDialog
 from . import shared_widget as SW
 from .custom_widget import MessageBox, FrameLessMessageBox, ImgtransProgressMessageBox, ProgressMessageBox
 
+
+def _restore_custom_colors(colors: List[str]) -> None:
+    for index, color_name in enumerate(colors[:QColorDialog.customCount()]):
+        color = QColor(color_name)
+        if color.isValid():
+            QColorDialog.setCustomColor(index, color)
+
+
+def _current_custom_colors() -> List[str]:
+    return [
+        QColorDialog.customColor(index).name()
+        for index in range(QColorDialog.customCount())
+    ]
+
+
 class PageListView(QListWidget):
 
     reveal_file = Signal()
@@ -124,6 +139,7 @@ class MainWindow(mainwindow_cls):
         super().__init__()
 
         self.app = app
+        _restore_custom_colors(pcfg.custom_colors)
         install_app_style_filters(self.app)
         self.resetStyleSheet()
 
@@ -856,6 +872,7 @@ class MainWindow(mainwindow_cls):
         self.st_manager.hovering_transwidget = None
         self.st_manager.blockSignals(True)
         self.canvas.prepareClose()
+        pcfg.custom_colors = _current_custom_colors()
         self.save_config()
         return super().closeEvent(event)
 

--- a/ballontranslator/utils/config.py
+++ b/ballontranslator/utils/config.py
@@ -1,4 +1,4 @@
-import json, os, string, traceback
+import json, os, re, string, traceback
 import os.path as osp
 import copy
 from dataclasses import fields
@@ -389,6 +389,7 @@ class ProgramConfig(Config):
     text_transform_panel: bool = True
     expand_ttransform_panel: bool = True
     excluded_fonts: List[str] = field(default_factory=list)
+    custom_colors: List[str] = field(default_factory=list)
 
     @staticmethod
     def load(cfg_path: str):
@@ -423,6 +424,27 @@ class ProgramConfig(Config):
                         'Discard invalid or duplicate entries in excluded_fonts config.'
                     )
                 config_dict['excluded_fonts'] = normalized_fonts
+
+        if 'custom_colors' in config_dict:
+            custom_colors = config_dict['custom_colors']
+            if not isinstance(custom_colors, list):
+                LOGGER.warning(
+                    'Discard invalid custom_colors config: expected a list of colors.'
+                )
+                config_dict.pop('custom_colors')
+            else:
+                valid_colors = []
+                for color in custom_colors:
+                    if isinstance(color, str) and re.fullmatch(
+                        r'#[0-9a-fA-F]{6}', color
+                    ):
+                        valid_colors.append(color)
+                    else:
+                        LOGGER.warning(
+                            'Discard invalid entry in custom_colors config: %r.',
+                            color,
+                        )
+                config_dict['custom_colors'] = valid_colors
 
         if 'module' in config_dict:
             module_cfg = config_dict['module']

--- a/tests/test_custom_colors.py
+++ b/tests/test_custom_colors.py
@@ -1,0 +1,72 @@
+import json
+import os
+import tempfile
+import unittest
+from unittest.mock import patch
+
+from qtpy.QtGui import QColor
+
+from ballontranslator.ui.mainwindow import (
+    _current_custom_colors,
+    _restore_custom_colors,
+)
+from ballontranslator.utils.config import ProgramConfig
+
+
+class CustomColorPersistenceTests(unittest.TestCase):
+    def test_restore_sets_each_saved_color(self) -> None:
+        with (
+            patch(
+                'ballontranslator.ui.mainwindow.QColorDialog.customCount',
+                return_value=2,
+            ),
+            patch(
+                'ballontranslator.ui.mainwindow.QColorDialog.setCustomColor'
+            ) as set_custom_color,
+        ):
+            _restore_custom_colors(['#123456', '#abcdef', '#ffffff'])
+
+        self.assertEqual(set_custom_color.call_count, 2)
+        self.assertEqual(set_custom_color.call_args_list[0].args[0], 0)
+        self.assertEqual(set_custom_color.call_args_list[0].args[1].name(), '#123456')
+        self.assertEqual(set_custom_color.call_args_list[1].args[0], 1)
+        self.assertEqual(set_custom_color.call_args_list[1].args[1].name(), '#abcdef')
+
+    def test_current_colors_are_serializable_hex_strings(self) -> None:
+        with (
+            patch(
+                'ballontranslator.ui.mainwindow.QColorDialog.customCount',
+                return_value=2,
+            ),
+            patch(
+                'ballontranslator.ui.mainwindow.QColorDialog.customColor',
+                side_effect=[QColor('#123456'), QColor('#abcdef')],
+            ),
+        ):
+            colors = _current_custom_colors()
+
+        self.assertEqual(colors, ['#123456', '#abcdef'])
+
+    def test_config_load_discards_only_invalid_custom_colors(self) -> None:
+        with tempfile.TemporaryDirectory() as directory:
+            config_path = os.path.join(directory, 'config.json')
+            with open(config_path, 'w', encoding='utf8') as config_file:
+                json.dump(
+                    {
+                        'custom_colors': [
+                            '#123456',
+                            'invalid',
+                            42,
+                            '#ABCDEF',
+                        ]
+                    },
+                    config_file,
+                )
+
+            config = ProgramConfig.load(config_path)
+
+        self.assertEqual(config.custom_colors, ['#123456', '#ABCDEF'])
+
+
+if __name__ == '__main__':
+    unittest.main()


### PR DESCRIPTION
## Summary

- Save custom colors from `QColorDialog` in the application configuration
- Restore the saved colors when the main window is initialized
- Ignore malformed color entries without discarding valid colors
- Add tests for color saving, restoration, and configuration validation

## Problem

Custom colors added through the color picker were only retained for the current session and were reset after restarting BallonsTranslator.

## Testing

- Added three custom color persistence tests
- All three tests pass
- Verified compatibility with existing configuration files


https://github.com/user-attachments/assets/9e5de5b1-4adc-4fa2-a0d8-06d20fc04f30

