### PR TITLE
fix(flux_inpaint): drop the dead pre-batch _prepare_image_ids copy

### DIFF
--- a/ballontranslator/modules/inpaint/flux_inpaint_pipeline.py
+++ b/ballontranslator/modules/inpaint/flux_inpaint_pipeline.py
@@ -334,57 +334,6 @@ class Flux2KleinInpaintPipeline(DiffusionPipeline, Flux2LoraLoaderMixin):
         return latent_ids
 
     @staticmethod
-    # Copied from diffusers.pipelines.flux2.pipeline_flux2.Flux2Pipeline._prepare_image_ids
-    def _prepare_image_ids(
-        image_latents: list[torch.Tensor],  # [(1, C, H, W), (1, C, H, W), ...]
-        scale: int = 10,
-    ):
-        r"""
-        Generates 4D time-space coordinates (T, H, W, L) for a sequence of image latents.
-
-        This function creates a unique coordinate for every pixel/patch across all input latent with different
-        dimensions.
-
-        Args:
-            image_latents (list[torch.Tensor]):
-                A list of image latent feature tensors, typically of shape (C, H, W).
-            scale (int, optional):
-                A factor used to define the time separation (T-coordinate) between latents. T-coordinate for the i-th
-                latent is: 'scale + scale * i'. Defaults to 10.
-
-        Returns:
-            torch.Tensor:
-                The combined coordinate tensor. Shape: (1, N_total, 4) Where N_total is the sum of (H * W) for all
-                input latents.
-
-        Coordinate Components (Dimension 4):
-            - T (Time): The unique index indicating which latent image the coordinate belongs to.
-            - H (Height): The row index within that latent image.
-            - W (Width): The column index within that latent image.
-            - L (Seq. Length): A sequence length dimension, which is always fixed at 0 (size 1)
-        """
-
-        if not isinstance(image_latents, list):
-            raise ValueError(f"Expected `image_latents` to be a list, got {type(image_latents)}.")
-
-        # create time offset for each reference image
-        t_coords = [scale + scale * t for t in torch.arange(0, len(image_latents))]
-        t_coords = [t.view(-1) for t in t_coords]
-
-        image_latent_ids = []
-        for x, t in zip(image_latents, t_coords):
-            x = x.squeeze(0)
-            _, height, width = x.shape
-
-            x_ids = torch.cartesian_prod(t, torch.arange(height), torch.arange(width), torch.arange(1))
-            image_latent_ids.append(x_ids)
-
-        image_latent_ids = torch.cat(image_latent_ids, dim=0)
-        image_latent_ids = image_latent_ids.unsqueeze(0)
-
-        return image_latent_ids
-
-    @staticmethod
     # Copied from diffusers.pipelines.flux2.pipeline_flux2.Flux2Pipeline._patchify_latents
     def _patchify_latents(latents):
         batch_size, num_channels_latents, height, width = latents.shape


### PR DESCRIPTION
## What

`Flux2KleinInpaintPipeline` in `ballontranslator/modules/inpaint/flux_inpaint_pipeline.py` defines `_prepare_image_ids` **twice**:

| | line | signature |
|---|---|---|
| first (dead) | 336 | `_prepare_image_ids(image_latents, scale=10)` — the copy carried over verbatim from `diffusers.pipelines.flux2.Flux2Pipeline` |
| second (live) | 963 | `_prepare_image_ids(image_latents, batch_size, scale=10)` — the batch-aware rewrite |

Python binds the later definition, so the first one is unreachable dead code.

## Why the second one is definitely the intended implementation

The class has exactly one call site, and it passes a keyword the first signature does not accept:

```python
image_latent_ids = self._prepare_image_ids(image_latents, batch_size=batch_size)
```

Replaying that call against both signatures:

```
dead (first def)  -> TypeError: got an unexpected keyword argument 'batch_size'
live (second def) -> binds OK
```

So if the first copy were ever the live binding, image-id preparation would crash outright. It isn't, and it never runs.

The two bodies also differ in behaviour — the live one expands ids across the batch dimension and handles `b_i > 1` per-sample image counts, which the dead copy has no notion of — so this is a leftover from before the batch rewrite, not a redundant twin.

## Change

Deletes the dead copy only (`+0 / −51`). The surviving definition is byte-for-byte unchanged.

## Verification

- `ast.dump` of the *final* binding for every class- and module-level name is identical before and after, except the enclosing `Flux2KleinInpaintPipeline` node itself (which loses the dead method from its body). In particular `Flux2KleinInpaintPipeline._prepare_image_ids` resolves to exactly the same AST as before → no runtime behaviour change.
- `py_compile` clean.
- Per `AGENTS.md` ("the old path should be gone enough that future readers do not have to understand both"), this removes the stale path rather than leaving both in place.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
